### PR TITLE
Fix uses of CUB_PTX_ARCH in CUB tests to work with NVC++

### DIFF
--- a/test/test_warp_reduce.cu
+++ b/test/test_warp_reduce.cu
@@ -68,11 +68,12 @@ struct WrapperFunctor
     template <typename T>
     inline __host__ __device__ T operator()(const T &a, const T &b) const
     {
-#if CUB_PTX_ARCH != 0
-        if ((cub::LaneId() % LOGICAL_WARP_THREADS) >= num_valid)
-            cub::ThreadTrap();
-#endif
-
+	if (CUB_IS_DEVICE_CODE) {
+            #if CUB_INCLUDE_DEVICE_CODE
+                if ((cub::LaneId() % LOGICAL_WARP_THREADS) >= num_valid)
+                    cub::ThreadTrap();
+            #endif
+	}
         return op(a, b);
     }
 


### PR DESCRIPTION
Using `CUB_PTX_ARCH` to conditionally compile code for host or device doesn't
work correctly with NVC++'s unified compilation model.  Change some of the
uses of `CUB_PTX_ARCH` in CUB test code to work with both NVCC and NVC++.
This fixes test_warp_reduce when compiled with NVC++.  The uses of
`CUB_PTX_ARCH` in the main CUB code were dealt with some time ago.