### PR TITLE
Remove pragma unroll from device radix sort, thread reduce, histogram, radix rank, select if and block exchange

### DIFF
--- a/cub/agent/agent_histogram.cuh
+++ b/cub/agent/agent_histogram.cuh
@@ -251,7 +251,6 @@ struct AgentHistogram
     __device__ __forceinline__ void InitBinCounters(CounterT* privatized_histograms[NUM_ACTIVE_CHANNELS])
     {
         // Initialize histogram bin counts to zeros
-        #pragma unroll
         for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
         {
             for (int privatized_bin = threadIdx.x; privatized_bin < num_privatized_bins[CHANNEL]; privatized_bin += BLOCK_THREADS)
@@ -295,7 +294,6 @@ struct AgentHistogram
         CTA_SYNC();
 
         // Apply privatized bin counts to output bin counts
-        #pragma unroll
         for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
         {
             int channel_bins = num_privatized_bins[CHANNEL];
@@ -348,13 +346,11 @@ struct AgentHistogram
         CounterT*           privatized_histograms[NUM_ACTIVE_CHANNELS],
         Int2Type<true>      is_rle_compress)
     {
-        #pragma unroll
         for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
         {
             // Bin pixels
             int bins[PIXELS_PER_THREAD];
 
-            #pragma unroll
             for (int PIXEL = 0; PIXEL < PIXELS_PER_THREAD; ++PIXEL)
             {
                 bins[PIXEL] = -1;
@@ -363,7 +359,6 @@ struct AgentHistogram
 
             CounterT accumulator = 1;
 
-            #pragma unroll
             for (int PIXEL = 0; PIXEL < PIXELS_PER_THREAD - 1; ++PIXEL)
             {
                 if (bins[PIXEL] != bins[PIXEL + 1])
@@ -390,10 +385,8 @@ struct AgentHistogram
         CounterT*           privatized_histograms[NUM_ACTIVE_CHANNELS],
         Int2Type<false>     is_rle_compress)
     {
-        #pragma unroll
         for (int PIXEL = 0; PIXEL < PIXELS_PER_THREAD; ++PIXEL)
         {
-            #pragma unroll
             for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
             {
                 int bin = -1;
@@ -559,7 +552,6 @@ struct AgentHistogram
             Int2Type<IS_ALIGNED>());
 
         // Set valid flags
-        #pragma unroll
         for (int PIXEL = 0; PIXEL < PIXELS_PER_THREAD; ++PIXEL)
             is_valid[PIXEL] = IS_FULL_TILE || (((threadIdx.x * PIXELS_PER_THREAD + PIXEL) * NUM_CHANNELS) < valid_samples);
 

--- a/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/agent/agent_radix_sort_downsweep.cuh
@@ -243,7 +243,6 @@ struct AgentRadixSortDownsweep
         int             (&ranks)[ITEMS_PER_THREAD],
         OffsetT         valid_items)
     {
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
         {
             temp_storage.keys_and_offsets.exchange_keys[ranks[ITEM]] = twiddled_keys[ITEM];
@@ -251,7 +250,6 @@ struct AgentRadixSortDownsweep
 
         CTA_SYNC();
 
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
         {
             UnsignedBits key            = temp_storage.keys_and_offsets.exchange_keys[threadIdx.x + (ITEM * BLOCK_THREADS)];
@@ -284,7 +282,6 @@ struct AgentRadixSortDownsweep
 
         ValueExchangeT &exchange_values = temp_storage.exchange_values.Alias();
 
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
         {
             exchange_values[ranks[ITEM]] = values[ITEM];
@@ -292,7 +289,6 @@ struct AgentRadixSortDownsweep
 
         CTA_SYNC();
 
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
         {
             ValueT value = exchange_values[threadIdx.x + (ITEM * BLOCK_THREADS)];
@@ -513,7 +509,6 @@ struct AgentRadixSortDownsweep
             Int2Type<LOAD_WARP_STRIPED>());
 
         // Twiddle key bits if necessary
-        #pragma unroll
         for (int KEY = 0; KEY < ITEMS_PER_THREAD; KEY++)
         {
             keys[KEY] = Traits<KeyT>::TwiddleIn(keys[KEY]);
@@ -530,7 +525,6 @@ struct AgentRadixSortDownsweep
         CTA_SYNC();
 
         // Share exclusive digit prefix
-        #pragma unroll
         for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
         {
             int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
@@ -547,7 +541,6 @@ struct AgentRadixSortDownsweep
         // Get inclusive digit prefix
         int inclusive_digit_prefix[BINS_TRACKED_PER_THREAD];
 
-        #pragma unroll
         for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
         {
             int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
@@ -573,7 +566,6 @@ struct AgentRadixSortDownsweep
         CTA_SYNC();
 
         // Update global scatter base offsets for each digit
-        #pragma unroll
         for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
         {
             int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
@@ -674,7 +666,6 @@ struct AgentRadixSortDownsweep
         digit_extractor(current_bit, num_bits),
         short_circuit(1)
     {
-        #pragma unroll
         for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
         {
             this->bin_offset[track] = bin_offset[track];
@@ -713,7 +704,6 @@ struct AgentRadixSortDownsweep
         digit_extractor(current_bit, num_bits),
         short_circuit(1)
     {
-        #pragma unroll
         for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
         {
             int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
@@ -755,7 +745,6 @@ struct AgentRadixSortDownsweep
         else
         {
             // Process full tiles of tile_items
-            #pragma unroll 1
             while (block_offset + TILE_ITEMS <= block_end)
             {
                 ProcessTile<true>(block_offset);

--- a/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/agent/agent_radix_sort_onesweep.cuh
@@ -201,8 +201,7 @@ struct AgentRadixSortOnesweep
 
     __device__ __forceinline__ void LookbackPartial(int (&bins)[BINS_PER_THREAD])
     {
-        #pragma unroll
-        for (int u = 0; u < BINS_PER_THREAD; ++u) 
+        for (int u = 0; u < BINS_PER_THREAD; ++u)
         {
             int bin = ThreadBin(u);
             if (FULL_BINS || bin < RADIX_DIGITS)
@@ -228,7 +227,6 @@ struct AgentRadixSortOnesweep
             : agent(agent), bins(bins), keys(keys) {}
         __device__ __forceinline__ void operator()(int (&other_bins)[BINS_PER_THREAD])
         {
-            #pragma unroll
             for (int u = 0; u < BINS_PER_THREAD; ++u)
             {
                 bins[u] = other_bins[u];
@@ -241,7 +239,6 @@ struct AgentRadixSortOnesweep
   
     __device__ __forceinline__ void LookbackGlobal(int (&bins)[BINS_PER_THREAD])
     {
-        #pragma unroll
         for (int u = 0; u < BINS_PER_THREAD; ++u)
         {
             int bin = ThreadBin(u);
@@ -285,7 +282,6 @@ struct AgentRadixSortOnesweep
                                   num_items - tile_offset, Twiddle::DefaultKey());
         }
 
-        #pragma unroll
         for (int u = 0; u < ITEMS_PER_THREAD; ++u)
         {
             keys[u] = Twiddle::In(keys[u]);
@@ -323,7 +319,6 @@ struct AgentRadixSortOnesweep
     {
         // check if any bin can be short-circuited
         bool short_circuit = false;
-        #pragma unroll
         for (int u = 0; u < BINS_PER_THREAD; ++u)
         {
             if (FULL_BINS || ThreadBin(u) < RADIX_DIGITS)
@@ -345,7 +340,6 @@ struct AgentRadixSortOnesweep
         // compute offsets
         int common_bin = Digit(keys[0]);
         int offsets[BINS_PER_THREAD];
-        #pragma unroll
         for (int u = 0; u < BINS_PER_THREAD; ++u)
         {
             int bin = ThreadBin(u);
@@ -360,7 +354,6 @@ struct AgentRadixSortOnesweep
 
         // scatter the keys
         OffsetT global_offset = s.global_offsets[common_bin];
-        #pragma unroll
         for (int u = 0; u < ITEMS_PER_THREAD; ++u)
         {
             keys[u] = Twiddle::Out(keys[u]);
@@ -401,7 +394,6 @@ struct AgentRadixSortOnesweep
     void ScatterKeysShared(UnsignedBits (&keys)[ITEMS_PER_THREAD], int (&ranks)[ITEMS_PER_THREAD])
     {
         // write to shared memory
-        #pragma unroll
         for (int u = 0; u < ITEMS_PER_THREAD; ++u)
         {
             s.keys_out[ranks[u]] = keys[u];
@@ -412,7 +404,6 @@ struct AgentRadixSortOnesweep
     void ScatterValuesShared(ValueT (&values)[ITEMS_PER_THREAD], int (&ranks)[ITEMS_PER_THREAD])
     {
         // write to shared memory
-        #pragma unroll
         for (int u = 0; u < ITEMS_PER_THREAD; ++u)
         {
             s.values_out[ranks[u]] = values[u];
@@ -422,7 +413,6 @@ struct AgentRadixSortOnesweep
     __device__ __forceinline__ void LoadBinsToOffsetsGlobal(int (&offsets)[BINS_PER_THREAD])
     {
         // global offset - global part
-        #pragma unroll
         for (int u = 0; u < BINS_PER_THREAD; ++u)
         {
             int bin = ThreadBin(u);
@@ -439,7 +429,6 @@ struct AgentRadixSortOnesweep
         bool last_block = (block_idx + 1) * TILE_ITEMS >= num_items;
         if (d_bins_out != NULL && last_block)
         {
-            #pragma unroll
             for (int u = 0; u < BINS_PER_THREAD; ++u)
             {
                 int bin = ThreadBin(u);
@@ -455,7 +444,7 @@ struct AgentRadixSortOnesweep
     __device__ __forceinline__ void ScatterKeysGlobalDirect()
     {
         int tile_items = FULL_TILE ? TILE_ITEMS : num_items - block_idx * TILE_ITEMS;
-        #pragma unroll
+
         for (int u = 0; u < ITEMS_PER_THREAD; ++u)
         {
             int idx = threadIdx.x + u * BLOCK_THREADS;
@@ -473,7 +462,7 @@ struct AgentRadixSortOnesweep
     __device__ __forceinline__ void ScatterValuesGlobalDirect(int (&digits)[ITEMS_PER_THREAD])
     {
         int tile_items = FULL_TILE ? TILE_ITEMS : num_items - block_idx * TILE_ITEMS;
-        #pragma unroll
+
         for (int u = 0; u < ITEMS_PER_THREAD; ++u)
         {
             int idx = threadIdx.x + u * BLOCK_THREADS;
@@ -560,7 +549,6 @@ struct AgentRadixSortOnesweep
 
     __device__ __forceinline__ void ComputeKeyDigits(int (&digits)[ITEMS_PER_THREAD])
     {
-        #pragma unroll
         for (int u = 0; u < ITEMS_PER_THREAD; ++u)
         {
             int idx = threadIdx.x + u * BLOCK_THREADS;

--- a/cub/agent/agent_select_if.cuh
+++ b/cub/agent/agent_select_if.cuh
@@ -269,7 +269,6 @@ struct AgentSelectIf
         OffsetT                     (&selection_flags)[ITEMS_PER_THREAD],
         Int2Type<USE_SELECT_OP>     /*select_method*/)
     {
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
         {
             // Out-of-bounds items are selection_flags
@@ -307,7 +306,6 @@ struct AgentSelectIf
         }
 
         // Convert flag type to selection_flags type
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
         {
             selection_flags[ITEM] = flags[ITEM];
@@ -345,7 +343,6 @@ struct AgentSelectIf
         }
 
         // Set selection flags for out-of-bounds items
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
         {
             // Set selection_flags for out-of-bounds items
@@ -370,7 +367,6 @@ struct AgentSelectIf
         OffsetT num_selections)
     {
         // Scatter flagged items
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
         {
             if (selection_flags[ITEM])
@@ -401,7 +397,6 @@ struct AgentSelectIf
         CTA_SYNC();
 
         // Compact and scatter items
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
         {
             int local_scatter_offset = selection_indices[ITEM] - num_selections_prefix;
@@ -439,7 +434,6 @@ struct AgentSelectIf
         int tile_num_rejections = num_tile_items - num_tile_selections;
 
         // Scatter items to shared memory (rejections first)
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
         {
             int item_idx                = (threadIdx.x * ITEMS_PER_THREAD) + ITEM;
@@ -455,7 +449,6 @@ struct AgentSelectIf
         CTA_SYNC();
 
         // Gather items from shared memory and scatter to global
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
         {
             int item_idx            = (ITEM * BLOCK_THREADS) + threadIdx.x;

--- a/cub/block/block_exchange.cuh
+++ b/cub/block/block_exchange.cuh
@@ -200,7 +200,6 @@ private:
         OutputT         output_items[ITEMS_PER_THREAD],     ///< [out] Items to exchange, converting between <em>blocked</em> and <em>striped</em> arrangements.
         Int2Type<false> /*time_slicing*/)
     {
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = (linear_tid * ITEMS_PER_THREAD) + ITEM;
@@ -210,7 +209,6 @@ private:
 
         CTA_SYNC();
 
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = int(ITEM * BLOCK_THREADS) + linear_tid;
@@ -289,7 +287,6 @@ private:
         OutputT         output_items[ITEMS_PER_THREAD],     ///< [out] Items to exchange, converting between <em>blocked</em> and <em>striped</em> arrangements.
         Int2Type<false> /*time_slicing*/)
     {
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = warp_offset + ITEM + (lane_id * ITEMS_PER_THREAD);
@@ -299,7 +296,6 @@ private:
 
         WARP_SYNC(0xffffffff);
 
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = warp_offset + (ITEM * WARP_TIME_SLICED_THREADS) + lane_id;
@@ -376,7 +372,6 @@ private:
         OutputT         output_items[ITEMS_PER_THREAD],     ///< [out] Items to exchange, converting between <em>blocked</em> and <em>striped</em> arrangements.
         Int2Type<false> /*time_slicing*/)
     {
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = int(ITEM * BLOCK_THREADS) + linear_tid;
@@ -387,7 +382,6 @@ private:
         CTA_SYNC();
 
         // No timeslicing
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = (linear_tid * ITEMS_PER_THREAD) + ITEM;
@@ -467,7 +461,6 @@ private:
         OutputT         output_items[ITEMS_PER_THREAD],     ///< [out] Items to exchange, converting between <em>blocked</em> and <em>striped</em> arrangements.
         Int2Type<false> /*time_slicing*/)
     {
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = warp_offset + (ITEM * WARP_TIME_SLICED_THREADS) + lane_id;
@@ -477,7 +470,6 @@ private:
 
         WARP_SYNC(0xffffffff);
 
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = warp_offset + ITEM + (lane_id * ITEMS_PER_THREAD);
@@ -535,7 +527,6 @@ private:
         OffsetT         ranks[ITEMS_PER_THREAD],    ///< [in] Corresponding scatter ranks
         Int2Type<false> /*time_slicing*/)
     {
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = ranks[ITEM];
@@ -545,7 +536,6 @@ private:
 
         CTA_SYNC();
 
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = (linear_tid * ITEMS_PER_THREAD) + ITEM;
@@ -617,7 +607,6 @@ private:
         OffsetT         ranks[ITEMS_PER_THREAD],    ///< [in] Corresponding scatter ranks
         Int2Type<false> /*time_slicing*/)
     {
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = ranks[ITEM];
@@ -627,7 +616,6 @@ private:
 
         CTA_SYNC();
 
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = int(ITEM * BLOCK_THREADS) + linear_tid;
@@ -991,7 +979,6 @@ public:
         OutputT     output_items[ITEMS_PER_THREAD],     ///< [out] Items from exchange, converting between <em>striped</em> and <em>blocked</em> arrangements.
         OffsetT     ranks[ITEMS_PER_THREAD])            ///< [in] Corresponding scatter ranks
     {
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = ranks[ITEM];
@@ -1002,7 +989,6 @@ public:
 
         CTA_SYNC();
 
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = int(ITEM * BLOCK_THREADS) + linear_tid;
@@ -1030,7 +1016,6 @@ public:
         OffsetT     ranks[ITEMS_PER_THREAD],            ///< [in] Corresponding scatter ranks
         ValidFlag   is_valid[ITEMS_PER_THREAD])         ///< [in] Corresponding flag denoting item validity
     {
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = ranks[ITEM];
@@ -1041,7 +1026,6 @@ public:
 
         CTA_SYNC();
 
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = int(ITEM * BLOCK_THREADS) + linear_tid;
@@ -1212,7 +1196,6 @@ public:
         T               items[ITEMS_PER_THREAD],        ///< [in-out] Items to exchange
         OffsetT         ranks[ITEMS_PER_THREAD])        ///< [in] Corresponding scatter ranks
     {
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             if (INSERT_PADDING) ranks[ITEM] = SHR_ADD(ranks[ITEM], LOG_SMEM_BANKS, ranks[ITEM]);
@@ -1221,7 +1204,6 @@ public:
 
         WARP_SYNC(0xffffffff);
 
-        #pragma unroll
         for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ITEM++)
         {
             int item_offset = (ITEM * LOGICAL_WARP_THREADS) + lane_id;

--- a/cub/block/block_histogram.cuh
+++ b/cub/block/block_histogram.cuh
@@ -292,7 +292,6 @@ public:
         // Initialize histogram bin counts to zeros
         int histo_offset = 0;
 
-        #pragma unroll
         for(; histo_offset + BLOCK_THREADS <= BINS; histo_offset += BLOCK_THREADS)
         {
             histogram[histo_offset + linear_tid] = 0;

--- a/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/device/dispatch/dispatch_histogram.cuh
@@ -77,7 +77,6 @@ __global__ void DeviceHistogramInitKernel(
 
     int output_bin = (blockIdx.x * blockDim.x) + threadIdx.x;
 
-    #pragma unroll
     for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
     {
         if (output_bin < num_output_bins_wrapper.array[CHANNEL])

--- a/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -333,7 +333,6 @@ __global__ void DeviceRadixSortSingleTileKernel(
         Int2Type<KEYS_ONLY>());
 
     // Store keys and values
-    #pragma unroll
     for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
     {
         int item_offset = ITEM * BLOCK_THREADS + threadIdx.x;
@@ -447,7 +446,6 @@ __global__ void DeviceSegmentedRadixSortKernel(
     if (IS_DESCENDING)
     {
         // Reverse bin counts
-        #pragma unroll
         for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
         {
             int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
@@ -458,7 +456,6 @@ __global__ void DeviceSegmentedRadixSortKernel(
 
         CTA_SYNC();
 
-        #pragma unroll
         for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
         {
             int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
@@ -472,7 +469,6 @@ __global__ void DeviceSegmentedRadixSortKernel(
     OffsetT bin_offset[BINS_TRACKED_PER_THREAD];     // The global scatter base offset for each digit value in this pass (valid in the first RADIX_DIGITS threads)
     DigitScanT(temp_storage.scan).ExclusiveSum(bin_count, bin_offset);
 
-    #pragma unroll
     for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
     {
         bin_offset[track] += segment_begin;
@@ -481,7 +477,6 @@ __global__ void DeviceSegmentedRadixSortKernel(
     if (IS_DESCENDING)
     {
         // Reverse bin offsets
-        #pragma unroll
         for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
         {
             int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
@@ -492,7 +487,6 @@ __global__ void DeviceSegmentedRadixSortKernel(
 
         CTA_SYNC();
 
-        #pragma unroll
         for (int track = 0; track < BINS_TRACKED_PER_THREAD; ++track)
         {
             int bin_idx = (threadIdx.x * BINS_TRACKED_PER_THREAD) + track;
@@ -579,7 +573,6 @@ __global__ void DeviceRadixSortExclusiveSumKernel(OffsetT* d_bins)
     // load the bins
     OffsetT bins[BINS_PER_THREAD];
     int bin_start = blockIdx.x * RADIX_DIGITS;
-    #pragma unroll
     for (int u = 0; u < BINS_PER_THREAD; ++u)
     {
         int bin = threadIdx.x * BINS_PER_THREAD + u;
@@ -591,7 +584,6 @@ __global__ void DeviceRadixSortExclusiveSumKernel(OffsetT* d_bins)
     BlockScan(temp_storage).ExclusiveSum(bins, bins);
 
     // store the offsets
-    #pragma unroll
     for (int u = 0; u < BINS_PER_THREAD; ++u)
     {
         int bin = threadIdx.x * BINS_PER_THREAD + u;

--- a/cub/thread/thread_reduce.cuh
+++ b/cub/thread/thread_reduce.cuh
@@ -60,7 +60,6 @@ __device__ __forceinline__ T ThreadReduce(
 {
     T retval = prefix;
 
-    #pragma unroll
     for (int i = 0; i < LENGTH; ++i)
         retval = reduction_op(retval, input[i]);
 


### PR DESCRIPTION
1. There is no difference in performance and compilation time for the reduce with simple operators. On complex operators (256 sqrt calls), the compilation time is up to 2.4 times faster, and the runtime speedup is about 2x without `pragma unroll`. 
2. There is no difference in performance and compilation time for the radix sort. 
3. There is no difference in performance and compilation time for the histogram.
4. There is a 20% slowdown for scan with some complex operators, so it's better to leave `pragma unroll` there.
5. There is no difference in performance and compilation time for the `select_if` algorithm with simple operators. On complex operators (128 sqrt calls), there is a 3.2x compilation time improvement and a 1.6x runtime speedup. 
6. There is no difference in performance for the default block exchange algorithms. There is a significant slowdown (2x) for time-sliced versions, though. Therefore I've left `pragma unroll` in time-sliced versions only. 