### PR TITLE
Fix to support wrapping CUB in a custom outer namespace with macros

### DIFF
--- a/cub/util_namespace.cuh
+++ b/cub/util_namespace.cuh
@@ -48,6 +48,7 @@
 #endif
 
 // Declare these namespaces here for the purpose of Doxygenating them
+CUB_NS_PREFIX
 
 /*! \namespace cub
  *  \brief \p cub is the top-level namespace which contains all CUB
@@ -57,3 +58,5 @@ namespace cub
 {
 
 }
+
+CUB_NS_POSTFIX


### PR DESCRIPTION
Fixes #222 

Verified using the following example from issue #222 

```
#define CUB_NS_PREFIX namespace {
#define CUB_NS_POSTFIX }
#include <cub/cub.cuh>
int main()
{
        int res = (int)cub::Equals<int, int>::VALUE;
        return res;
}
```