### PR TITLE
Fix cub::DeviceHistogram::MultiHistogramEven() 1-Dimensional overload, when OffsetT is not an `int`.

### DIFF
--- a/cub/device/device_histogram.cuh
+++ b/cub/device/device_histogram.cuh
@@ -150,7 +150,7 @@ struct DeviceHistogram
             lower_level1,
             upper_level1,
             num_samples,
-            1,
+            static_cast<OffsetT>(1),
             sizeof(SampleT) * num_samples,
             stream,
             debug_synchronous);

--- a/cub/device/device_histogram.cuh
+++ b/cub/device/device_histogram.cuh
@@ -346,7 +346,7 @@ struct DeviceHistogram
             lower_level,
             upper_level,
             num_pixels,
-            1,
+            static_cast<OffsetT>(1),
             sizeof(SampleT) * NUM_CHANNELS * num_pixels,
             stream,
             debug_synchronous);


### PR DESCRIPTION
When using gcc=7.5.0 and `OffsetT=int64_t`, the following template errors occur:
```
/usr/local/cuda/include/cub/device/device_histogram.cuh(144): error: no instance of overloaded function "dgl::cub::DeviceHistogram::MultiHistogramEven" matches the argument list
            argument types are: (void *, size_t, int32_t *, unsigned long long *[1], int [1], int32_t [1], int32_t [1], int64_t, int, unsigned long, cudaStream_t, __nv_bool)
          detected during:
            instantiation of "cudaError_t dgl::cub::DeviceHistogram::HistogramEven(void *, size_t &, SampleIteratorT, CounterT *, int, LevelT, LevelT, OffsetT, cudaStream_t, __nv_bool) [with SampleIteratorT=int32_t *, CounterT=unsigned long long, LevelT=int32_t, OffsetT=int64_t]"
```

This resolves this, by casting the `0` to an `OffsetT`, so as to ensure `num_rows` and `num_row_samples` are of the same type.