### PR TITLE
Update install rules to install cmake into lib directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.18)
 endif()
 
 # CXX is only needed for AppendOptionIfAvailable.
-project(CUB CUDA CXX)
+project(CUB)
 
 # Determine whether CUB is the top-level project or included into
 # another project via add_subdirectory().
@@ -16,6 +16,17 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}")
 else()
   set(CUB_TOPLEVEL_PROJECT OFF)
 endif()
+
+# This must be done before any languages are enabled:
+if (CUB_TOPLEVEL_PROJECT)
+  include(cmake/CubCompilerHacks.cmake)
+endif()
+
+# This must appear after our Compiler Hacks or else CMake will delete the cache
+# and reconfigure from scratch.
+# This must also appear before the installation rules, as it is required by the
+# GNUInstallDirs CMake module.
+enable_language(CXX)
 
 # Thrust has its own copy of CUB install rules to handle packaging usecases
 # where we want to install CUB headers but aren't actually building anything.
@@ -35,11 +46,6 @@ if (NOT CUB_TOPLEVEL_PROJECT AND NOT CUB_IN_THRUST)
   return()
 endif()
 
-include(cmake/AppendOptionIfAvailable.cmake)
-include(cmake/CubBuildCompilerTargets.cmake)
-include(cmake/CubBuildTargetList.cmake)
-include(cmake/CubCudaConfig.cmake)
-
 option(CUB_ENABLE_HEADER_TESTING "Test that all public headers compile." ON)
 option(CUB_ENABLE_TESTING "Build CUB testing suite." ON)
 option(CUB_ENABLE_EXAMPLES "Build CUB examples." ON)
@@ -52,6 +58,11 @@ if (NOT (CUB_ENABLE_HEADER_TESTING OR
          CUB_ENABLE_EXAMPLES))
   return()
 endif()
+
+include(cmake/AppendOptionIfAvailable.cmake)
+include(cmake/CubBuildCompilerTargets.cmake)
+include(cmake/CubBuildTargetList.cmake)
+include(cmake/CubCudaConfig.cmake)
 
 if ("" STREQUAL "${CMAKE_BUILD_TYPE}")
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose the type of build." FORCE)

--- a/cmake/CubCompilerHacks.cmake
+++ b/cmake/CubCompilerHacks.cmake
@@ -1,0 +1,17 @@
+# Setup compiler paths.
+# This file must be included before enabling any languages.
+
+if (NOT ("${CMAKE_CUDA_HOST_COMPILER}" STREQUAL "" OR
+  "${CMAKE_CUDA_HOST_COMPILER}" STREQUAL "${CMAKE_CXX_COMPILER}"))
+  set(tmp "${CMAKE_CUDA_HOST_COMPILER}")
+  unset(CMAKE_CUDA_HOST_COMPILER CACHE)
+  message(FATAL_ERROR
+    "For convenience, CUB's test harness uses CMAKE_CXX_COMPILER for the "
+    "CUDA host compiler. Refusing to overwrite specified "
+    "CMAKE_CUDA_HOST_COMPILER -- please reconfigure without setting this "
+    "variable. Currently:\n"
+    "CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}\n"
+    "CMAKE_CUDA_HOST_COMPILER=${tmp}"
+  )
+endif()
+set(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}")

--- a/cmake/CubCudaConfig.cmake
+++ b/cmake/CubCudaConfig.cmake
@@ -1,12 +1,4 @@
-if (NOT ("${CMAKE_CUDA_HOST_COMPILER}" STREQUAL "" OR
-         "${CMAKE_CUDA_HOST_COMPILER}" STREQUAL "${CMAKE_CXX_COMPILER}"))
-  message(FATAL_ERROR
-    "CUB tests and examples require the C++ compiler and the CUDA host "
-    "compiler to be the same; to set this compiler, please use the "
-    "CMAKE_CXX_COMPILER variable, not the CMAKE_CUDA_HOST_COMPILER variable."
-  )
-endif()
-set(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}")
+enable_language(CUDA)
 
 #
 # Architecture options:

--- a/cmake/CubInstallRules.cmake
+++ b/cmake/CubInstallRules.cmake
@@ -11,5 +11,10 @@ install(DIRECTORY "${CUB_SOURCE_DIR}/cub"
   TYPE INCLUDE
   FILES_MATCHING
     PATTERN "*.cuh"
+)
+
+install(DIRECTORY "${CUB_SOURCE_DIR}/cub"
+  TYPE LIB
+  FILES_MATCHING
     PATTERN "*.cmake"
 )

--- a/cmake/CubInstallRules.cmake
+++ b/cmake/CubInstallRules.cmake
@@ -4,6 +4,9 @@ if (CUB_IN_THRUST)
   return()
 endif()
 
+# Bring in CMAKE_INSTALL_LIBDIR
+include(GNUInstallDirs)
+
 # CUB is a header library; no need to build anything before installing:
 set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY TRUE)
 
@@ -13,8 +16,6 @@ install(DIRECTORY "${CUB_SOURCE_DIR}/cub"
     PATTERN "*.cuh"
 )
 
-install(DIRECTORY "${CUB_SOURCE_DIR}/cub"
-  TYPE LIB
-  FILES_MATCHING
-    PATTERN "*.cmake"
+install(DIRECTORY "${CUB_SOURCE_DIR}/cub/cmake/"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cub"
 )

--- a/cub/cmake/cub-config-version.cmake
+++ b/cub/cmake/cub-config-version.cmake
@@ -1,5 +1,12 @@
 # Parse version information from version.cuh:
-file(READ "${CMAKE_CURRENT_LIST_DIR}/../../../include/cub/version.cuh" CUB_VERSION_HEADER)
+unset(_CUB_VERSION_INCLUDE_DIR CACHE) # Clear old result to force search
+find_path(_CUB_VERSION_INCLUDE_DIR cub/version.cuh
+  NO_DEFAULT_PATH # Only search explicit paths below:
+  PATHS
+    ${CMAKE_CURRENT_LIST_DIR}/../..            # Source tree
+    ${CMAKE_CURRENT_LIST_DIR}/../../../include # Install tree
+)
+file(READ "${_CUB_VERSION_INCLUDE_DIR}/cub/version.cuh" CUB_VERSION_HEADER)
 string(REGEX MATCH "#define[ \t]+CUB_VERSION[ \t]+([0-9]+)" DUMMY "${CUB_VERSION_HEADER}")
 set(CUB_VERSION_FLAT ${CMAKE_MATCH_1})
 # Note that CUB calls this the PATCH number, CMake calls it the TWEAK number:

--- a/cub/cmake/cub-config-version.cmake
+++ b/cub/cmake/cub-config-version.cmake
@@ -1,5 +1,5 @@
-# Parse version information from version.h:
-file(READ "${CMAKE_CURRENT_LIST_DIR}/../version.cuh" CUB_VERSION_HEADER)
+# Parse version information from version.cuh:
+file(READ "${CMAKE_CURRENT_LIST_DIR}/../../../include/cub/version.cuh" CUB_VERSION_HEADER)
 string(REGEX MATCH "#define[ \t]+CUB_VERSION[ \t]+([0-9]+)" DUMMY "${CUB_VERSION_HEADER}")
 set(CUB_VERSION_FLAT ${CMAKE_MATCH_1})
 # Note that CUB calls this the PATCH number, CMake calls it the TWEAK number:

--- a/cub/cmake/cub-config.cmake
+++ b/cub/cmake/cub-config.cmake
@@ -31,8 +31,11 @@ endfunction()
 #
 
 _cub_declare_interface_alias(CUB::CUB _CUB_CUB)
-# Strip out the 'cub/cmake/' from 'cub/cmake/cub-config.cmake':
-get_filename_component(_CUB_INCLUDE_DIR "../../../include" ABSOLUTE BASE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+# Pull in the include dir detected by cub-config-version.cmake
+set(_CUB_INCLUDE_DIR "${_CUB_VERSION_INCLUDE_DIR}"
+  CACHE INTERNAL "Location of CUB headers."
+)
+unset(_CUB_VERSION_INCLUDE_DIR CACHE) # Clear tmp variable from cache
 target_include_directories(_CUB_CUB INTERFACE "${_CUB_INCLUDE_DIR}")
 
 if (CUB_IGNORE_DEPRECATED_CPP_DIALECT OR

--- a/cub/cmake/cub-config.cmake
+++ b/cub/cmake/cub-config.cmake
@@ -32,7 +32,7 @@ endfunction()
 
 _cub_declare_interface_alias(CUB::CUB _CUB_CUB)
 # Strip out the 'cub/cmake/' from 'cub/cmake/cub-config.cmake':
-get_filename_component(_CUB_INCLUDE_DIR "../.." ABSOLUTE BASE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+get_filename_component(_CUB_INCLUDE_DIR "../../../include" ABSOLUTE BASE_DIR "${CMAKE_CURRENT_LIST_DIR}")
 target_include_directories(_CUB_CUB INTERFACE "${_CUB_INCLUDE_DIR}")
 
 if (CUB_IGNORE_DEPRECATED_CPP_DIALECT OR

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(cmake)
+
 # TODO investigate whether this is really needed:
 math(EXPR CUB_TEST_ARCH "${CUB_MINIMAL_ENABLED_ARCH} * 10")
 message(STATUS "CUB Test architecture (TEST_ARCH): ${CUB_TEST_ARCH}")

--- a/test/cmake/CMakeLists.txt
+++ b/test/cmake/CMakeLists.txt
@@ -1,0 +1,15 @@
+if (NOT CUB_IN_THRUST) # Thrust has its own checks for this:
+  # Test that we can use `find_package` on an installed CUB:
+  add_test(
+    NAME cub.test.cmake.test_install
+    COMMAND "${CMAKE_COMMAND}"
+      --log-level=VERBOSE
+      -G "${CMAKE_GENERATOR}"
+      -S "${CMAKE_CURRENT_SOURCE_DIR}/test_install"
+      -B "${CMAKE_CURRENT_BINARY_DIR}/test_install"
+      -D "CUB_BINARY_DIR=${CUB_BINARY_DIR}"
+      -D "CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+      -D "CMAKE_CUDA_COMPILER=${CMAKE_CUDA_COMPILER}"
+      -D "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+  )
+endif()

--- a/test/cmake/test_install/CMakeLists.txt
+++ b/test/cmake/test_install/CMakeLists.txt
@@ -1,0 +1,93 @@
+# Test that an installation of the project can be located by find_package() call
+# with appropriate prefix settings.
+#
+# Expects CUB_BINARY_DIR to be set to an existing cub build directory.
+
+cmake_minimum_required(VERSION 3.15)
+
+project(CubTestInstall CXX CUDA)
+
+# This will eventually get deleted recursively -- keep that in mind if modifying
+set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/install_prefix/")
+
+function(do_manual_install)
+  # Inspired by the VTK-m install tests, we can just glob up all of the
+  # cmake_install.cmake, include (ie. run) them, and they'll effectively
+  # install the project into the current value of CMAKE_INSTALL_PREFIX.
+
+  # Gather all of the install files from CUB's root:
+  file(GLOB_RECURSE install_files
+    LIST_DIRECTORIES False
+    "${CUB_BINARY_DIR}/cmake_install.cmake"
+  )
+
+  message(STATUS "Locating install files...")
+  foreach (install_file IN LISTS install_files)
+    message(STATUS "  * ${install_file}")
+  endforeach()
+
+  message(STATUS "Building install tree...")
+  foreach(install_file IN LISTS install_files)
+    include("${install_file}")
+  endforeach()
+endfunction()
+
+function(do_cleanup)
+  message(STATUS "Removing ${CMAKE_INSTALL_PREFIX}")
+  file(REMOVE_RECURSE "${CMAKE_INSTALL_PREFIX}")
+endfunction()
+
+function(assert_boolean var_name expect)
+  if (expect)
+    if (NOT ${var_name})
+      message(FATAL_ERROR "'${var_name}' is false, expected true.")
+    endif()
+  else()
+    if (${var_name})
+      message(FATAL_ERROR "'${var_name}' is true, expected false.")
+    endif()
+  endif()
+endfunction()
+
+function(assert_target target_name)
+  if (NOT TARGET "${target_name}")
+    message(FATAL_ERROR "Target '${target_name}' not defined.")
+  endif()
+endfunction()
+
+function(find_installed_project)
+  set(CMAKE_PREFIX_PATH "${CMAKE_INSTALL_PREFIX}")
+  find_package(CUB CONFIG)
+
+  if (NOT CUB_FOUND)
+    message(FATAL_ERROR
+      "find_package(CUB) failed. "
+      "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}"
+    )
+  endif()
+
+  # Test some internal config vars to check that this is the expected install:
+  # TODO The cmake_path (3.19) command will provide more robust ways to do this
+
+  # Escape regex special characters in the install prefix, see
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/18580
+  string(REGEX REPLACE "([][+.*()^])" "\\\\\\1"
+    prefix_regex
+    "${CMAKE_INSTALL_PREFIX}"
+  )
+  if (NOT _CUB_INCLUDE_DIR MATCHES "^${prefix_regex}")
+    message(FATAL_ERROR
+      "Found CUB in unexpected location: "
+      " * _CUB_INCLUDE_DIR=${_CUB_INCLUDE_DIR} "
+      " * ExpectedPrefix=${CMAKE_INSTALL_DIR}"
+    )
+  endif()
+
+  assert_target(CUB::CUB)
+
+endfunction()
+
+do_cleanup() # Prepare for new installation
+do_manual_install()
+find_installed_project()
+do_cleanup() # Clean up if successful


### PR DESCRIPTION
See https://github.com/nvidia/thrust/issues/1322

Updates the cmake install rules to install in `lib/cub/cmake` instead of `include/cub/cmake` as the include folder is not searched in a normal `find_package(cub)` call.