### PR TITLE
Fix block shuffle

### DIFF
--- a/cmake/CubCudaConfig.cmake
+++ b/cmake/CubCudaConfig.cmake
@@ -4,7 +4,7 @@ enable_language(CUDA)
 # Architecture options:
 #
 
-set(all_archs 35 37 50 52 53 60 61 62 70 72 75 80)
+set(all_archs 35 37 50 52 53 60 61 62 70 72 75 80 86)
 set(arch_message "CUB: Explicitly enabled compute architectures:")
 
 # Thrust sets up the architecture flags in CMAKE_CUDA_FLAGS already. Just

--- a/cub/block/block_shuffle.cuh
+++ b/cub/block/block_shuffle.cuh
@@ -87,11 +87,7 @@ private:
      ******************************************************************************/
 
     /// Shared memory storage layout type (last element from each thread's input)
-    struct _TempStorage
-    {
-        T prev[BLOCK_THREADS];
-        T next[BLOCK_THREADS];
-    };
+    typedef T _TempStorage[BLOCK_THREADS];
 
 
 public:
@@ -171,14 +167,14 @@ public:
         T&  output,                 ///< [out] The \p input item from the successor (or predecessor) thread <em>thread</em><sub><em>i</em>+<tt>distance</tt></sub> (may be aliased to \p input).  This value is only updated for for <em>thread<sub>i</sub></em> when 0 <= (<em>i</em> + \p distance) < <tt>BLOCK_THREADS-1</tt>
         int distance = 1)           ///< [in] Offset distance (may be negative)
     {
-        temp_storage[linear_tid].prev = input;
+        temp_storage[linear_tid] = input;
 
         CTA_SYNC();
 
         const int offset_tid = static_cast<int>(linear_tid) + distance;
         if ((offset_tid >= 0) && (offset_tid < BLOCK_THREADS))
         {
-            output = temp_storage[static_cast<size_t>(offset_tid)].prev;
+            output = temp_storage[static_cast<size_t>(offset_tid)];
         }
     }
 
@@ -194,7 +190,7 @@ public:
         T&  output,                 ///< [out] The \p input item from thread <em>thread</em><sub>(<em>i</em>+<tt>distance></tt>)%<tt><BLOCK_THREADS></tt></sub> (may be aliased to \p input).  This value is not updated for <em>thread</em><sub>BLOCK_THREADS-1</sub>
         unsigned int distance = 1)  ///< [in] Offset distance (0 < \p distance < <tt>BLOCK_THREADS</tt>)
     {
-        temp_storage[linear_tid].prev = input;
+        temp_storage[linear_tid] = input;
 
         CTA_SYNC();
 
@@ -202,7 +198,7 @@ public:
         if (offset >= BLOCK_THREADS)
             offset -= BLOCK_THREADS;
 
-        output = temp_storage[offset].prev;
+        output = temp_storage[offset];
     }
 
 
@@ -219,7 +215,7 @@ public:
         T (&input)[ITEMS_PER_THREAD],   ///< [in] The calling thread's input items
         T (&prev)[ITEMS_PER_THREAD])    ///< [out] The corresponding predecessor items (may be aliased to \p input).  The item \p prev[0] is not updated for <em>thread</em><sub>0</sub>.
     {
-        temp_storage[linear_tid].prev = input[ITEMS_PER_THREAD - 1];
+        temp_storage[linear_tid] = input[ITEMS_PER_THREAD - 1];
 
         CTA_SYNC();
 
@@ -227,9 +223,8 @@ public:
         for (int ITEM = ITEMS_PER_THREAD - 1; ITEM > 0; --ITEM)
             prev[ITEM] = input[ITEM - 1];
 
-
         if (linear_tid > 0)
-            prev[0] = temp_storage[linear_tid - 1].prev;
+            prev[0] = temp_storage[linear_tid - 1];
     }
 
 
@@ -248,7 +243,7 @@ public:
         T &block_suffix)                ///< [out] The item \p input[ITEMS_PER_THREAD-1] from <em>thread</em><sub><tt>BLOCK_THREADS-1</tt></sub>, provided to all threads
     {
         Up(input, prev);
-        block_suffix = temp_storage[BLOCK_THREADS - 1].prev;
+        block_suffix = temp_storage[BLOCK_THREADS - 1];
     }
 
 
@@ -265,16 +260,16 @@ public:
         T (&input)[ITEMS_PER_THREAD],   ///< [in] The calling thread's input items
         T (&prev)[ITEMS_PER_THREAD])    ///< [out] The corresponding predecessor items (may be aliased to \p input).  The value \p prev[0] is not updated for <em>thread</em><sub>BLOCK_THREADS-1</sub>.
     {
-        temp_storage[linear_tid].prev = input[ITEMS_PER_THREAD - 1];
+        temp_storage[linear_tid] = input[0];
 
         CTA_SYNC();
 
         #pragma unroll
-        for (int ITEM = ITEMS_PER_THREAD - 1; ITEM > 0; --ITEM)
-            prev[ITEM] = input[ITEM - 1];
+        for (int ITEM = 0; ITEM < ITEMS_PER_THREAD - 1; ITEM++)
+            prev[ITEM] = input[ITEM + 1];
 
-        if (linear_tid > 0)
-            prev[0] = temp_storage[linear_tid - 1].prev;
+        if (linear_tid < BLOCK_THREADS - 1)
+            prev[ITEMS_PER_THREAD - 1] = temp_storage[linear_tid + 1];
     }
 
 
@@ -292,8 +287,8 @@ public:
         T (&prev)[ITEMS_PER_THREAD],    ///< [out] The corresponding predecessor items (may be aliased to \p input).  The value \p prev[0] is not updated for <em>thread</em><sub>BLOCK_THREADS-1</sub>.
         T &block_prefix)                ///< [out] The item \p input[0] from <em>thread</em><sub><tt>0</tt></sub>, provided to all threads
     {
-        Up(input, prev);
-        block_prefix = temp_storage[BLOCK_THREADS - 1].prev;
+        Down(input, prev);
+        block_prefix = temp_storage[0];
     }
 
     //@}  end member group

--- a/test/test_block_shuffle.cu
+++ b/test/test_block_shuffle.cu
@@ -1,0 +1,369 @@
+/******************************************************************************
+ * Copyright (c) 2011-2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Test of BlockShuffle utilities
+ ******************************************************************************/
+
+// Ensure printing of CUDA runtime errors to console
+#define CUB_STDERR
+
+#include <stdio.h>
+#include <limits>
+#include <typeinfo>
+#include <memory>
+
+#include <cub/util_allocator.cuh>
+#include <cub/block/block_shuffle.cuh>
+
+#include "test_util.h"
+
+using namespace cub;
+
+template<typename DataType>
+__global__ void IotaKernel(
+        const unsigned int num_items,
+        DataType *data)
+{
+    const unsigned int i = threadIdx.x + blockIdx.x * blockDim.x;
+
+    if (i < num_items)
+    {
+        data[i] = i;
+    }
+}
+
+template<typename DataType>
+void Iota(
+        const unsigned int num_items,
+        DataType *data)
+{
+    const unsigned int ThreadsPerBlock = 256;
+    const unsigned int blocks_per_grid = (num_items + ThreadsPerBlock - 1) / ThreadsPerBlock;
+
+    IotaKernel<<<blocks_per_grid, ThreadsPerBlock>>>(num_items, data);
+
+    CubDebugExit(cudaPeekAtLastError());
+    CubDebugExit(cudaDeviceSynchronize());
+}
+
+template <
+        typename DataType,
+        unsigned int ThreadsInBlock,
+        unsigned int ItemsPerThread,
+        typename ActionType>
+__global__ void BlockShuffleTestKernel(
+        DataType *data,
+        ActionType action)
+{
+    typedef cub::BlockShuffle<DataType, ThreadsInBlock> BlockShuffle;
+
+    __shared__ typename BlockShuffle::TempStorage temp_storage_shuffle;
+
+    DataType thread_data[ItemsPerThread];
+
+    data += threadIdx.x * ItemsPerThread;
+    for (unsigned int item = 0; item < ItemsPerThread; item++)
+    {
+        thread_data[item] = data[item];
+    }
+    __syncthreads();
+
+    BlockShuffle block_shuffle(temp_storage_shuffle);
+    action(block_shuffle, thread_data);
+
+    for (unsigned int item = 0; item < ItemsPerThread; item++)
+    {
+        data[item] = thread_data[item];
+    }
+}
+
+template<
+        typename DataType,
+        unsigned int ItemsPerThread,
+        unsigned int ThreadsInBlock,
+        typename ActionType>
+void BlockShuffleTest(DataType *data, ActionType action)
+{
+    BlockShuffleTestKernel<DataType, ThreadsInBlock, ItemsPerThread><<<1, ThreadsInBlock>>> (data, action);
+
+    CubDebugExit(cudaPeekAtLastError());
+    CubDebugExit(cudaDeviceSynchronize());
+}
+
+template <
+        typename DataType,
+        unsigned int ItemsPerThread,
+        unsigned int ThreadsInBlock>
+struct UpTest
+{
+    __device__ void operator()(
+            BlockShuffle<DataType, ThreadsInBlock> &block_shuffle,
+            DataType (&thread_data)[ItemsPerThread]) const
+    {
+        block_shuffle.Up(thread_data, thread_data);
+    }
+
+    static __host__ bool check(const DataType *data, int i)
+    {
+        if (i == 0)
+        {
+            return data[i] == 0;
+        }
+
+        return data[i] == i - 1;
+    }
+};
+
+template <
+        typename DataType,
+        unsigned int ItemsPerThread,
+        unsigned int ThreadsInBlock>
+struct DownTest
+{
+    __device__ void operator()(
+            BlockShuffle<DataType, ThreadsInBlock> &block_shuffle,
+            DataType (&thread_data)[ItemsPerThread]) const
+    {
+        block_shuffle.Down(thread_data, thread_data);
+    }
+
+    static __host__ bool check(const DataType *data, int i)
+    {
+        if (i == ItemsPerThread * ThreadsInBlock - 1)
+        {
+            return data[i] == i;
+        }
+
+        return data[i] == i + 1;
+    }
+};
+
+template<typename DataType,
+         unsigned int ThreadsInBlock,
+         int offset>
+struct OffsetTestBase
+{
+    static constexpr unsigned int ItemsPerThread = 1;
+
+    __device__ void operator()(
+            BlockShuffle<DataType, ThreadsInBlock> &block_shuffle,
+            DataType (&thread_data)[ItemsPerThread]) const
+    {
+        block_shuffle.Offset(thread_data[0], thread_data[0], offset);
+    }
+};
+
+template <typename DataType,
+          unsigned int ThreadsInBlock>
+struct OffsetUpTest : public OffsetTestBase<DataType, ThreadsInBlock, -1 /* offset */>
+{
+    static __host__ bool check(const DataType *data, int i)
+    {
+        return UpTest<DataType, 1 /* ItemsPerThread */, ThreadsInBlock>::check (data, i);
+    }
+};
+
+template<typename DataType,
+         unsigned int ThreadsInBlock>
+struct OffsetDownTest : public OffsetTestBase<DataType, ThreadsInBlock, 1 /* offset */>
+{
+    static __host__ bool check(const DataType *data, int i)
+    {
+        return DownTest<DataType, 1 /* ItemsPerThread */, ThreadsInBlock>::check (data, i);
+    }
+};
+
+template<typename DataType,
+         unsigned int ThreadsInBlock,
+         unsigned int offset>
+struct RotateTestBase
+{
+    static constexpr unsigned int ItemsPerThread = 1;
+
+    __device__ void operator()(
+            BlockShuffle<DataType, ThreadsInBlock> &block_shuffle,
+            DataType (&thread_data)[ItemsPerThread]) const
+    {
+        block_shuffle.Rotate(thread_data[0], thread_data[0], offset);
+    }
+
+    static __host__ bool check(const DataType *data, int i)
+    {
+        return data[i] == static_cast<DataType>((i + offset) % ThreadsInBlock);
+    }
+};
+
+template<typename DataType,
+         unsigned int ThreadsInBlock>
+struct RotateUpTest : public RotateTestBase<DataType, ThreadsInBlock, 1 /* offset */>
+{ };
+
+template<typename DataType,
+         unsigned int ThreadsInBlock>
+struct RotateTest : public RotateTestBase<DataType, ThreadsInBlock, 24 /* offset */>
+{ };
+
+
+template <typename DataType, typename TestType>
+int CheckResult(
+        int num_items,
+        const DataType *d_output,
+        DataType *h_output,
+        const TestType &test)
+{
+    CubDebugExit(cudaMemcpy(h_output, d_output, num_items * sizeof (DataType), cudaMemcpyDeviceToHost));
+
+    for (int i = 0; i < num_items; i++)
+    {
+        if (!test.check (h_output, i))
+        {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+template <
+        typename DataType,
+        unsigned int ItemsPerThread,
+        unsigned int ThreadsInBlock,
+        template<typename, unsigned int, unsigned int> class TestType>
+void Test(unsigned int num_items,
+          DataType *d_data,
+          DataType *h_data)
+{
+    TestType<DataType, ItemsPerThread, ThreadsInBlock> test;
+
+    Iota(num_items, d_data);
+    BlockShuffleTest<DataType, ItemsPerThread, ThreadsInBlock>(d_data, test);
+    AssertEquals(0, CheckResult(num_items, d_data, h_data, test));
+}
+
+/**
+ * Some methods of it only support a single element per thread.
+ * This structure skips tests for unsupported cases.
+ */
+template <
+        typename DataType,
+        unsigned int ItemsPerThread,
+        unsigned int ThreadsInBlock,
+        template<typename, unsigned int> class TestType>
+struct SingleItemTestHelper
+{
+    static void run(unsigned int /* num_items */,
+                    DataType * /* d_data */,
+                    DataType * /* h_data */)
+    {
+    }
+};
+
+template <
+        typename DataType,
+        unsigned int ThreadsInBlock,
+        template<typename, unsigned int> class TestType>
+struct SingleItemTestHelper<DataType, 1, ThreadsInBlock, TestType>
+{
+    static void run(unsigned int num_items,
+                   DataType *d_data,
+                   DataType *h_data)
+    {
+        TestType<DataType, ThreadsInBlock> test;
+
+        Iota(num_items, d_data);
+        BlockShuffleTest<DataType, 1 /* ItemsPerThread */, ThreadsInBlock>(d_data, test);
+        AssertEquals(0, CheckResult(num_items, d_data, h_data, test));
+    }
+};
+
+
+template <
+        typename DataType,
+        unsigned int ItemsPerThread,
+        unsigned int ThreadsInBlock>
+void Test(
+    CachingDeviceAllocator &g_allocator
+)
+{
+    const unsigned int num_items = ItemsPerThread * ThreadsInBlock;
+
+    DataType *d_data = nullptr;
+    CubDebugExit(g_allocator.DeviceAllocate((void**)&d_data, sizeof(DataType) * num_items));
+
+    std::unique_ptr<DataType[]> h_data(new DataType[num_items]);
+
+    Test<DataType, ItemsPerThread, ThreadsInBlock, UpTest>(num_items, d_data, h_data.get());
+    Test<DataType, ItemsPerThread, ThreadsInBlock, DownTest>(num_items, d_data, h_data.get());
+
+    SingleItemTestHelper<DataType, ItemsPerThread, ThreadsInBlock, OffsetUpTest>().run(num_items,
+                                                                                       d_data,
+                                                                                       h_data.get());
+
+    SingleItemTestHelper<DataType, ItemsPerThread, ThreadsInBlock, OffsetDownTest>().run(num_items,
+                                                                                         d_data,
+                                                                                         h_data.get());
+
+    SingleItemTestHelper<DataType, ItemsPerThread, ThreadsInBlock, RotateUpTest>().run(num_items,
+                                                                                       d_data,
+                                                                                       h_data.get());
+
+    SingleItemTestHelper<DataType, ItemsPerThread, ThreadsInBlock, RotateTest>().run(num_items,
+                                                                                     d_data,
+                                                                                     h_data.get());
+
+    if (d_data)
+    {
+        CubDebugExit(g_allocator.DeviceFree(d_data));
+    }
+}
+
+template <unsigned int ItemsPerThread>
+void Test(CachingDeviceAllocator &g_allocator)
+{
+    Test<int16_t, ItemsPerThread, 32>(g_allocator);
+    Test<int32_t, ItemsPerThread, 32>(g_allocator);
+    Test<int32_t, ItemsPerThread, 512>(g_allocator);
+    Test<int64_t, ItemsPerThread, 512>(g_allocator);
+    Test<int64_t, ItemsPerThread, 1024>(g_allocator);
+}
+
+int main(int argc, char** argv)
+{
+    CommandLineArgs args(argc, argv);
+
+    // Initialize device
+    CubDebugExit(args.DeviceInit());
+
+    CachingDeviceAllocator g_allocator(true);
+
+    Test<1> (g_allocator);
+    Test<2> (g_allocator);
+    Test<15> (g_allocator);
+
+    return 0;
+}


### PR DESCRIPTION
In order to fix [the issue](https://github.com/NVIDIA/cub/issues/264) with `BlockShuffle::Down` function I've written tests for `BlockShuffle` . It turned out that it was broken because of the wrong `_TempStorage` type which also led to extra shared memory usage.  