### PR TITLE
Fix build error for RandomBits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .p4config
 *~
 \#*
+/build

--- a/test/test_util.h
+++ b/test/test_util.h
@@ -628,11 +628,16 @@ __host__ __device__ __forceinline__ void InitValue(
     cub::KeyValuePair<KeyT, ValueT>&    value,
     int                                 index = 0)
 {
+#ifndef __CUDA_ARCH__
     InitValue(gen_mode, value.value, index);
 
     // Assign corresponding flag with a likelihood of the last bit being set with entropy-reduction level 3
     RandomBits(value.key, 3);
     value.key = (value.key & 0x1);
+#else
+    printf("This overload of InitValue is not implemented on device");
+    assert(false);
+#endif
 }
 
 


### PR DESCRIPTION
I am unable to build cub on my configuration:
```
/home/gaoxiang/cub/test/test_util.h(635): error #20011-D: calling a __host__ function("void  ::RandomBits<int> (T1 &, int, int, int)") from a __host__ __device__ function("InitValue<int, float> ") is not allowed
```

My configuration:
```
gaoxiang@sunnyvale ~/cub/build build-error $ nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2021 NVIDIA Corporation
Built on Sun_Mar_21_19:15:46_PDT_2021
Cuda compilation tools, release 11.3, V11.3.58
Build cuda_11.3.r11.3/compiler.29745058_0

gaoxiang@sunnyvale ~/cub/build build-error $ g++ --version
g++ (GCC) 10.2.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```