### PR TITLE
Avoid warnings about unreachable code

### DIFF
--- a/cub/block/radix_rank_sort_operations.cuh
+++ b/cub/block/radix_rank_sort_operations.cuh
@@ -93,12 +93,14 @@ struct BaseDigitExtractor
 
     static __device__ __forceinline__ UnsignedBits ProcessFloatMinusZero(UnsignedBits key)
     {
-        if (!FLOAT_KEY) return key;
-        
-        UnsignedBits TWIDDLED_MINUS_ZERO_BITS =
-            TraitsT::TwiddleIn(UnsignedBits(1) << UnsignedBits(8 * sizeof(UnsignedBits) - 1));
-        UnsignedBits TWIDDLED_ZERO_BITS = TraitsT::TwiddleIn(0);
-        return key == TWIDDLED_MINUS_ZERO_BITS ? TWIDDLED_ZERO_BITS : key;
+        if (!FLOAT_KEY) {
+            return key;
+        } else {
+            UnsignedBits TWIDDLED_MINUS_ZERO_BITS =
+                TraitsT::TwiddleIn(UnsignedBits(1) << UnsignedBits(8 * sizeof(UnsignedBits) - 1));
+            UnsignedBits TWIDDLED_ZERO_BITS = TraitsT::TwiddleIn(0);
+            return key == TWIDDLED_MINUS_ZERO_BITS ? TWIDDLED_ZERO_BITS : key;
+        }
     }
 };
 


### PR DESCRIPTION
NVC++ warns about unreachable code in specializations of `BaseDigitExtractor::ProcessFloatMinusZero` where `FLOAT_KEY` is false.  Rearrange the code to avoid the warning, without changing the behavior at all.