### PR TITLE
Fix some integer overflows

### DIFF
--- a/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/agent/agent_reduce_by_key.cuh
@@ -518,7 +518,7 @@ struct AgentReduceByKey
      * Scan tiles of items as part of a dynamic chained scan
      */
     __device__ __forceinline__ void ConsumeRange(
-        int                 num_items,          ///< Total number of input items
+        OffsetT             num_items,          ///< Total number of input items
         ScanTileStateT&     tile_state,         ///< Global tile state descriptor
         int                 start_tile)         ///< The starting tile for the current grid
     {

--- a/cub/agent/agent_scan.cuh
+++ b/cub/agent/agent_scan.cuh
@@ -330,7 +330,7 @@ struct AgentScan
      * Scan tiles of items as part of a dynamic chained scan
      */
     __device__ __forceinline__ void ConsumeRange(
-        int                 num_items,          ///< Total number of input items
+        OffsetT             num_items,          ///< Total number of input items
         ScanTileStateT&     tile_state,         ///< Global tile state descriptor
         int                 start_tile)         ///< The starting tile for the current grid
     {

--- a/cub/agent/agent_segment_fixup.cuh
+++ b/cub/agent/agent_segment_fixup.cuh
@@ -346,7 +346,7 @@ struct AgentSegmentFixup
      * Scan tiles of items as part of a dynamic chained scan
      */
     __device__ __forceinline__ void ConsumeRange(
-        int                 num_items,          ///< Total number of input items
+        OffsetT             num_items,          ///< Total number of input items
         int                 num_tiles,          ///< Total number of input tiles
         ScanTileStateT&     tile_state)         ///< Global tile state descriptor
     {


### PR DESCRIPTION
A few remaining ints changed to OffsetT. This allows us to switch cub to use 64 bit offsets via  `cub::DispatchScan` without crashing.

Related: https://github.com/dmlc/xgboost/pull/6234