### PR TITLE
Fix for the compilation error: template argument for template type parameter must be a type

### DIFF
--- a/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/device/dispatch/dispatch_reduce.cuh
@@ -359,8 +359,8 @@ template <
     typename ReductionOpT>      ///< Binary reduction functor type having member <tt>T operator()(const T &a, const T &b)</tt> 
 struct DispatchReduce :
     DeviceReducePolicy<
-        std::iterator_traits<InputIteratorT>::value_type,
-        std::iterator_traits<OutputIteratorT>::value_type,
+        typename std::iterator_traits<InputIteratorT>::value_type,
+        typename std::iterator_traits<OutputIteratorT>::value_type,
         OffsetT,
         ReductionOpT>
 {
@@ -680,8 +680,8 @@ template <
     typename ReductionOpT>      ///< Binary reduction functor type having member <tt>T operator()(const T &a, const T &b)</tt> 
 struct DispatchSegmentedReduce :
     DeviceReducePolicy<
-        std::iterator_traits<InputIteratorT>::value_type,
-        std::iterator_traits<OutputIteratorT>::value_type,
+        typename std::iterator_traits<InputIteratorT>::value_type,
+        typename std::iterator_traits<OutputIteratorT>::value_type,
         OffsetT,
         ReductionOpT>
 {


### PR DESCRIPTION
Error log:
```
clang version 10.0.0 (https://github.com/llvm/llvm-project.git a11668e87b9096c821ee9fd213e398e909b92965)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /home/emankov/git/HIP/hipify-clang/build_x64_Release_LLVM_trunk_CUDA_101
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/5
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/5.4.0
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/6
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/6.5.0
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/7
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/7.4.0
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/8
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/9
Selected GCC installation: /usr/lib/gcc/x86_64-linux-gnu/6.5.0
Candidate multilib: .;@m64
Selected multilib: .;@m64
Found CUDA installation: /usr/local/cuda-10.1, version 10.1
clang Invocation:
 "/home/emankov/git/HIP/hipify-clang/build_x64_Release_LLVM_trunk_CUDA_101/clang-tool" "-cc1" "-triple" "x86_64-unknown-linux-gnu" "-target-sdk-version=10.1" "-aux-triple" "nvptx64-nvidia-cuda" "-fsyntax-only" "-disable-free" "-disable-llvm-verifier" "-discard-value-names" "-main-file-name" "cub_02.cu-2e96e9.hip" "-mrelocation-model" "static" "-mthread-model" "posix" "-mframe-pointer=all" "-fmath-errno" "-masm-verbose" "-mconstructor-aliases" "-munwind-tables" "-fuse-init-array" "-target-cpu" "x86-64" "-dwarf-column-info" "-debugger-tuning=gdb" "-v" "-resource-dir" "/home/emankov/git/LLVM/trunk/llvm_x64_Release/dist/lib/clang/10.0.0" "-internal-isystem" "/home/emankov/git/LLVM/trunk/llvm_x64_Release/dist/lib/clang/10.0.0/include/cuda_wrappers" "-internal-isystem" "/usr/local/cuda-10.1/include" "-include" "__clang_cuda_runtime_wrapper.h" "-isystem" "./include/cuda_wrappers" "-isystem" "./include" "-isystem" "/usr/local/cuda-10.1/samples/common/inc" "-I" "/home/emankov/git/HIP/tests/hipify-clang/unit_tests/libraries/CUB" "-D" "__LP64__" "-I" "/home/emankov/cudnn-10.0-v7.6.2.24/include" "-I" "/home/emankov/git/cub" "-internal-isystem" "/usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/c++/6.5.0" "-internal-isystem" "/usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/x86_64-linux-gnu/c++/6.5.0" "-internal-isystem" "/usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/x86_64-linux-gnu/c++/6.5.0" "-internal-isystem" "/usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/c++/6.5.0/backward" "-internal-isystem" "/usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/c++/6.5.0" "-internal-isystem" "/usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/x86_64-linux-gnu/c++/6.5.0" "-internal-isystem" "/usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/x86_64-linux-gnu/c++/6.5.0" "-internal-isystem" "/usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/c++/6.5.0/backward" "-internal-isystem" "/usr/local/include" "-internal-isystem" "/home/emankov/git/LLVM/trunk/llvm_x64_Release/dist/lib/clang/10.0.0/include" "-internal-externc-isystem" "/usr/include/x86_64-linux-gnu" "-internal-externc-isystem" "/include" "-internal-externc-isystem" "/usr/include" "-internal-isystem" "/usr/local/include" "-internal-isystem" "/home/emankov/git/LLVM/trunk/llvm_x64_Release/dist/lib/clang/10.0.0/include" "-internal-externc-isystem" "/usr/include/x86_64-linux-gnu" "-internal-externc-isystem" "/include" "-internal-externc-isystem" "/usr/include" "-Wno-pragma-once-outside-header" "-std=c++11" "-fdeprecated-macro" "-fdebug-compilation-dir" "/home/emankov/git/HIP/hipify-clang/build_x64_Release_LLVM_trunk_CUDA_101/unit_tests/libraries/CUB" "-ferror-limit" "19" "-fmessage-length" "0" "-fobjc-runtime=gcc" "-fcxx-exceptions" "-fexceptions" "-fdiagnostics-show-option" "-faddrsig" "-x" "cuda" "/tmp/lit_tmp_PEAhzE/cub_02.cu-2e96e9.hip"

clang -cc1 version 10.0.0 based upon LLVM 10.0.0svn default target x86_64-unknown-linux-gnu
ignoring nonexistent directory "./include/cuda_wrappers"
ignoring nonexistent directory "./include"
ignoring nonexistent directory "/include"
ignoring nonexistent directory "/include"
ignoring duplicate directory "/usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/x86_64-linux-gnu/c++/6.5.0"
ignoring duplicate directory "/usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/c++/6.5.0"
ignoring duplicate directory "/usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/x86_64-linux-gnu/c++/6.5.0"
ignoring duplicate directory "/usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/x86_64-linux-gnu/c++/6.5.0"
ignoring duplicate directory "/usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/c++/6.5.0/backward"
ignoring duplicate directory "/usr/local/include"
ignoring duplicate directory "/home/emankov/git/LLVM/trunk/llvm_x64_Release/dist/lib/clang/10.0.0/include"
ignoring duplicate directory "/usr/include/x86_64-linux-gnu"
ignoring duplicate directory "/usr/include"
#include "..." search starts here:
#include <...> search starts here:
 /home/emankov/git/HIP/tests/hipify-clang/unit_tests/libraries/CUB
 /home/emankov/cudnn-10.0-v7.6.2.24/include
 /home/emankov/git/cub
 /usr/local/cuda-10.1/samples/common/inc
 /home/emankov/git/LLVM/trunk/llvm_x64_Release/dist/lib/clang/10.0.0/include/cuda_wrappers
 /usr/local/cuda-10.1/include
 /usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/c++/6.5.0
 /usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/x86_64-linux-gnu/c++/6.5.0
 /usr/lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/c++/6.5.0/backward
 /usr/local/include
 /home/emankov/git/LLVM/trunk/llvm_x64_Release/dist/lib/clang/10.0.0/include
 /usr/include/x86_64-linux-gnu
 /usr/include
End of search list.
In file included from /tmp/lit_tmp_PEAhzE/cub_02.cu-2e96e9.hip:7:
In file included from /home/emankov/git/cub/cub/cub.cuh:53:
In file included from /home/emankov/git/cub/cub/device/device_reduce.cuh:42:
/home/emankov/git/cub/cub/device/dispatch/dispatch_reduce.cuh:362:9: error: template argument for template type parameter must be a type; did you forget 'typename'?
        std::iterator_traits<InputIteratorT>::value_type,
        ^
        typename
/home/emankov/git/cub/cub/device/dispatch/dispatch_reduce.cuh:237:14: note: template parameter is declared here
    typename InputT,            ///< Input data type
             ^
/home/emankov/git/cub/cub/device/dispatch/dispatch_reduce.cuh:363:9: error: template argument for template type parameter must be a type; did you forget 'typename'?
        std::iterator_traits<OutputIteratorT>::value_type,
        ^
        typename
/home/emankov/git/cub/cub/device/dispatch/dispatch_reduce.cuh:238:14: note: template parameter is declared here
    typename OutputT,           ///< Compute/output data type
             ^
/home/emankov/git/cub/cub/device/dispatch/dispatch_reduce.cuh:683:9: error: template argument for template type parameter must be a type; did you forget 'typename'?
        std::iterator_traits<InputIteratorT>::value_type,
        ^
        typename
/home/emankov/git/cub/cub/device/dispatch/dispatch_reduce.cuh:237:14: note: template parameter is declared here
    typename InputT,            ///< Input data type
             ^
/home/emankov/git/cub/cub/device/dispatch/dispatch_reduce.cuh:684:9: error: template argument for template type parameter must be a type; did you forget 'typename'?
        std::iterator_traits<OutputIteratorT>::value_type,
        ^
        typename
/home/emankov/git/cub/cub/device/dispatch/dispatch_reduce.cuh:238:14: note: template parameter is declared here
    typename OutputT,           ///< Compute/output data type
             ^
4 errors generated when compiling for host.
Error while processing /tmp/lit_tmp_PEAhzE/cub_02.cu-2e96e9.hip.

error: command failed with exit status: 1
```