### PR TITLE
nvc++ and __CUDACC__

### DIFF
--- a/cub/util_compiler.cuh
+++ b/cub/util_compiler.cuh
@@ -63,7 +63,7 @@
 #endif // CUB_HOST_COMPILER
 
 // figure out which device compiler we're using
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__NVCOMPILER_CUDA__)
 #  define CUB_DEVICE_COMPILER CUB_DEVICE_COMPILER_NVCC
 #elif CUB_HOST_COMPILER == CUB_HOST_COMPILER_MSVC
 #  define CUB_DEVICE_COMPILER CUB_DEVICE_COMPILER_MSVC


### PR DESCRIPTION
In the near future, `nvc++ -stdpar` will be changed to no longer predefine the macro `__CUDACC__`.  Adjust the uses of `__CUDACC__` in Thrust and CUB to check for NVC++'s stdpar mode in addition to the `__CUDACC__`.