### PR TITLE
Small fixes for CachingDeviceAllocator

### DIFF
--- a/cub/util_allocator.cuh
+++ b/cub/util_allocator.cuh
@@ -680,10 +680,11 @@ struct CachingDeviceAllocator
             // Reduce balance and erase entry
             cached_bytes[current_device].free -= begin->bytes;
 
+            cached_blocks.erase(begin);
+
             if (debug) _CubLog("\tDevice %d freed %lld bytes.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
                 current_device, (long long) begin->bytes, (long long) cached_blocks.size(), (long long) cached_bytes[current_device].free, (long long) live_blocks.size(), (long long) cached_bytes[current_device].live);
 
-            cached_blocks.erase(begin);
         }
 
         mutex.Unlock();

--- a/cub/util_allocator.cuh
+++ b/cub/util_allocator.cuh
@@ -594,6 +594,9 @@ struct CachingDeviceAllocator
             }
         }
 
+        // Unlock
+        mutex.Unlock();
+
         // First set to specified device (entrypoint may not be set)
         if (device != entrypoint_device)
         {
@@ -606,9 +609,6 @@ struct CachingDeviceAllocator
             // Insert the ready event in the associated stream (must have current device set properly)
             if (CubDebug(error = cudaEventRecord(search_key.ready_event, search_key.associated_stream))) return error;
         }
-
-        // Unlock
-        mutex.Unlock();
 
         if (!recached)
         {


### PR DESCRIPTION
This PR fixes the following issues

1.
The following code prints correct number of cached bytes, but incorrect number of cached blocks. 

```#include <cub/cub.cuh>

int main(){
    cub::CachingDeviceAllocator alloc(
        false, //skip_cleanup 
        true //debug
    );

    void* ptr;
    alloc.DeviceAllocate(&ptr, 128);
    alloc.DeviceFree(ptr);
    alloc.FreeAllCached();
}
```

```
Device 0 allocated new device block at 0x7fffca400000 (512 bytes associated with stream 0).
        0 available blocks cached (0 bytes), 1 live blocks outstanding(512 bytes).
Device 0 returned 512 bytes from associated stream 0.
         1 available blocks cached (512 bytes), 0 live blocks outstanding. (0 bytes)
Device 0 freed 512 bytes.
          1 available blocks cached (0 bytes), 0 live blocks (0 bytes) outstanding.

```

2.
Mutex remains locked in DeviceFree if error occured.
