### PR TITLE
Minor histogram fixes for Mac

### DIFF
--- a/cub/util_allocator.cuh
+++ b/cub/util_allocator.cuh
@@ -252,7 +252,7 @@ struct CachingDeviceAllocator : DeviceAllocator
     size_t          max_cached_bytes;   /// Maximum aggregate cached bytes per device
 
     bool            debug;              /// Whether or not to print (de)allocation events to stdout
-    bool            silent_cleanup;     /// Whether or not to report errors when destructor is called.  (The CUDA runtime may have already shut down for statically declared allocators)
+    bool            skip_cleanup;       /// Whether or not to skip a call to FreeAllCached() when destructor is called.  (The CUDA runtime may have already shut down for statically declared allocators)
 
 #ifndef __CUDA_ARCH__   // Only define STL container members in host code
 
@@ -305,12 +305,12 @@ struct CachingDeviceAllocator : DeviceAllocator
      * which delineates five bin-sizes: 512B, 4KB, 32KB, 256KB, and 2MB and
      * sets a maximum of 6,291,455 cached bytes per device
      */
-    __host__ __device__ __forceinline__ CachingDeviceAllocator(bool silent_cleanup = false) :
+    __host__ __device__ __forceinline__ CachingDeviceAllocator(bool skip_cleanup = false) :
     #ifndef __CUDA_ARCH__   // Only define STL container members in host code
         cached_blocks(BlockDescriptor::SizeCompare),
         live_blocks(BlockDescriptor::PtrCompare),
     #endif
-        silent_cleanup(silent_cleanup),
+        skip_cleanup(skip_cleanup),
         debug(false),
         spin_lock(0),
         bin_growth(8),
@@ -598,11 +598,11 @@ struct CachingDeviceAllocator : DeviceAllocator
     /**
      * \brief Frees all cached device allocations on all devices
      */
-    __host__ __device__ __forceinline__ cudaError_t FreeAllCached(bool silent = false)
+    __host__ __device__ __forceinline__ cudaError_t FreeAllCached()
     {
     #ifdef __CUDA_ARCH__
         // Caching functionality only defined on host
-        return CubDebug2(cudaErrorInvalidConfiguration, silent);
+        return CubDebug(cudaErrorInvalidConfiguration);
     #else
 
         cudaError_t error                   = cudaSuccess;
@@ -624,18 +624,18 @@ struct CachingDeviceAllocator : DeviceAllocator
             // Get entry-point device ordinal if necessary
             if (entrypoint_device == INVALID_DEVICE_ORDINAL)
             {
-                if (CubDebug2(error = cudaGetDevice(&entrypoint_device), silent)) break;
+                if (CubDebug(error = cudaGetDevice(&entrypoint_device))) break;
             }
 
             // Set current device ordinal if necessary
             if (begin->device != current_device)
             {
-                if (CubDebug2(error = cudaSetDevice(begin->device), silent)) break;
+                if (CubDebug(error = cudaSetDevice(begin->device))) break;
                 current_device = begin->device;
             }
 
             // Free device memory
-            if (CubDebug2(error = cudaFree(begin->d_ptr), silent)) break;
+            if (CubDebug(error = cudaFree(begin->d_ptr))) break;
 
             // Reduce balance and erase entry
             cached_bytes[current_device] -= begin->bytes;
@@ -654,7 +654,7 @@ struct CachingDeviceAllocator : DeviceAllocator
         // Attempt to revert back to entry-point device if necessary
         if (entrypoint_device != INVALID_DEVICE_ORDINAL)
         {
-            if (CubDebug2(error = cudaSetDevice(entrypoint_device), silent)) return error;
+            if (CubDebug(error = cudaSetDevice(entrypoint_device))) return error;
         }
 
         return error;
@@ -668,7 +668,8 @@ struct CachingDeviceAllocator : DeviceAllocator
      */
     CUB_DESTRUCTOR __forceinline__ virtual ~CachingDeviceAllocator()
     {
-        FreeAllCached(silent_cleanup);
+        if (!skip_cleanup)
+            FreeAllCached();
     }
 
 };

--- a/cub/util_iterator.cuh
+++ b/cub/util_iterator.cuh
@@ -161,7 +161,7 @@ public:
 #ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
 
 // Anonymous namespace
-//namespace {
+namespace {
 
 /// Templated Texture reference type for multiplicand vector
 template <typename T>
@@ -198,8 +198,7 @@ struct TexIteratorRef
 template <typename Value>
 typename TexIteratorRef<Value>::TexRef TexIteratorRef<Value>::ref = 0;
 
-
-//} // Anonymous namespace
+} // Anonymous namespace
 
 
 


### PR DESCRIPTION
- Undo accidental comment-out of anonymous namespace around texiterator
  tex reference
- Skip cleanup of allocated storage in default caching allocator on exit
  (bus error on mac because the CUDA runtime is already gone)
