### PR TITLE
Document that cub's device scan supports inplace operations, and add tests to enforce this feature.

### DIFF
--- a/cub/device/device_scan.cuh
+++ b/cub/device/device_scan.cuh
@@ -67,7 +67,7 @@ namespace cub {
  * idea is to leverage a small, constant factor of redundant work in order to overlap the latencies
  * of global prefix propagation with local computation.  As such, our algorithm requires only
  * ~2<em>n</em> data movement (<em>n</em> inputs are read, <em>n</em> outputs are written), and typically
- * proceeds at "memcpy" speeds.
+ * proceeds at "memcpy" speeds. Our algorithm supports inplace operations.
  *
  * \par
  * [1] [Duane Merrill and Michael Garland.  "Single-pass Parallel Prefix Scan with Decoupled Look-back", <em>NVIDIA Technical Report NVR-2016-002</em>, 2016.](https://research.nvidia.com/publication/single-pass-parallel-prefix-scan-decoupled-look-back)

--- a/test/test_device_scan.cu
+++ b/test/test_device_scan.cu
@@ -604,7 +604,7 @@ void Solve(
     }
 }
 
-template<typename OutputT, typename DeviceInputIteratorT, bool inplace>
+template<typename OutputT, typename DeviceInputIteratorT, bool InPlace>
 struct AllocateOutput {
     static void run(OutputT *&d_out, DeviceInputIteratorT, int num_items) {
         CubDebugExit(g_allocator.DeviceAllocate((void**)&d_out, sizeof(OutputT) * num_items));
@@ -627,7 +627,7 @@ template <
     typename            OutputT,
     typename            ScanOpT,
     typename            InitialValueT,
-    bool                inplace=false>
+    bool                InPlace=false>
 void Test(
     DeviceInputIteratorT    d_in,
     OutputT                 *h_reference,
@@ -639,7 +639,7 @@ void Test(
 
     // Allocate device output array
     OutputT *d_out = NULL;
-    AllocateOutput<OutputT, DeviceInputIteratorT, inplace>::run(d_out, d_in, num_items);
+    AllocateOutput<OutputT, DeviceInputIteratorT, InPlace>::run(d_out, d_in, num_items);
 
     // Allocate CDP device arrays
     size_t          *d_temp_storage_bytes = NULL;


### PR DESCRIPTION
Per the title. PyTorch is already using this assumption, and it seems to be working fine. But we want the support of this feature to be official.

cc: @ngimel