### PR TITLE
CUDA attribute caching

### DIFF
--- a/cub/util_arch.cuh
+++ b/cub/util_arch.cuh
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -12,7 +12,7 @@
  *     * Neither the name of the NVIDIA CORPORATION nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -56,6 +56,11 @@ namespace cub {
     #endif
 #endif
 
+
+/// Maximum number of devices supported.
+#ifndef CUB_MAX_DEVICES
+    #define CUB_MAX_DEVICES 128
+#endif
 
 /// Whether or not the source targeted by the active compiler pass is allowed to  invoke device kernels or methods from the CUDA runtime API.
 #ifndef CUB_RUNTIME_FUNCTION

--- a/cub/util_device.cuh
+++ b/cub/util_device.cuh
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -12,7 +12,7 @@
  *     * Neither the name of the NVIDIA CORPORATION nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -141,6 +141,47 @@ CUB_RUNTIME_FUNCTION __forceinline__ cudaError_t PtxVersion(int &ptx_version)
 
     ptx_version = CUB_PTX_ARCH;
     return cudaSuccess;
+
+#elif __cplusplus >= 201103L
+
+    struct Cache
+    {
+        struct Result {
+          int const ptx_version;
+          cudaError_t const error;
+
+          Result(int ptx_version_, cudaError_t error_)
+              : ptx_version(ptx_version_), error(error_)
+          {}
+        };
+
+        Result result;
+
+        Cache()
+            : result(
+                  [] {
+                      int ptx_version = 0;
+                      cudaError_t error = cudaSuccess;
+                      do
+                      {
+                          cudaFuncAttributes empty_kernel_attrs;
+                          if (CubDebug(error = cudaFuncGetAttributes(&empty_kernel_attrs, EmptyKernel<void>))) break;
+                          ptx_version = empty_kernel_attrs.ptxVersion * 10;
+                      }
+                      while (0);
+
+                      return Result(ptx_version, error);
+                  }()
+              )
+        {}
+    };
+
+    static Cache cache;
+
+    if (!CubDebug(cache.result.error))
+        ptx_version = cache.result.ptx_version;
+
+    return cache.result.error;
 
 #else
 


### PR DESCRIPTION
This change adds a multi-device aware caching facility for `PtxVersion` and `SmVersion`. CUDA attribute queries, such as `cudaFunctionGetAttributes` and (to a lesser degree) `cudaDeviceGetAttribute` call into the CUDA driver and may involve the acquisition of driver locks, which can cause slowness, especially under contention. Some users (RAPIDS, FB PyTorch) have encountered performance issues because of this.