### PR TITLE
Port adjacent difference into CUB

### DIFF
--- a/cub/agent/agent_adjacent_difference.cuh
+++ b/cub/agent/agent_adjacent_difference.cuh
@@ -1,0 +1,254 @@
+/******************************************************************************
+ * Copyright (c) 2011-2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include "../config.cuh"
+#include "../util_type.cuh"
+#include "../util_namespace.cuh"
+#include "../block/block_load.cuh"
+#include "../block/block_store.cuh"
+#include "../block/block_adjacent_difference.cuh"
+
+#include <thrust/system/cuda/detail/core/util.h>
+
+
+CUB_NAMESPACE_BEGIN
+
+
+template <
+  int                      _BLOCK_THREADS,
+  int                      _ITEMS_PER_THREAD = 1,
+  cub::BlockLoadAlgorithm  _LOAD_ALGORITHM   = cub::BLOCK_LOAD_DIRECT,
+  cub::CacheLoadModifier   _LOAD_MODIFIER    = cub::LOAD_LDG,
+  cub::BlockStoreAlgorithm _STORE_ALGORITHM  = cub::BLOCK_STORE_DIRECT>
+struct AgentAdjacentDifferencePolicy
+{
+  static constexpr int BLOCK_THREADS    = _BLOCK_THREADS;
+  static constexpr int ITEMS_PER_THREAD = _ITEMS_PER_THREAD;
+  static constexpr int ITEMS_PER_TILE   = BLOCK_THREADS * ITEMS_PER_THREAD;
+
+  static constexpr cub::BlockLoadAlgorithm LOAD_ALGORITHM   = _LOAD_ALGORITHM;
+  static constexpr cub::CacheLoadModifier LOAD_MODIFIER     = _LOAD_MODIFIER;
+  static constexpr cub::BlockStoreAlgorithm STORE_ALGORITHM = _STORE_ALGORITHM;
+};
+
+template <typename Policy,
+          typename InputIteratorT,
+          typename OutputIteratorT,
+          typename DifferenceOpT,
+          typename OffsetT,
+          typename InputT,
+          typename OutputT,
+          bool InPlace,
+          bool ReadLeft>
+struct AgentDifference
+{
+  using LoadIt = typename THRUST_NS_QUALIFIER::cuda_cub::core::LoadIterator<Policy, InputIteratorT>::type;
+
+  using BlockLoad = typename cub::BlockLoadType<Policy, LoadIt>::type;
+  using BlockStore = typename cub::BlockStoreType<Policy, OutputIteratorT, OutputT>::type;
+
+  using BlockAdjacentDifferenceT =
+    cub::BlockAdjacentDifference<InputT, Policy::BLOCK_THREADS>;
+
+  union _TempStorage
+  {
+    typename BlockLoad::TempStorage load;
+    typename BlockStore::TempStorage store;
+    typename BlockAdjacentDifferenceT::TempStorage adjacent_difference;
+  };
+
+  /// Alias wrapper allowing storage to be unioned
+  struct TempStorage : Uninitialized<_TempStorage> {};
+
+  static constexpr int BLOCK_THREADS = Policy::BLOCK_THREADS;
+  static constexpr int ITEMS_PER_THREAD = Policy::ITEMS_PER_THREAD;
+  static constexpr int ITEMS_PER_TILE = Policy::ITEMS_PER_TILE;
+  static constexpr int SHARED_MEMORY_SIZE = static_cast<int>(sizeof(TempStorage));
+
+  _TempStorage &temp_storage;
+  InputIteratorT input_it;
+  LoadIt load_it;
+  InputT *first_tile_previous;
+  OutputIteratorT result;
+  DifferenceOpT difference_op;
+  OffsetT num_items;
+
+  __device__ __forceinline__ AgentDifference(TempStorage &temp_storage,
+                                             InputIteratorT input_it,
+                                             InputT *first_tile_previous,
+                                             OutputIteratorT result,
+                                             DifferenceOpT difference_op,
+                                             OffsetT num_items)
+      : temp_storage(temp_storage.Alias())
+      , input_it(input_it)
+      , load_it(
+          THRUST_NS_QUALIFIER::cuda_cub::core::make_load_iterator(Policy(),
+                                                                  input_it))
+      , first_tile_previous(first_tile_previous)
+      , result(result)
+      , difference_op(difference_op)
+      , num_items(num_items)
+  {}
+
+  template <bool IS_LAST_TILE,
+            bool IS_FIRST_TILE>
+  __device__ __forceinline__ void consume_tile_impl(int num_remaining,
+                                                    int tile_idx,
+                                                    OffsetT tile_base)
+  {
+    InputT input[ITEMS_PER_THREAD];
+    OutputT output[ITEMS_PER_THREAD];
+
+    if (IS_LAST_TILE)
+    {
+      // Fill last elements with the first element
+      // because collectives are not suffix guarded
+      BlockLoad(temp_storage.load)
+        .Load(load_it + tile_base, input, num_remaining, *(load_it + tile_base));
+    }
+    else
+    {
+      BlockLoad(temp_storage.load).Load(load_it + tile_base, input);
+    }
+
+    CTA_SYNC();
+
+    if (ReadLeft)
+    {
+      if (IS_FIRST_TILE)
+      {
+        BlockAdjacentDifferenceT(temp_storage.adjacent_difference)
+          .SubtractLeft(input, output, difference_op);
+      }
+      else
+      {
+        InputT tile_prev_input = InPlace ? first_tile_previous[tile_idx]
+                                         : *(input_it + tile_base - 1);
+
+        BlockAdjacentDifferenceT(temp_storage.adjacent_difference)
+          .SubtractLeft(input, output, difference_op, tile_prev_input);
+      }
+    }
+    else
+    {
+      if (IS_LAST_TILE)
+      {
+        BlockAdjacentDifferenceT(temp_storage.adjacent_difference)
+          .SubtractRightPartialTile(input, output, difference_op, num_remaining);
+      }
+      else
+      {
+        InputT tile_next_input = InPlace ? first_tile_previous[tile_idx]
+                                         : *(input_it + tile_base + ITEMS_PER_TILE);
+
+        BlockAdjacentDifferenceT(temp_storage.adjacent_difference)
+          .SubtractRight(input, output, difference_op, tile_next_input);
+      }
+    }
+
+    CTA_SYNC();
+
+    if (IS_LAST_TILE)
+    {
+      BlockStore(temp_storage.store)
+        .Store(result + tile_base, output, num_remaining);
+    }
+    else
+    {
+      BlockStore(temp_storage.store).Store(result + tile_base, output);
+    }
+  }
+
+  template <bool IS_LAST_TILE>
+  __device__ __forceinline__ void consume_tile(int num_remaining,
+                                               int tile_idx,
+                                               OffsetT tile_base)
+  {
+    if (tile_idx == 0)
+    {
+      consume_tile_impl<IS_LAST_TILE, true>(num_remaining,
+                                            tile_idx,
+                                            tile_base);
+    }
+    else
+    {
+      consume_tile_impl<IS_LAST_TILE, false>(num_remaining,
+                                             tile_idx,
+                                             tile_base);
+    }
+  }
+
+  __device__ __forceinline__ void Process(int tile_idx,
+                                          OffsetT tile_base)
+  {
+    OffsetT num_remaining = num_items - tile_base;
+
+    if (num_remaining > ITEMS_PER_TILE) // not a last tile
+    {
+      consume_tile<false>(num_remaining, tile_idx, tile_base);
+    }
+    else
+    {
+      consume_tile<true>(num_remaining, tile_idx, tile_base);
+    }
+  }
+};
+
+template <typename InputIteratorT,
+          typename InputT,
+          typename OffsetT,
+          bool ReadLeft>
+struct AgentDifferenceInit
+{
+  static constexpr int BLOCK_THREADS = 128;
+
+  static __device__ __forceinline__ void Process(int tile_idx,
+                                                 InputIteratorT first,
+                                                 InputT *result,
+                                                 OffsetT num_tiles,
+                                                 int items_per_tile)
+  {
+    OffsetT tile_base  = static_cast<OffsetT>(tile_idx) * items_per_tile;
+
+    if (tile_base > 0 && tile_idx < num_tiles)
+    {
+      if (ReadLeft)
+      {
+        result[tile_idx] = first[tile_base - 1];
+      }
+      else
+      {
+        result[tile_idx - 1] = first[tile_base];
+      }
+    }
+  }
+};
+
+
+CUB_NAMESPACE_END

--- a/cub/block/block_adjacent_difference.cuh
+++ b/cub/block/block_adjacent_difference.cuh
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2011, Duane Merrill.  All rights reserved.
- * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2011-2021, NVIDIA CORPORATION.  All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -27,8 +27,10 @@
  ******************************************************************************/
 
 /**
- * \file
- * The cub::BlockDiscontinuity class provides [<em>collective</em>](index.html#sec0) methods for flagging discontinuities within an ordered set of items partitioned across a CUDA thread block.
+ * @file
+ * The cub::BlockAdjacentDifference class provides
+ * [<em>collective</em>](index.html#sec0) methods for computing the differences
+ * of adjacent elements partitioned across a CUDA thread block.
  */
 
 #pragma once
@@ -39,27 +41,105 @@
 
 CUB_NAMESPACE_BEGIN
 
-template <
-    typename    T,
-    int         BLOCK_DIM_X,
-    int         BLOCK_DIM_Y     = 1,
-    int         BLOCK_DIM_Z     = 1,
-    int         PTX_ARCH        = CUB_PTX_ARCH>
+
+/**
+ * @brief BlockAdjacentDifference provides
+ *        [<em>collective</em>](index.html#sec0) methods for computing the
+ *        differences of adjacent elements partitioned across a CUDA thread
+ *        block.
+ *
+ * @ingroup BlockModule
+ *
+ * @par Overview
+ * - BlockAdjacentDifference calculates the differences of adjacent elements in
+ *   the elements partitioned across a CUDA thread block. Because the binary
+ *   operation could be noncommutative, there are two sets of methods.
+ *   Methods named SubtractLeft subtract left element `i - 1` of input sequence
+ *   from current element `i`. Methods named SubtractRight subtract current
+ *   element `i` from the right one `i + 1`:
+ *   @par
+ *   @code
+ *   int values[4]; // [1, 2, 3, 4]
+ *   //...
+ *   int subtract_left_result[4];  <-- [  1,  1,  1,  1 ]
+ *   int subtract_right_result[4]; <-- [ -1, -1, -1,  4 ]
+ *   @endcode
+ * - For SubtractLeft, if the left element is out of bounds, the
+ *   output value is assigned to `input[0]` without modification.
+ * - For SubtractRight, if the right element is out of bounds, the output value
+ *   is assigned to the current input value without modification.
+ * - The following example under the examples/block folder illustrates usage of
+ *   dynamically shared memory with BlockReduce and how to re-purpose
+ *   the same memory region:
+ *   <a href="../../examples/block/example_block_reduce_dyn_smem.cu">example_block_reduce_dyn_smem.cu</a>
+ *   This example can be easily adapted to the storage required by
+ *   BlockAdjacentDifference.
+ *
+ * @par Snippet
+ * The code snippet below illustrates how to use @p BlockAdjacentDifference to
+ * compute the left difference between adjacent elements.
+ *
+ * @par
+ * @code
+ * #include <cub/cub.cuh>
+ * // or equivalently <cub/block/block_adjacent_difference.cuh>
+ *
+ * struct CustomDifference
+ * {
+ *   template <typename DataType>
+ *   __device__ DataType operator()(DataType &lhs, DataType &rhs)
+ *   {
+ *     return lhs - rhs;
+ *   }
+ * };
+ *
+ * __global__ void ExampleKernel(...)
+ * {
+ *     // Specialize BlockAdjacentDifference for a 1D block of
+ *     // 128 threads of type int
+ *     using BlockAdjacentDifferenceT =
+ *        cub::BlockAdjacentDifference<int, 128>;
+ *
+ *     // Allocate shared memory for BlockDiscontinuity
+ *     __shared__ typename BlockAdjacentDifferenceT::TempStorage temp_storage;
+ *
+ *     // Obtain a segment of consecutive items that are blocked across threads
+ *     int thread_data[4];
+ *     ...
+ *
+ *     // Collectively compute adjacent_difference
+ *     int result[4];
+ *
+ *     BlockAdjacentDifferenceT(temp_storage).SubtractLeft(
+ *         result,
+ *         thread_data,
+ *         CustomDifference());
+ *
+ * @endcode
+ * @par
+ * Suppose the set of input `thread_data` across the block of threads is
+ * <tt>{ [4,2,1,1], [1,1,1,1], [2,3,3,3], [3,4,1,4], ... }</tt>.
+ * The corresponding output `result` in those threads will be
+ * <tt>{ [4,-2,-1,0], [0,0,0,0], [1,1,0,0], [0,1,-3,3], ... }</tt>.
+ *
+ */
+template <typename T,
+          int BLOCK_DIM_X,
+          int BLOCK_DIM_Y = 1,
+          int BLOCK_DIM_Z = 1,
+          int PTX_ARCH    = CUB_PTX_ARCH>
 class BlockAdjacentDifference
 {
 private:
 
-    /******************************************************************************
+    /***************************************************************************
      * Constants and type definitions
-     ******************************************************************************/
+     **************************************************************************/
 
     /// Constants
-    enum
-    {
-        /// The thread block size in threads
-        BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
-    };
 
+    /// The thread block size in threads
+    static constexpr int BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z;
 
     /// Shared memory storage layout type (last element from each thread's input)
     struct _TempStorage
@@ -69,9 +149,9 @@ private:
     };
 
 
-    /******************************************************************************
+    /***************************************************************************
      * Utility methods
-     ******************************************************************************/
+     **************************************************************************/
 
     /// Internal storage allocator
     __device__ __forceinline__ _TempStorage& PrivateStorage()
@@ -82,42 +162,53 @@ private:
 
 
     /// Specialization for when FlagOp has third index param
-    template <typename FlagOp, bool HAS_PARAM = BinaryOpHasIdxParam<T, FlagOp>::HAS_PARAM>
+    template <typename FlagOp,
+              bool HAS_PARAM = BinaryOpHasIdxParam<T, FlagOp>::HAS_PARAM>
     struct ApplyOp
     {
         // Apply flag operator
-        static __device__ __forceinline__ T FlagT(FlagOp flag_op, const T &a, const T &b, int idx)
-        {
-            return flag_op(b, a, idx);
-        }
+      static __device__ __forceinline__ T FlagT(FlagOp flag_op,
+                                                const T &a,
+                                                const T &b,
+                                                int idx)
+      {
+        return flag_op(b, a, idx);
+      }
     };
 
     /// Specialization for when FlagOp does not have a third index param
     template <typename FlagOp>
     struct ApplyOp<FlagOp, false>
     {
-        // Apply flag operator
-        static __device__ __forceinline__ T FlagT(FlagOp flag_op, const T &a, const T &b, int /*idx*/)
-        {
-            return flag_op(b, a);
-        }
+      // Apply flag operator
+      static __device__ __forceinline__ T FlagT(FlagOp flag_op,
+                                                const T &a,
+                                                const T &b,
+                                                int /*idx*/)
+      {
+        return flag_op(b, a);
+      }
     };
 
     /// Templated unrolling of item comparison (inductive case)
     template <int ITERATION, int MAX_ITERATIONS>
     struct Iterate
     {
-        // Head flags
-        template <
-            int             ITEMS_PER_THREAD,
-            typename        FlagT,
-            typename        FlagOp>
-        static __device__ __forceinline__ void FlagHeads(
-            int                     linear_tid,
-            FlagT                   (&flags)[ITEMS_PER_THREAD],         ///< [out] Calling thread's discontinuity head_flags
-            T                       (&input)[ITEMS_PER_THREAD],         ///< [in] Calling thread's input items
-            T                       (&preds)[ITEMS_PER_THREAD],         ///< [out] Calling thread's predecessor items
-            FlagOp                  flag_op)                            ///< [in] Binary boolean flag predicate
+        /**
+         * Head flags
+         *
+         * @param[out] flags Calling thread's discontinuity head_flags
+         * @param[in] input Calling thread's input items
+         * @param[out] preds Calling thread's predecessor items
+         * @param[in] flag_op Binary boolean flag predicate
+         */
+        template <int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
+        static __device__ __forceinline__ void
+        FlagHeads(int linear_tid,
+                  FlagT (&flags)[ITEMS_PER_THREAD],
+                  T (&input)[ITEMS_PER_THREAD],
+                  T (&preds)[ITEMS_PER_THREAD],
+                  FlagOp flag_op)
         {
             preds[ITERATION] = input[ITERATION - 1];
 
@@ -127,19 +218,26 @@ private:
                 input[ITERATION],
                 (linear_tid * ITEMS_PER_THREAD) + ITERATION);
 
-            Iterate<ITERATION + 1, MAX_ITERATIONS>::FlagHeads(linear_tid, flags, input, preds, flag_op);
+            Iterate<ITERATION + 1, MAX_ITERATIONS>::FlagHeads(linear_tid,
+                                                              flags,
+                                                              input,
+                                                              preds,
+                                                              flag_op);
         }
 
-        // Tail flags
-        template <
-            int             ITEMS_PER_THREAD,
-            typename        FlagT,
-            typename        FlagOp>
-        static __device__ __forceinline__ void FlagTails(
-            int                     linear_tid,
-            FlagT                   (&flags)[ITEMS_PER_THREAD],         ///< [out] Calling thread's discontinuity head_flags
-            T                       (&input)[ITEMS_PER_THREAD],         ///< [in] Calling thread's input items
-            FlagOp                  flag_op)                            ///< [in] Binary boolean flag predicate
+        /**
+         * Tail flags
+         *
+         * @param[out] flags Calling thread's discontinuity head_flags
+         * @param[in] input Calling thread's input items
+         * @param[in] flag_op Binary boolean flag predicate
+         */
+        template <int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
+        static __device__ __forceinline__ void
+        FlagTails(int linear_tid,
+                  FlagT (&flags)[ITEMS_PER_THREAD],
+                  T (&input)[ITEMS_PER_THREAD],
+                  FlagOp flag_op)
         {
             flags[ITERATION] = ApplyOp<FlagOp>::FlagT(
                 flag_op,
@@ -147,45 +245,41 @@ private:
                 input[ITERATION + 1],
                 (linear_tid * ITEMS_PER_THREAD) + ITERATION + 1);
 
-            Iterate<ITERATION + 1, MAX_ITERATIONS>::FlagTails(linear_tid, flags, input, flag_op);
+          Iterate<ITERATION + 1, MAX_ITERATIONS>::FlagTails(linear_tid,
+                                                            flags,
+                                                            input,
+                                                            flag_op);
         }
-
     };
 
     /// Templated unrolling of item comparison (termination case)
     template <int MAX_ITERATIONS>
     struct Iterate<MAX_ITERATIONS, MAX_ITERATIONS>
     {
-        // Head flags
-        template <
-            int             ITEMS_PER_THREAD,
-            typename        FlagT,
-            typename        FlagOp>
-        static __device__ __forceinline__ void FlagHeads(
-            int                     /*linear_tid*/,
-            FlagT                   (&/*flags*/)[ITEMS_PER_THREAD],         ///< [out] Calling thread's discontinuity head_flags
-            T                       (&/*input*/)[ITEMS_PER_THREAD],         ///< [in] Calling thread's input items
-            T                       (&/*preds*/)[ITEMS_PER_THREAD],         ///< [out] Calling thread's predecessor items
-            FlagOp                  /*flag_op*/)                            ///< [in] Binary boolean flag predicate
-        {}
+      // Head flags
+      template <int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
+      static __device__ __forceinline__ void
+      FlagHeads(int /*linear_tid*/,
+                FlagT (&/*flags*/)[ITEMS_PER_THREAD],
+                T (&/*input*/)[ITEMS_PER_THREAD],
+                T (&/*preds*/)[ITEMS_PER_THREAD],
+                FlagOp /*flag_op*/)
+      {}
 
-        // Tail flags
-        template <
-            int             ITEMS_PER_THREAD,
-            typename        FlagT,
-            typename        FlagOp>
-        static __device__ __forceinline__ void FlagTails(
-            int                     /*linear_tid*/,
-            FlagT                   (&/*flags*/)[ITEMS_PER_THREAD],         ///< [out] Calling thread's discontinuity head_flags
-            T                       (&/*input*/)[ITEMS_PER_THREAD],         ///< [in] Calling thread's input items
-            FlagOp                  /*flag_op*/)                            ///< [in] Binary boolean flag predicate
-        {}
+      // Tail flags
+      template <int ITEMS_PER_THREAD, typename FlagT, typename FlagOp>
+      static __device__ __forceinline__ void
+      FlagTails(int /*linear_tid*/,
+                FlagT (&/*flags*/)[ITEMS_PER_THREAD],
+                T (&/*input*/)[ITEMS_PER_THREAD],
+                FlagOp /*flag_op*/)
+      {}
     };
 
 
-    /******************************************************************************
+    /***************************************************************************
      * Thread fields
-     ******************************************************************************/
+     **************************************************************************/
 
     /// Shared storage reference
     _TempStorage &temp_storage;
@@ -200,50 +294,685 @@ public:
     struct TempStorage : Uninitialized<_TempStorage> {};
 
 
-    /******************************************************************//**
-     * \name Collective constructors
-     *********************************************************************/
+    /***********************************************************************//**
+     * @name Collective constructors
+     **************************************************************************/
     //@{
 
     /**
-     * \brief Collective constructor using a private static allocation of shared memory as temporary storage.
+     * @brief Collective constructor using a private static allocation of shared
+     *        memory as temporary storage.
      */
     __device__ __forceinline__ BlockAdjacentDifference()
-    :
-        temp_storage(PrivateStorage()),
-        linear_tid(RowMajorTid(BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z))
+        : temp_storage(PrivateStorage())
+        , linear_tid(RowMajorTid(BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z))
     {}
-
 
     /**
-     * \brief Collective constructor using the specified memory allocation as temporary storage.
+     * @brief Collective constructor using the specified memory allocation as
+     *        temporary storage.
+     *
+     * @param[in] temp_storage Reference to memory allocation having layout type TempStorage
      */
-    __device__ __forceinline__ BlockAdjacentDifference(
-        TempStorage &temp_storage)  ///< [in] Reference to memory allocation having layout type TempStorage
-    :
-        temp_storage(temp_storage.Alias()),
-        linear_tid(RowMajorTid(BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z))
+    __device__ __forceinline__ BlockAdjacentDifference(TempStorage &temp_storage)
+        : temp_storage(temp_storage.Alias())
+        , linear_tid(RowMajorTid(BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z))
     {}
 
+    //@}  end member group
+    /***********************************************************************//**
+     * @name Read left operations
+     **************************************************************************/
+    //@{
+
+    /**
+     * @brief Subtracts the left element of each adjacent pair of elements
+     *        partitioned across a CUDA thread block.
+     *
+     * @par
+     * - \rowmajor
+     * - \smemreuse
+     *
+     * @par Snippet
+     * The code snippet below illustrates how to use @p BlockAdjacentDifference
+     * to compute the left difference between adjacent elements.
+     *
+     * @par
+     * @code
+     * #include <cub/cub.cuh>
+     * // or equivalently <cub/block/block_adjacent_difference.cuh>
+     *
+     * struct CustomDifference
+     * {
+     *   template <typename DataType>
+     *   __device__ DataType operator()(DataType &lhs, DataType &rhs)
+     *   {
+     *     return lhs - rhs;
+     *   }
+     * };
+     *
+     * __global__ void ExampleKernel(...)
+     * {
+     *     // Specialize BlockAdjacentDifference for a 1D block
+     *     // of 128 threads of type int
+     *     using BlockAdjacentDifferenceT =
+     *        cub::BlockAdjacentDifference<int, 128>;
+     *
+     *     // Allocate shared memory for BlockDiscontinuity
+     *     __shared__ typename BlockAdjacentDifferenceT::TempStorage temp_storage;
+     *
+     *     // Obtain a segment of consecutive items that are blocked across threads
+     *     int thread_data[4];
+     *     ...
+     *
+     *     // Collectively compute adjacent_difference
+     *     BlockAdjacentDifferenceT(temp_storage).SubtractLeft(
+     *         thread_data,
+     *         thread_data,
+     *         CustomDifference());
+     *
+     * @endcode
+     * @par
+     * Suppose the set of input `thread_data` across the block of threads is
+     * `{ [4,2,1,1], [1,1,1,1], [2,3,3,3], [3,4,1,4], ... }`.
+     * The corresponding output `result` in those threads will be
+     * `{ [4,-2,-1,0], [0,0,0,0], [1,1,0,0], [0,1,-3,3], ... }`.
+     *
+     * @param[out] output
+     *   Calling thread's adjacent difference result
+     *
+     * @param[in] input
+     *   Calling thread's input items (may be aliased to @p output)
+     *
+     * @param[in] difference_op
+     *   Binary difference operator
+     */
+    template <int ITEMS_PER_THREAD,
+              typename OutputType,
+              typename DifferenceOpT>
+    __device__ __forceinline__ void
+    SubtractLeft(T (&input)[ITEMS_PER_THREAD],
+                 OutputType (&output)[ITEMS_PER_THREAD],
+                 DifferenceOpT difference_op)
+    {
+      // Share last item
+      temp_storage.last_items[linear_tid] = input[ITEMS_PER_THREAD - 1];
+
+      CTA_SYNC();
+
+      #pragma unroll
+      for (int item = ITEMS_PER_THREAD - 1; item > 0; item--)
+      {
+        output[item] = difference_op(input[item], input[item - 1]);
+      }
+
+      if (linear_tid == 0)
+      {
+        output[0] = input[0];
+      }
+      else
+      {
+        output[0] = difference_op(input[0],
+                                  temp_storage.last_items[linear_tid - 1]);
+      }
+    }
+
+    /**
+     * @brief Subtracts the left element of each adjacent pair of elements
+     *        partitioned across a CUDA thread block.
+     *
+     * @par
+     * - \rowmajor
+     * - \smemreuse
+     *
+     * @par Snippet
+     * The code snippet below illustrates how to use @p BlockAdjacentDifference
+     * to compute the left difference between adjacent elements.
+     *
+     * @par
+     * @code
+     * #include <cub/cub.cuh>
+     * // or equivalently <cub/block/block_adjacent_difference.cuh>
+     *
+     * struct CustomDifference
+     * {
+     *   template <typename DataType>
+     *   __device__ DataType operator()(DataType &lhs, DataType &rhs)
+     *   {
+     *     return lhs - rhs;
+     *   }
+     * };
+     *
+     * __global__ void ExampleKernel(...)
+     * {
+     *     // Specialize BlockAdjacentDifference for a 1D block of
+     *     // 128 threads of type int
+     *     using BlockAdjacentDifferenceT =
+     *        cub::BlockAdjacentDifference<int, 128>;
+     *
+     *     // Allocate shared memory for BlockDiscontinuity
+     *     __shared__ typename BlockAdjacentDifferenceT::TempStorage temp_storage;
+     *
+     *     // Obtain a segment of consecutive items that are blocked across threads
+     *     int thread_data[4];
+     *     ...
+     *
+     *     // The last item in the previous tile:
+     *     int tile_predecessor_item = ...;
+     *
+     *     // Collectively compute adjacent_difference
+     *     BlockAdjacentDifferenceT(temp_storage).SubtractLeft(
+     *         thread_data,
+     *         thread_data,
+     *         CustomDifference(),
+     *         tile_predecessor_item);
+     *
+     * @endcode
+     * @par
+     * Suppose the set of input `thread_data` across the block of threads is
+     * `{ [4,2,1,1], [1,1,1,1], [2,3,3,3], [3,4,1,4], ... }`.
+     * and that `tile_predecessor_item` is `3`. The corresponding output
+     * `result` in those threads will be
+     * `{ [1,-2,-1,0], [0,0,0,0], [1,1,0,0], [0,1,-3,3], ... }`.
+     *
+     * @param[out] output
+     *   Calling thread's adjacent difference result
+     *
+     * @param[in] input
+     *   Calling thread's input items (may be aliased to \p output)
+     *
+     * @param[in] difference_op
+     *   Binary difference operator
+     *
+     * @param[in] tile_predecessor_item
+     *   <b>[<em>thread</em><sub>0</sub> only]</b> item which is going to be
+     *   subtracted from the first tile item (<tt>input<sub>0</sub></tt> from
+     *   <em>thread</em><sub>0</sub>).
+     */
+    template <int ITEMS_PER_THREAD,
+              typename OutputT,
+              typename DifferenceOpT>
+    __device__ __forceinline__ void
+    SubtractLeft(T (&input)[ITEMS_PER_THREAD],
+                 OutputT (&output)[ITEMS_PER_THREAD],
+                 DifferenceOpT difference_op,
+                 T tile_predecessor_item)
+    {
+      // Share last item
+      temp_storage.last_items[linear_tid] = input[ITEMS_PER_THREAD - 1];
+
+      CTA_SYNC();
+
+      #pragma unroll
+      for (int item = ITEMS_PER_THREAD - 1; item > 0; item--)
+      {
+        output[item] = difference_op(input[item], input[item - 1]);
+      }
+
+      // Set flag for first thread-item
+      if (linear_tid == 0)
+      {
+        output[0] = difference_op(input[0], tile_predecessor_item);
+      }
+      else
+      {
+        output[0] = difference_op(input[0],
+                                  temp_storage.last_items[linear_tid - 1]);
+      }
+    }
+
+    /**
+     * @brief Subtracts the left element of each adjacent pair of elements partitioned across a CUDA thread block.
+     *
+     * @par
+     * - \rowmajor
+     * - \smemreuse
+     *
+     * @par Snippet
+     * The code snippet below illustrates how to use @p BlockAdjacentDifference to
+     * compute the left difference between adjacent elements.
+     *
+     * @par
+     * @code
+     * #include <cub/cub.cuh>
+     * // or equivalently <cub/block/block_adjacent_difference.cuh>
+     *
+     * struct CustomDifference
+     * {
+     *   template <typename DataType>
+     *   __device__ DataType operator()(DataType &lhs, DataType &rhs)
+     *   {
+     *     return lhs - rhs;
+     *   }
+     * };
+     *
+     * __global__ void ExampleKernel(...)
+     * {
+     *     // Specialize BlockAdjacentDifference for a 1D block of 
+     *     // 128 threads of type int
+     *     using BlockAdjacentDifferenceT =
+     *        cub::BlockAdjacentDifference<int, 128>;
+     *
+     *     // Allocate shared memory for BlockDiscontinuity
+     *     __shared__ typename BlockAdjacentDifferenceT::TempStorage temp_storage;
+     *
+     *     // Obtain a segment of consecutive items that are blocked across threads
+     *     int thread_data[4];
+     *     ...
+     *
+     *     // Collectively compute adjacent_difference
+     *     BlockAdjacentDifferenceT(temp_storage).SubtractLeft(
+     *         thread_data,
+     *         thread_data,
+     *         CustomDifference());
+     *
+     * @endcode
+     * @par
+     * Suppose the set of input `thread_data` across the block of threads is
+     * `{ [4,2,1,1], [1,1,1,1], [2,3,3,3], [3,4,1,4], ... }`.
+     * The corresponding output `result` in those threads will be
+     * `{ [4,-2,-1,0], [0,0,0,0], [1,1,0,0], [0,1,-3,3], ... }`.
+     *
+     * @param[out] output
+     *   Calling thread's adjacent difference result
+     *
+     * @param[in] input
+     *   Calling thread's input items (may be aliased to \p output)
+     *
+     * @param[in] difference_op
+     *   Binary difference operator
+     *
+     * @param[in]
+     *   Number of valid items in thread block
+     */
+    template <int ITEMS_PER_THREAD,
+              typename OutputType,
+              typename DifferenceOpT>
+    __device__ __forceinline__ void
+    SubtractLeftPartialTile(T (&input)[ITEMS_PER_THREAD],
+                            OutputType (&output)[ITEMS_PER_THREAD],
+                            DifferenceOpT difference_op,
+                            int valid_items)
+    {
+      // Share last item
+      temp_storage.last_items[linear_tid] = input[ITEMS_PER_THREAD - 1];
+
+      CTA_SYNC();
+
+      if ((linear_tid + 1) * ITEMS_PER_THREAD <= valid_items)
+      {
+        #pragma unroll
+        for (int item = ITEMS_PER_THREAD - 1; item > 0; item--)
+        {
+          output[item] = difference_op(input[item], input[item - 1]);
+        }
+      }
+      else
+      {
+        #pragma unroll
+        for (int item = ITEMS_PER_THREAD - 1; item > 0; item--)
+        {
+          const int idx = linear_tid * ITEMS_PER_THREAD + item;
+
+          if (idx < valid_items)
+          {
+            output[item] = difference_op(input[item], input[item - 1]);
+          }
+          else
+          {
+            output[item] = input[item];
+          }
+        }
+      }
+
+      if (linear_tid == 0 || valid_items <= linear_tid * ITEMS_PER_THREAD)
+      {
+        output[0] = input[0];
+      }
+      else
+      {
+        output[0] = difference_op(input[0],
+                                  temp_storage.last_items[linear_tid - 1]);
+      }
+    }
 
     //@}  end member group
     /******************************************************************//**
-     * \name Head flag operations
+     * @name Read right operations
      *********************************************************************/
     //@{
 
+    /**
+     * @brief Subtracts the right element of each adjacent pair of elements
+     *        partitioned across a CUDA thread block.
+     *
+     * @par
+     * - \rowmajor
+     * - \smemreuse
+     *
+     * @par Snippet
+     * The code snippet below illustrates how to use @p BlockAdjacentDifference
+     * to compute the right difference between adjacent elements.
+     *
+     * @par
+     * @code
+     * #include <cub/cub.cuh>
+     * // or equivalently <cub/block/block_adjacent_difference.cuh>
+     *
+     * struct CustomDifference
+     * {
+     *   template <typename DataType>
+     *   __device__ DataType operator()(DataType &lhs, DataType &rhs)
+     *   {
+     *     return lhs - rhs;
+     *   }
+     * };
+     *
+     * __global__ void ExampleKernel(...)
+     * {
+     *     // Specialize BlockAdjacentDifference for a 1D block of
+     *     // 128 threads of type int
+     *     using BlockAdjacentDifferenceT =
+     *        cub::BlockAdjacentDifference<int, 128>;
+     *
+     *     // Allocate shared memory for BlockDiscontinuity
+     *     __shared__ typename BlockAdjacentDifferenceT::TempStorage temp_storage;
+     *
+     *     // Obtain a segment of consecutive items that are blocked across threads
+     *     int thread_data[4];
+     *     ...
+     *
+     *     // Collectively compute adjacent_difference
+     *     BlockAdjacentDifferenceT(temp_storage).SubtractRight(
+     *         thread_data,
+     *         thread_data,
+     *         CustomDifference());
+     *
+     * @endcode
+     * @par
+     * Suppose the set of input `thread_data` across the block of threads is
+     * `{ ...3], [4,2,1,1], [1,1,1,1], [2,3,3,3], [3,4,1,4] }`.
+     * The corresponding output `result` in those threads will be
+     * `{ ..., [-1,2,1,0], [0,0,0,-1], [-1,0,0,0], [-1,3,-3,4] }`.
+     *
+     * @param[out] output
+     *   Calling thread's adjacent difference result
+     *
+     * @param[in] input
+     *   Calling thread's input items (may be aliased to \p output)
+     *
+     * @param[in] difference_op
+     *   Binary difference operator
+     */
+    template <int ITEMS_PER_THREAD,
+              typename OutputT,
+              typename DifferenceOpT>
+    __device__ __forceinline__ void
+    SubtractRight(T (&input)[ITEMS_PER_THREAD],
+                  OutputT (&output)[ITEMS_PER_THREAD],
+                  DifferenceOpT difference_op)
+    {
+      // Share first item
+      temp_storage.first_items[linear_tid] = input[0];
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
+      CTA_SYNC();
 
+      #pragma unroll
+      for (int item = 0; item < ITEMS_PER_THREAD - 1; item++)
+      {
+        output[item] = difference_op(input[item], input[item + 1]);
+      }
+
+      if (linear_tid == BLOCK_THREADS - 1)
+      {
+        output[ITEMS_PER_THREAD - 1] = input[ITEMS_PER_THREAD - 1];
+      }
+      else
+      {
+        output[ITEMS_PER_THREAD - 1] =
+          difference_op(input[ITEMS_PER_THREAD - 1],
+                        temp_storage.first_items[linear_tid + 1]);
+      }
+    }
+
+    /**
+     * @brief Subtracts the right element of each adjacent pair of elements
+     *        partitioned across a CUDA thread block.
+     *
+     * @par
+     * - \rowmajor
+     * - \smemreuse
+     *
+     * @par Snippet
+     * The code snippet below illustrates how to use @p BlockAdjacentDifference
+     * to compute the right difference between adjacent elements.
+     *
+     * @par
+     * @code
+     * #include <cub/cub.cuh>
+     * // or equivalently <cub/block/block_adjacent_difference.cuh>
+     *
+     * struct CustomDifference
+     * {
+     *   template <typename DataType>
+     *   __device__ DataType operator()(DataType &lhs, DataType &rhs)
+     *   {
+     *     return lhs - rhs;
+     *   }
+     * };
+     *
+     * __global__ void ExampleKernel(...)
+     * {
+     *     // Specialize BlockAdjacentDifference for a 1D block of
+     *     // 128 threads of type int
+     *     using BlockAdjacentDifferenceT =
+     *        cub::BlockAdjacentDifference<int, 128>;
+     *
+     *     // Allocate shared memory for BlockDiscontinuity
+     *     __shared__ typename BlockAdjacentDifferenceT::TempStorage temp_storage;
+     *
+     *     // Obtain a segment of consecutive items that are blocked across threads
+     *     int thread_data[4];
+     *     ...
+     *
+     *     // The first item in the nest tile:
+     *     int tile_successor_item = ...;
+     *
+     *     // Collectively compute adjacent_difference
+     *     BlockAdjacentDifferenceT(temp_storage).SubtractRight(
+     *         thread_data,
+     *         thread_data,
+     *         CustomDifference(),
+     *         tile_successor_item);
+     *
+     * @endcode
+     * @par
+     * Suppose the set of input `thread_data` across the block of threads is
+     * `{ ...3], [4,2,1,1], [1,1,1,1], [2,3,3,3], [3,4,1,4] }`,
+     * and that `tile_successor_item` is `3`. The corresponding output `result`
+     * in those threads will be
+     * `{ ..., [-1,2,1,0], [0,0,0,-1], [-1,0,0,0], [-1,3,-3,1] }`.
+     *
+     * @param[out] output
+     *   Calling thread's adjacent difference result
+     *
+     * @param[in] input
+     *   Calling thread's input items (may be aliased to @p output)
+     *
+     * @param[in] difference_op
+     *   Binary difference operator
+     *
+     * @param[in] tile_successor_item
+     *   <b>[<em>thread</em><sub><tt>BLOCK_THREADS</tt>-1</sub> only]</b> item
+     *   which is going to be subtracted from the last tile item
+     *   (<tt>input</tt><sub><em>ITEMS_PER_THREAD</em>-1</sub> from
+     *   <em>thread</em><sub><em>BLOCK_THREADS</em>-1</sub>).
+     */
+    template <int ITEMS_PER_THREAD,
+              typename OutputT,
+              typename DifferenceOpT>
+    __device__ __forceinline__ void
+    SubtractRight(T (&input)[ITEMS_PER_THREAD],
+                  OutputT (&output)[ITEMS_PER_THREAD],
+                  DifferenceOpT difference_op,
+                  T tile_successor_item)
+    {
+      // Share first item
+      temp_storage.first_items[linear_tid] = input[0];
+
+      CTA_SYNC();
+
+      // Set flag for last thread-item
+      T successor_item = (linear_tid == BLOCK_THREADS - 1)
+                           ? tile_successor_item // Last thread
+                           : temp_storage.first_items[linear_tid + 1];
+
+      #pragma unroll
+      for (int item = 0; item < ITEMS_PER_THREAD - 1; item++)
+      {
+        output[item] = difference_op(input[item], input[item + 1]);
+      }
+
+      output[ITEMS_PER_THREAD - 1] =
+        difference_op(input[ITEMS_PER_THREAD - 1], successor_item);
+    }
+
+    /**
+     * @brief Subtracts the right element of each adjacent pair in range of
+     *        elements partitioned across a CUDA thread block.
+     *
+     * @par
+     * - \rowmajor
+     * - \smemreuse
+     *
+     * @par Snippet
+     * The code snippet below illustrates how to use @p BlockAdjacentDifference to
+     * compute the right difference between adjacent elements.
+     *
+     * @par
+     * @code
+     * #include <cub/cub.cuh>
+     * // or equivalently <cub/block/block_adjacent_difference.cuh>
+     *
+     * struct CustomDifference
+     * {
+     *   template <typename DataType>
+     *   __device__ DataType operator()(DataType &lhs, DataType &rhs)
+     *   {
+     *     return lhs - rhs;
+     *   }
+     * };
+     *
+     * __global__ void ExampleKernel(...)
+     * {
+     *     // Specialize BlockAdjacentDifference for a 1D block of
+     *     // 128 threads of type int
+     *     using BlockAdjacentDifferenceT =
+     *        cub::BlockAdjacentDifference<int, 128>;
+     *
+     *     // Allocate shared memory for BlockDiscontinuity
+     *     __shared__ typename BlockAdjacentDifferenceT::TempStorage temp_storage;
+     *
+     *     // Obtain a segment of consecutive items that are blocked across threads
+     *     int thread_data[4];
+     *     ...
+     *
+     *     // Collectively compute adjacent_difference
+     *     BlockAdjacentDifferenceT(temp_storage).SubtractRightPartialTile(
+     *         thread_data,
+     *         thread_data,
+     *         CustomDifference(),
+     *         valid_items);
+     *
+     * @endcode
+     * @par
+     * Suppose the set of input `thread_data` across the block of threads is
+     * `{ ...3], [4,2,1,1], [1,1,1,1], [2,3,3,3], [3,4,1,4] }`.
+     * and that `valid_items` is `507`. The corresponding output `result` in
+     * those threads will be
+     * `{ ..., [-1,2,1,0], [0,0,0,-1], [-1,0,3,3], [3,4,1,4] }`.
+     *
+     * @param[out] output
+     *   Calling thread's adjacent difference result
+     *
+     * @param[in] input
+     *   Calling thread's input items (may be aliased to @p output)
+     *
+     * @param[in] difference_op
+     *   Binary difference operator
+     *
+     * @param[in] valid_items
+     *   Number of valid items in thread block
+     */
+    template <int ITEMS_PER_THREAD,
+              typename OutputT,
+              typename DifferenceOpT>
+    __device__ __forceinline__ void
+    SubtractRightPartialTile(T (&input)[ITEMS_PER_THREAD],
+                             OutputT (&output)[ITEMS_PER_THREAD],
+                             DifferenceOpT difference_op,
+                             int valid_items)
+    {
+      // Share first item
+      temp_storage.first_items[linear_tid] = input[0];
+
+      CTA_SYNC();
+
+      if ((linear_tid + 1) * ITEMS_PER_THREAD < valid_items)
+      {
+        #pragma unroll
+        for (int item = 0; item < ITEMS_PER_THREAD - 1; item++)
+        {
+           output[item] = difference_op(input[item], input[item + 1]);
+        }
+
+        output[ITEMS_PER_THREAD - 1] =
+          difference_op(input[ITEMS_PER_THREAD - 1],
+                        temp_storage.first_items[linear_tid + 1]);
+      }
+      else
+      {
+        #pragma unroll
+        for (int item = 0; item < ITEMS_PER_THREAD; item++)
+        {
+          const int idx = linear_tid * ITEMS_PER_THREAD + item;
+
+          // Right element of input[valid_items - 1] is out of bounds.
+          // According to the API it's copied into output array
+          // without modification.
+          if (idx < valid_items - 1)
+          {
+            output[item] = difference_op(input[item], input[item + 1]);
+          }
+          else
+          {
+            output[item] = input[item];
+          }
+        }
+      }
+    }
+
+    //@}  end member group
+    /******************************************************************//**
+     * @name Head flag operations (deprecated)
+     *********************************************************************/
+    //@{
+
+    #ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
+
+    /**
+     * \deprecated [Since 1.14.0] The cub::BlockAdjacentDifference::FlagHeads
+     * APIs are deprecated. Use cub::BlockAdjacentDifference::SubtractLeft instead.
+     */
     template <
         int             ITEMS_PER_THREAD,
         typename        FlagT,
         typename        FlagOp>
-    __device__ __forceinline__ void FlagHeads(
-        FlagT           (&head_flags)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity head_flags
-        T               (&input)[ITEMS_PER_THREAD],         ///< [in] Calling thread's input items
-        T               (&preds)[ITEMS_PER_THREAD],         ///< [out] Calling thread's predecessor items
-        FlagOp          flag_op)                            ///< [in] Binary boolean flag predicate
+    CUB_DEPRECATED __device__ __forceinline__ void FlagHeads(
+        FlagT           (&output)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity head_flags
+        T               (&input)[ITEMS_PER_THREAD],     ///< [in] Calling thread's input items
+        T               (&preds)[ITEMS_PER_THREAD],     ///< [out] Calling thread's predecessor items
+        FlagOp          flag_op)                        ///< [in] Binary boolean flag predicate
     {
         // Share last item
         temp_storage.last_items[linear_tid] = input[ITEMS_PER_THREAD - 1];
@@ -253,28 +982,31 @@ public:
         if (linear_tid == 0)
         {
             // Set flag for first thread-item (preds[0] is undefined)
-            head_flags[0] = 1;
+            output[0] = 1;
         }
         else
         {
             preds[0] = temp_storage.last_items[linear_tid - 1];
-            head_flags[0] = ApplyOp<FlagOp>::FlagT(flag_op, preds[0], input[0], linear_tid * ITEMS_PER_THREAD);
+            output[0] = ApplyOp<FlagOp>::FlagT(flag_op, preds[0], input[0], linear_tid * ITEMS_PER_THREAD);
         }
 
-        // Set head_flags for remaining items
-        Iterate<1, ITEMS_PER_THREAD>::FlagHeads(linear_tid, head_flags, input, preds, flag_op);
+        // Set output for remaining items
+        Iterate<1, ITEMS_PER_THREAD>::FlagHeads(linear_tid, output, input, preds, flag_op);
     }
 
-    template <
-        int             ITEMS_PER_THREAD,
-        typename        FlagT,
-        typename        FlagOp>
-    __device__ __forceinline__ void FlagHeads(
-        FlagT           (&head_flags)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity head_flags
-        T               (&input)[ITEMS_PER_THREAD],         ///< [in] Calling thread's input items
-        T               (&preds)[ITEMS_PER_THREAD],         ///< [out] Calling thread's predecessor items
-        FlagOp          flag_op,                            ///< [in] Binary boolean flag predicate
-        T               tile_predecessor_item)              ///< [in] <b>[<em>thread</em><sub>0</sub> only]</b> Item with which to compare the first tile item (<tt>input<sub>0</sub></tt> from <em>thread</em><sub>0</sub>).
+    /**
+     * \deprecated [Since 1.14.0] The cub::BlockAdjacentDifference::FlagHeads
+     * APIs are deprecated. Use cub::BlockAdjacentDifference::SubtractLeft instead.
+     */
+    template <int             ITEMS_PER_THREAD,
+              typename        FlagT,
+              typename        FlagOp>
+    CUB_DEPRECATED __device__ __forceinline__ void FlagHeads(
+        FlagT           (&output)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity result
+        T               (&input)[ITEMS_PER_THREAD],     ///< [in] Calling thread's input items
+        T               (&preds)[ITEMS_PER_THREAD],     ///< [out] Calling thread's predecessor items
+        FlagOp          flag_op,                        ///< [in] Binary boolean flag predicate
+        T               tile_predecessor_item)          ///< [in] <b>[<em>thread</em><sub>0</sub> only]</b> Item with which to compare the first tile item (<tt>input<sub>0</sub></tt> from <em>thread</em><sub>0</sub>).
     {
         // Share last item
         temp_storage.last_items[linear_tid] = input[ITEMS_PER_THREAD - 1];
@@ -286,53 +1018,60 @@ public:
             tile_predecessor_item :              // First thread
             temp_storage.last_items[linear_tid - 1];
 
-        head_flags[0] = ApplyOp<FlagOp>::FlagT(flag_op, preds[0], input[0], linear_tid * ITEMS_PER_THREAD);
+        output[0] = ApplyOp<FlagOp>::FlagT(flag_op, preds[0], input[0], linear_tid * ITEMS_PER_THREAD);
 
-        // Set head_flags for remaining items
-        Iterate<1, ITEMS_PER_THREAD>::FlagHeads(linear_tid, head_flags, input, preds, flag_op);
+        // Set output for remaining items
+        Iterate<1, ITEMS_PER_THREAD>::FlagHeads(linear_tid, output, input, preds, flag_op);
     }
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
-
-    template <
-        int             ITEMS_PER_THREAD,
-        typename        FlagT,
-        typename        FlagOp>
-    __device__ __forceinline__ void FlagHeads(
-        FlagT           (&head_flags)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity head_flags
-        T               (&input)[ITEMS_PER_THREAD],         ///< [in] Calling thread's input items
-        FlagOp          flag_op)                            ///< [in] Binary boolean flag predicate
+    /**
+     * \deprecated [Since 1.14.0] The cub::BlockAdjacentDifference::FlagHeads
+     * APIs are deprecated. Use cub::BlockAdjacentDifference::SubtractLeft instead.
+     */
+    template <int ITEMS_PER_THREAD,
+              typename FlagT,
+              typename FlagOp>
+    CUB_DEPRECATED __device__ __forceinline__ void
+    FlagHeads(FlagT           (&output)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity result
+              T               (&input)[ITEMS_PER_THREAD],     ///< [in] Calling thread's input items
+              FlagOp          flag_op)                        ///< [in] Binary boolean flag predicate
     {
         T preds[ITEMS_PER_THREAD];
-        FlagHeads(head_flags, input, preds, flag_op);
+        FlagHeads(output, input, preds, flag_op);
+    }
+
+    /**
+     * \deprecated [Since 1.14.0] The cub::BlockAdjacentDifference::FlagHeads
+     * APIs are deprecated. Use cub::BlockAdjacentDifference::SubtractLeft instead.
+     */
+    template <int ITEMS_PER_THREAD,
+              typename FlagT,
+              typename FlagOp>
+    CUB_DEPRECATED __device__ __forceinline__ void
+    FlagHeads(FlagT           (&output)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity result
+              T               (&input)[ITEMS_PER_THREAD],     ///< [in] Calling thread's input items
+              FlagOp          flag_op,                        ///< [in] Binary boolean flag predicate
+              T               tile_predecessor_item)          ///< [in] <b>[<em>thread</em><sub>0</sub> only]</b> Item with which to compare the first tile item (<tt>input<sub>0</sub></tt> from <em>thread</em><sub>0</sub>).
+    {
+        T preds[ITEMS_PER_THREAD];
+        FlagHeads(output, input, preds, flag_op, tile_predecessor_item);
     }
 
 
+    /**
+     * \deprecated [Since 1.14.0] The cub::BlockAdjacentDifference::FlagTails
+     * APIs are deprecated. Use cub::BlockAdjacentDifference::SubtractRight instead.
+     */
     template <
-        int             ITEMS_PER_THREAD,
-        typename        FlagT,
-        typename        FlagOp>
-    __device__ __forceinline__ void FlagHeads(
-        FlagT           (&head_flags)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity head_flags
-        T               (&input)[ITEMS_PER_THREAD],         ///< [in] Calling thread's input items
-        FlagOp          flag_op,                            ///< [in] Binary boolean flag predicate
-        T               tile_predecessor_item)              ///< [in] <b>[<em>thread</em><sub>0</sub> only]</b> Item with which to compare the first tile item (<tt>input<sub>0</sub></tt> from <em>thread</em><sub>0</sub>).
-    {
-        T preds[ITEMS_PER_THREAD];
-        FlagHeads(head_flags, input, preds, flag_op, tile_predecessor_item);
-    }
-
-
-
-    template <
-        int             ITEMS_PER_THREAD,
-        typename        FlagT,
-        typename        FlagOp>
-    __device__ __forceinline__ void FlagTails(
-        FlagT           (&tail_flags)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity tail_flags
-        T               (&input)[ITEMS_PER_THREAD],         ///< [in] Calling thread's input items
-        FlagOp          flag_op)                            ///< [in] Binary boolean flag predicate
+      int             ITEMS_PER_THREAD,
+      typename        FlagT,
+      typename        FlagOp>
+    CUB_DEPRECATED __device__ __forceinline__ void FlagTails(
+        FlagT           (&output)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity result
+        T               (&input)[ITEMS_PER_THREAD],     ///< [in] Calling thread's input items
+        FlagOp          flag_op)                        ///< [in] Binary boolean flag predicate
     {
         // Share first item
         temp_storage.first_items[linear_tid] = input[0];
@@ -340,7 +1079,7 @@ public:
         CTA_SYNC();
 
         // Set flag for last thread-item
-        tail_flags[ITEMS_PER_THREAD - 1] = (linear_tid == BLOCK_THREADS - 1) ?
+        output[ITEMS_PER_THREAD - 1] = (linear_tid == BLOCK_THREADS - 1) ?
             1 :                             // Last thread
             ApplyOp<FlagOp>::FlagT(
                 flag_op,
@@ -348,20 +1087,24 @@ public:
                 temp_storage.first_items[linear_tid + 1],
                 (linear_tid * ITEMS_PER_THREAD) + ITEMS_PER_THREAD);
 
-        // Set tail_flags for remaining items
-        Iterate<0, ITEMS_PER_THREAD - 1>::FlagTails(linear_tid, tail_flags, input, flag_op);
+        // Set output for remaining items
+        Iterate<0, ITEMS_PER_THREAD - 1>::FlagTails(linear_tid, output, input, flag_op);
     }
 
 
+    /**
+     * \deprecated [Since 1.14.0] The cub::BlockAdjacentDifference::FlagTails
+     * APIs are deprecated. Use cub::BlockAdjacentDifference::SubtractRight instead.
+     */
     template <
-        int             ITEMS_PER_THREAD,
-        typename        FlagT,
-        typename        FlagOp>
-    __device__ __forceinline__ void FlagTails(
-        FlagT           (&tail_flags)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity tail_flags
-        T               (&input)[ITEMS_PER_THREAD],         ///< [in] Calling thread's input items
-        FlagOp          flag_op,                            ///< [in] Binary boolean flag predicate
-        T               tile_successor_item)                ///< [in] <b>[<em>thread</em><sub><tt>BLOCK_THREADS</tt>-1</sub> only]</b> Item with which to compare the last tile item (<tt>input</tt><sub><em>ITEMS_PER_THREAD</em>-1</sub> from <em>thread</em><sub><em>BLOCK_THREADS</em>-1</sub>).
+      int             ITEMS_PER_THREAD,
+      typename        FlagT,
+      typename        FlagOp>
+    CUB_DEPRECATED __device__ __forceinline__ void FlagTails(
+        FlagT           (&output)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity result
+        T               (&input)[ITEMS_PER_THREAD],     ///< [in] Calling thread's input items
+        FlagOp          flag_op,                        ///< [in] Binary boolean flag predicate
+        T               tile_successor_item)            ///< [in] <b>[<em>thread</em><sub><tt>BLOCK_THREADS</tt>-1</sub> only]</b> Item with which to compare the last tile item (<tt>input</tt><sub><em>ITEMS_PER_THREAD</em>-1</sub> from <em>thread</em><sub><em>BLOCK_THREADS</em>-1</sub>).
     {
         // Share first item
         temp_storage.first_items[linear_tid] = input[0];
@@ -373,22 +1116,27 @@ public:
             tile_successor_item :              // Last thread
             temp_storage.first_items[linear_tid + 1];
 
-        tail_flags[ITEMS_PER_THREAD - 1] = ApplyOp<FlagOp>::FlagT(
+        output[ITEMS_PER_THREAD - 1] = ApplyOp<FlagOp>::FlagT(
             flag_op,
             input[ITEMS_PER_THREAD - 1],
             successor_item,
             (linear_tid * ITEMS_PER_THREAD) + ITEMS_PER_THREAD);
 
-        // Set tail_flags for remaining items
-        Iterate<0, ITEMS_PER_THREAD - 1>::FlagTails(linear_tid, tail_flags, input, flag_op);
+        // Set output for remaining items
+        Iterate<0, ITEMS_PER_THREAD - 1>::FlagTails(linear_tid, output, input, flag_op);
     }
 
 
+    /**
+     * \deprecated [Since 1.14.0] The cub::BlockAdjacentDifference::FlagHeadsAndTails
+     * APIs are deprecated. Use cub::BlockAdjacentDifference::SubtractLeft or
+     * cub::BlockAdjacentDifference::SubtractRight instead.
+     */
     template <
-        int             ITEMS_PER_THREAD,
-        typename        FlagT,
-        typename        FlagOp>
-    __device__ __forceinline__ void FlagHeadsAndTails(
+      int             ITEMS_PER_THREAD,
+      typename        FlagT,
+      typename        FlagOp>
+    CUB_DEPRECATED __device__ __forceinline__ void FlagHeadsAndTails(
         FlagT           (&head_flags)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity head_flags
         FlagT           (&tail_flags)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity tail_flags
         T               (&input)[ITEMS_PER_THREAD],         ///< [in] Calling thread's input items
@@ -435,11 +1183,16 @@ public:
     }
 
 
+    /**
+     * \deprecated [Since 1.14.0] The cub::BlockAdjacentDifference::FlagHeadsAndTails
+     * APIs are deprecated. Use cub::BlockAdjacentDifference::SubtractLeft or
+     * cub::BlockAdjacentDifference::SubtractRight instead.
+     */
     template <
-        int             ITEMS_PER_THREAD,
-        typename        FlagT,
-        typename        FlagOp>
-    __device__ __forceinline__ void FlagHeadsAndTails(
+      int             ITEMS_PER_THREAD,
+      typename        FlagT,
+      typename        FlagOp>
+    CUB_DEPRECATED __device__ __forceinline__ void FlagHeadsAndTails(
         FlagT           (&head_flags)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity head_flags
         FlagT           (&tail_flags)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity tail_flags
         T               tile_successor_item,                ///< [in] <b>[<em>thread</em><sub><tt>BLOCK_THREADS</tt>-1</sub> only]</b> Item with which to compare the last tile item (<tt>input</tt><sub><em>ITEMS_PER_THREAD</em>-1</sub> from <em>thread</em><sub><em>BLOCK_THREADS</em>-1</sub>).
@@ -487,11 +1240,16 @@ public:
         Iterate<0, ITEMS_PER_THREAD - 1>::FlagTails(linear_tid, tail_flags, input, flag_op);
     }
 
+    /**
+     * \deprecated [Since 1.14.0] The cub::BlockAdjacentDifference::FlagHeadsAndTails
+     * APIs are deprecated. Use cub::BlockAdjacentDifference::SubtractLeft or
+     * cub::BlockAdjacentDifference::SubtractRight instead.
+     */
     template <
-        int             ITEMS_PER_THREAD,
-        typename        FlagT,
-        typename        FlagOp>
-    __device__ __forceinline__ void FlagHeadsAndTails(
+      int             ITEMS_PER_THREAD,
+      typename        FlagT,
+      typename        FlagOp>
+    CUB_DEPRECATED __device__ __forceinline__ void FlagHeadsAndTails(
         FlagT           (&head_flags)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity head_flags
         T               tile_predecessor_item,              ///< [in] <b>[<em>thread</em><sub>0</sub> only]</b> Item with which to compare the first tile item (<tt>input<sub>0</sub></tt> from <em>thread</em><sub>0</sub>).
         FlagT           (&tail_flags)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity tail_flags
@@ -534,11 +1292,16 @@ public:
     }
 
 
+    /**
+     * \deprecated [Since 1.14.0] The cub::BlockAdjacentDifference::FlagHeadsAndTails
+     * APIs are deprecated. Use cub::BlockAdjacentDifference::SubtractLeft or
+     * cub::BlockAdjacentDifference::SubtractRight instead.
+     */
     template <
         int             ITEMS_PER_THREAD,
         typename        FlagT,
         typename        FlagOp>
-    __device__ __forceinline__ void FlagHeadsAndTails(
+    CUB_DEPRECATED __device__ __forceinline__ void FlagHeadsAndTails(
         FlagT           (&head_flags)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity head_flags
         T               tile_predecessor_item,              ///< [in] <b>[<em>thread</em><sub>0</sub> only]</b> Item with which to compare the first tile item (<tt>input<sub>0</sub></tt> from <em>thread</em><sub>0</sub>).
         FlagT           (&tail_flags)[ITEMS_PER_THREAD],    ///< [out] Calling thread's discontinuity tail_flags
@@ -582,8 +1345,6 @@ public:
         // Set tail_flags for remaining items
         Iterate<0, ITEMS_PER_THREAD - 1>::FlagTails(linear_tid, tail_flags, input, flag_op);
     }
-
-
 
 };
 

--- a/cub/block/block_discontinuity.cuh
+++ b/cub/block/block_discontinuity.cuh
@@ -70,7 +70,7 @@ CUB_NAMESPACE_BEGIN
  *
  * __global__ void ExampleKernel(...)
  * {
- *     // Specialize BlockDiscontinuity for a 1D block of 128 threads on type int
+ *     // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
  *     typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
  *
  *     // Allocate shared memory for BlockDiscontinuity
@@ -382,7 +382,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads on type int
+     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
      *     typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
      *
      *     // Allocate shared memory for BlockDiscontinuity
@@ -446,7 +446,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads on type int
+     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
      *     typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
      *
      *     // Allocate shared memory for BlockDiscontinuity
@@ -524,7 +524,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads on type int
+     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
      *     typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
      *
      *     // Allocate shared memory for BlockDiscontinuity
@@ -603,7 +603,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads on type int
+     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
      *     typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
      *
      *     // Allocate shared memory for BlockDiscontinuity
@@ -702,7 +702,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads on type int
+     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
      *     typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
      *
      *     // Allocate shared memory for BlockDiscontinuity
@@ -814,7 +814,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads on type int
+     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
      *     typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
      *
      *     // Allocate shared memory for BlockDiscontinuity
@@ -932,7 +932,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads on type int
+     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
      *     typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
      *
      *     // Allocate shared memory for BlockDiscontinuity
@@ -1051,7 +1051,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads on type int
+     *     // Specialize BlockDiscontinuity for a 1D block of 128 threads of type int
      *     typedef cub::BlockDiscontinuity<int, 128> BlockDiscontinuity;
      *
      *     // Allocate shared memory for BlockDiscontinuity

--- a/cub/block/block_reduce.cuh
+++ b/cub/block/block_reduce.cuh
@@ -191,7 +191,7 @@ enum BlockReduceAlgorithm
  *
  * __global__ void ExampleKernel(...)
  * {
- *     // Specialize BlockReduce for a 1D block of 128 threads on type int
+ *     // Specialize BlockReduce for a 1D block of 128 threads of type int
  *     typedef cub::BlockReduce<int, 128> BlockReduce;
  *
  *     // Allocate shared memory for BlockReduce
@@ -328,7 +328,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockReduce for a 1D block of 128 threads on type int
+     *     // Specialize BlockReduce for a 1D block of 128 threads of type int
      *     typedef cub::BlockReduce<int, 128> BlockReduce;
      *
      *     // Allocate shared memory for BlockReduce
@@ -372,7 +372,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockReduce for a 1D block of 128 threads on type int
+     *     // Specialize BlockReduce for a 1D block of 128 threads of type int
      *     typedef cub::BlockReduce<int, 128> BlockReduce;
      *
      *     // Allocate shared memory for BlockReduce
@@ -420,7 +420,7 @@ public:
      *
      * __global__ void ExampleKernel(int num_valid, ...)
      * {
-     *     // Specialize BlockReduce for a 1D block of 128 threads on type int
+     *     // Specialize BlockReduce for a 1D block of 128 threads of type int
      *     typedef cub::BlockReduce<int, 128> BlockReduce;
      *
      *     // Allocate shared memory for BlockReduce
@@ -479,7 +479,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockReduce for a 1D block of 128 threads on type int
+     *     // Specialize BlockReduce for a 1D block of 128 threads of type int
      *     typedef cub::BlockReduce<int, 128> BlockReduce;
      *
      *     // Allocate shared memory for BlockReduce
@@ -519,7 +519,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockReduce for a 1D block of 128 threads on type int
+     *     // Specialize BlockReduce for a 1D block of 128 threads of type int
      *     typedef cub::BlockReduce<int, 128> BlockReduce;
      *
      *     // Allocate shared memory for BlockReduce
@@ -563,7 +563,7 @@ public:
      *
      * __global__ void ExampleKernel(int num_valid, ...)
      * {
-     *     // Specialize BlockReduce for a 1D block of 128 threads on type int
+     *     // Specialize BlockReduce for a 1D block of 128 threads of type int
      *     typedef cub::BlockReduce<int, 128> BlockReduce;
      *
      *     // Allocate shared memory for BlockReduce

--- a/cub/block/block_scan.cuh
+++ b/cub/block/block_scan.cuh
@@ -157,7 +157,7 @@ enum BlockScanAlgorithm
  *
  * __global__ void ExampleKernel(...)
  * {
- *     // Specialize BlockScan for a 1D block of 128 threads on type int
+ *     // Specialize BlockScan for a 1D block of 128 threads of type int
  *     typedef cub::BlockScan<int, 128> BlockScan;
  *
  *     // Allocate shared memory for BlockScan
@@ -313,7 +313,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan
@@ -359,7 +359,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan
@@ -501,7 +501,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan
@@ -551,7 +551,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan
@@ -710,7 +710,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan
@@ -758,7 +758,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan
@@ -906,7 +906,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan
@@ -968,7 +968,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan
@@ -1263,7 +1263,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan
@@ -1306,7 +1306,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan
@@ -1445,7 +1445,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan
@@ -1507,7 +1507,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan
@@ -1693,7 +1693,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan
@@ -1740,7 +1740,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan
@@ -1887,7 +1887,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan
@@ -1953,7 +1953,7 @@ public:
      *
      * __global__ void ExampleKernel(...)
      * {
-     *     // Specialize BlockScan for a 1D block of 128 threads on type int
+     *     // Specialize BlockScan for a 1D block of 128 threads of type int
      *     typedef cub::BlockScan<int, 128> BlockScan;
      *
      *     // Allocate shared memory for BlockScan

--- a/cub/cub.cuh
+++ b/cub/cub.cuh
@@ -38,6 +38,7 @@
 
 // Block
 #include "block/block_histogram.cuh"
+#include "block/block_adjacent_difference.cuh"
 #include "block/block_discontinuity.cuh"
 #include "block/block_exchange.cuh"
 #include "block/block_load.cuh"
@@ -62,6 +63,7 @@
 #include "device/device_segmented_reduce.cuh"
 #include "device/device_select.cuh"
 #include "device/device_spmv.cuh"
+#include "device/device_adjacent_difference.cuh"
 
 // Grid
 //#include "grid/grid_barrier.cuh"

--- a/cub/detail/type_traits.cuh
+++ b/cub/detail/type_traits.cuh
@@ -1,0 +1,54 @@
+/******************************************************************************
+ * Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/**
+ * \file
+ * Wrappers and extensions around <type_traits> utilities.
+ */
+
+#pragma once
+
+#include "../util_cpp_dialect.cuh"
+#include "../util_namespace.cuh"
+
+#include <type_traits>
+
+
+CUB_NAMESPACE_BEGIN
+namespace detail {
+
+template <typename Invokable, typename... Args>
+using invoke_result_t =
+#if CUB_CPP_DIALECT < 2017
+  typename std::result_of<Invokable(Args...)>::type;
+#else // 2017+
+  std::invoke_result_t<Invokable, Args...>;
+#endif
+
+
+} // namespace detail
+CUB_NAMESPACE_END

--- a/cub/device/device_adjacent_difference.cuh
+++ b/cub/device/device_adjacent_difference.cuh
@@ -1,0 +1,641 @@
+/******************************************************************************
+ * Copyright (c) 2011-2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include "../config.cuh"
+#include "../util_namespace.cuh"
+#include "dispatch/dispatch_adjacent_difference.cuh"
+
+#include <thrust/detail/integer_traits.h>
+#include <thrust/detail/cstdint.h>
+
+
+CUB_NAMESPACE_BEGIN
+
+
+/**
+ * @brief DeviceAdjacentDifference provides device-wide, parallel operations for
+ *        computing the differences of adjacent elements residing within
+ *        device-accessible memory.
+ *
+ * @ingroup SingleModule
+ *
+ * @par Overview
+ * - DeviceAdjacentDifference calculates the differences of adjacent elements in
+ *   d_input. Because the binary operation could be noncommutative, there
+ *   are two sets of methods. Methods named SubtractLeft subtract left element
+ *   `*(i - 1)` of input sequence from current element `*i`.
+ *   Methods named `SubtractRight` subtract current element `*i` from the
+ *   right one `*(i + 1)`:
+ *   @par
+ *   @code
+ *   int *d_values; // [1, 2, 3, 4]
+ *   //...
+ *   int *d_subtract_left_result  <-- [  1,  1,  1,  1 ]
+ *   int *d_subtract_right_result <-- [ -1, -1, -1,  4 ]
+ *   @endcode
+ * - For SubtractLeft, if the left element is out of bounds, the iterator is
+ *   assigned to <tt>\*(result + (i - first))</tt> without modification.
+ * - For SubtractRight, if the right element is out of bounds, the iterator is
+ *   assigned to <tt>\*(result + (i - first))</tt> without modification.
+ *
+ * @par Snippet
+ * The code snippet below illustrates how to use @p DeviceAdjacentDifference to
+ * compute the left difference between adjacent elements.
+ *
+ * @par
+ * @code
+ * #include <cub/cub.cuh>
+ * // or equivalently <cub/device/device_adjacent_difference.cuh>
+ *
+ * // Declare, allocate, and initialize device-accessible pointers
+ * int  num_items;       // e.g., 8
+ * int  *d_values;       // e.g., [1, 2, 1, 2, 1, 2, 1, 2]
+ * //...
+ *
+ * // Determine temporary device storage requirements
+ * void     *d_temp_storage = NULL;
+ * size_t   temp_storage_bytes = 0;
+ *
+ * cub::DeviceAdjacentDifference::SubtractLeft(
+ *   d_temp_storage, temp_storage_bytes, d_values, num_items);
+ *
+ * // Allocate temporary storage
+ * cudaMalloc(&d_temp_storage, temp_storage_bytes);
+ *
+ * // Run operation
+ * cub::DeviceAdjacentDifference::SubtractLeft(
+ *   d_temp_storage, temp_storage_bytes, d_values, num_items);
+ *
+ * // d_values <-- [1, 1, -1, 1, -1, 1, -1, 1]
+ * @endcode
+ */
+struct DeviceAdjacentDifference
+{
+private:
+
+  template <bool in_place,
+            bool read_left,
+            typename InputIteratorT,
+            typename OutputIteratorT,
+            typename DifferenceOpT>
+  static CUB_RUNTIME_FUNCTION cudaError_t
+  AdjacentDifference(void *d_temp_storage,
+                     std::size_t &temp_storage_bytes,
+                     InputIteratorT d_input,
+                     OutputIteratorT d_output,
+                     std::size_t num_items,
+                     DifferenceOpT difference_op,
+                     cudaStream_t stream,
+                     bool debug_synchronous)
+  {
+    const auto uint64_threshold = static_cast<std::size_t>(
+      THRUST_NS_QUALIFIER::detail::integer_traits<
+        THRUST_NS_QUALIFIER::detail::int32_t>::const_max);
+
+    if (num_items <= uint64_threshold)
+    {
+      using OffsetT = std::uint32_t;
+      using DispatchT = DispatchAdjacentDifference<InputIteratorT,
+                                                   OutputIteratorT,
+                                                   DifferenceOpT,
+                                                   OffsetT,
+                                                   in_place,
+                                                   read_left>;
+
+      return DispatchT::Dispatch(d_temp_storage,
+                                 temp_storage_bytes,
+                                 d_input,
+                                 d_output,
+                                 static_cast<OffsetT>(num_items),
+                                 difference_op,
+                                 stream,
+                                 debug_synchronous);
+    }
+    else
+    {
+      using OffsetT = std::uint64_t;
+      using DispatchT = DispatchAdjacentDifference<InputIteratorT,
+                                                   OutputIteratorT,
+                                                   DifferenceOpT,
+                                                   OffsetT,
+                                                   in_place,
+                                                   read_left>;
+
+      return DispatchT::Dispatch(d_temp_storage,
+                                 temp_storage_bytes,
+                                 d_input,
+                                 d_output,
+                                 static_cast<OffsetT>(num_items),
+                                 difference_op,
+                                 stream,
+                                 debug_synchronous);
+    }
+  }
+
+public:
+
+  /**
+   * @brief Subtracts the left element of each adjacent pair of elements residing within device-accessible memory.
+   * @ingroup SingleModule
+   *
+   * @par Overview
+   * - Calculates the differences of adjacent elements in `d_input`. That is,
+   *   `*d_input` is assigned to `*d_output`, and, for each iterator `i` in the
+   *   range `[d_input + 1, d_input + num_items)`, the result of
+   *   `difference_op(*i, *(i - 1))` is assigned to
+   *   `*(d_output + (i - d_input))`.
+   * - Note that the behavior is undefined if the input and output ranges
+   *   overlap in any way.
+   *
+   * @par Snippet
+   * The code snippet below illustrates how to use @p DeviceAdjacentDifference
+   * to compute the difference between adjacent elements.
+   *
+   * @par
+   * @code
+   * #include <cub/cub.cuh>
+   * // or equivalently <cub/device/device_adjacent_difference.cuh>
+   *
+   * struct CustomDifference
+   * {
+   *   template <typename DataType>
+   *   __device__ DataType operator()(DataType &lhs, DataType &rhs)
+   *   {
+   *     return lhs - rhs;
+   *   }
+   * };
+   *
+   * // Declare, allocate, and initialize device-accessible pointers
+   * int  num_items;      // e.g., 8
+   * int  *d_input;       // e.g., [1, 2, 1, 2, 1, 2, 1, 2]
+   * int  *d_output;
+   * ...
+   *
+   * // Determine temporary device storage requirements
+   * void     *d_temp_storage = NULL;
+   * size_t   temp_storage_bytes = 0;
+   *
+   * cub::DeviceAdjacentDifference::SubtractLeftCopy(
+   *   d_temp_storage, temp_storage_bytes,
+   *   d_input, d_output,
+   *   num_items, CustomDifference());
+   *
+   * // Allocate temporary storage
+   * cudaMalloc(&d_temp_storage, temp_storage_bytes);
+   *
+   * // Run operation
+   * cub::DeviceAdjacentDifference::SubtractLeftCopy(
+   *   d_temp_storage, temp_storage_bytes,
+   *   d_input, d_output,
+   *   num_items, CustomDifference());
+   *
+   * // d_input  <-- [1, 2, 1, 2, 1, 2, 1, 2]
+   * // d_output <-- [1, 1, -1, 1, -1, 1, -1, 1]
+   * @endcode
+   *
+   * @tparam InputIteratorT
+   *   is a model of <a href="https://en.cppreference.com/w/cpp/iterator/input_iterator">Input Iterator</a>,
+   *   and `x` and `y` are objects of `InputIteratorT`'s `value_type`, then
+   *   `x - y` is defined, and `InputIteratorT`'s `value_type` is convertible to
+   *   a type in `OutputIteratorT`'s set of `value_types`, and the return type
+   *   of `x - y` is convertible to a type in `OutputIteratorT`'s set of
+   *   `value_types`.
+   *
+   * @tparam OutputIteratorT
+   *   is a model of <a href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output Iterator</a>.
+   *
+   * @tparam DifferenceOpT
+   *   Its `result_type` is convertible to a type in `OutputIteratorT`'s set of
+   *   `value_types`.
+   *
+   * @param[in] d_temp_storage
+   *   Device-accessible allocation of temporary storage. When `nullptr`, the
+   *   required allocation size is written to `temp_storage_bytes` and no work
+   *   is done.
+   *
+   * @param[in,out] temp_storage_bytes
+   *   Reference to size in bytes of `d_temp_storage` allocation
+   *
+   * @param[in] d_input
+   *   Pointer to the input sequence
+   *
+   * @param[out] d_output
+   *   Pointer to the output sequence
+   *
+   * @param[in] num_items
+   *   Number of items in the input sequence
+   *
+   * @param[in] difference_op
+   *   The binary function used to compute differences
+   *
+   * @param[in] stream
+   *   <b>[optional]</b> CUDA stream to launch kernels within. Default is
+   *   stream<sub>0</sub>
+   *
+   * @param[in] debug_synchronous
+   *   <b>[optional]</b> Whether or not to synchronize the stream after every
+   *   kernel launch to check for errors. Also causes launch configurations to
+   *   be printed to the console. Default is `false`
+   */
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename DifferenceOpT = cub::Difference>
+  static CUB_RUNTIME_FUNCTION cudaError_t
+  SubtractLeftCopy(void *d_temp_storage,
+                   std::size_t &temp_storage_bytes,
+                   InputIteratorT d_input,
+                   OutputIteratorT d_output,
+                   std::size_t num_items,
+                   DifferenceOpT difference_op = {},
+                   cudaStream_t stream         = 0,
+                   bool debug_synchronous      = false)
+  {
+    constexpr bool in_place = false;
+    constexpr bool read_left = true;
+
+    return AdjacentDifference<in_place, read_left>(d_temp_storage,
+                                                   temp_storage_bytes,
+                                                   d_input,
+                                                   d_output,
+                                                   num_items,
+                                                   difference_op,
+                                                   stream,
+                                                   debug_synchronous);
+  }
+
+  /**
+   * @brief Subtracts the left element of each adjacent pair of elements
+   *        residing within device-accessible memory.
+   *
+   * @ingroup SingleModule
+   *
+   * @par Overview
+   * Calculates the differences of adjacent elements in `d_input`. That is, for
+   * each iterator `i` in the range `[d_input + 1, d_input + num_items)`, the
+   * result of `difference_op(*i, *(i - 1))` is assigned to
+   * `*(d_input + (i - d_input))`.
+   *
+   * @par Snippet
+   * The code snippet below illustrates how to use @p DeviceAdjacentDifference
+   * to compute the difference between adjacent elements.
+   *
+   * @par
+   * @code
+   * #include <cub/cub.cuh>
+   * // or equivalently <cub/device/device_adjacent_difference.cuh>
+   *
+   * struct CustomDifference
+   * {
+   *   template <typename DataType>
+   *   __device__ DataType operator()(DataType &lhs, DataType &rhs)
+   *   {
+   *     return lhs - rhs;
+   *   }
+   * };
+   *
+   * // Declare, allocate, and initialize device-accessible pointers
+   * int  num_items;     // e.g., 8
+   * int  *d_data;       // e.g., [1, 2, 1, 2, 1, 2, 1, 2]
+   * ...
+   *
+   * // Determine temporary device storage requirements
+   * void     *d_temp_storage = NULL;
+   * size_t   temp_storage_bytes = 0;
+   * cub::DeviceAdjacentDifference::SubtractLeft(
+   *   d_temp_storage, temp_storage_bytes,
+   *   d_data, num_items, CustomDifference());
+   *
+   * // Allocate temporary storage
+   * cudaMalloc(&d_temp_storage, temp_storage_bytes);
+   *
+   * // Run operation
+   * cub::DeviceAdjacentDifference::SubtractLeft(
+   *   d_temp_storage, temp_storage_bytes,
+   *   d_data, num_items, CustomDifference());
+   *
+   * // d_data <-- [1, 1, -1, 1, -1, 1, -1, 1]
+   * @endcode
+   *
+   * @tparam RandomAccessIteratorT
+   *   is a model of <a href="https://en.cppreference.com/w/cpp/iterator/random_access_iterator">Random Access Iterator</a>,
+   *   `RandomAccessIteratorT` is mutable. If `x` and `y` are objects of
+   *   `RandomAccessIteratorT`'s `value_type`, and `x - y` is defined, then the
+   *   return type of `x - y` should be convertible to a type in
+   *   `RandomAccessIteratorT`'s set of `value_types`.
+   *
+   * @tparam DifferenceOpT
+   *   Its `result_type` is convertible to a type in `RandomAccessIteratorT`'s
+   *   set of `value_types`.
+   *
+   * @param[in] d_temp_storage
+   *   Device-accessible allocation of temporary storage. When `nullptr`, the
+   *   required allocation size is written to `temp_storage_bytes` and no work
+   *   is done.
+   *
+   * @param[in,out] temp_storage_bytes
+   *   Reference to size in bytes of @p d_temp_storage allocation
+   *
+   * @param[in,out] d_input
+   *   Pointer to the input sequence and the result
+   *
+   * @param[in] num_items
+   *   Number of items in the input sequence
+   *
+   * @param[in] difference_op
+   *   The binary function used to compute differences
+   *
+   * @param[in] stream
+   *   <b>[optional]</b> CUDA stream to launch kernels within. Default is
+   *   stream<sub>0</sub>.
+   *
+   * @param[in] debug_synchronous
+   *   <b>[optional]</b> Whether or not to synchronize the stream after every
+   *   kernel launch to check for errors. Also causes launch configurations to
+   *   be printed to the console. Default is `false`.
+   */
+  template <typename RandomAccessIteratorT,
+            typename DifferenceOpT = cub::Difference>
+  static CUB_RUNTIME_FUNCTION cudaError_t
+  SubtractLeft(void *d_temp_storage,
+               std::size_t &temp_storage_bytes,
+               RandomAccessIteratorT d_input,
+               std::size_t num_items,
+               DifferenceOpT difference_op = {},
+               cudaStream_t stream         = 0,
+               bool debug_synchronous      = false)
+  {
+    constexpr bool in_place = true;
+    constexpr bool read_left = true;
+
+    return AdjacentDifference<in_place, read_left>(d_temp_storage,
+                                                   temp_storage_bytes,
+                                                   d_input,
+                                                   d_input,
+                                                   num_items,
+                                                   difference_op,
+                                                   stream,
+                                                   debug_synchronous);
+  }
+
+  /**
+   * @brief Subtracts the right element of each adjacent pair of elements
+   *        residing within device-accessible memory.
+   *
+   * @ingroup SingleModule
+   *
+   * @par Overview
+   * - Calculates the right differences of adjacent elements in `d_input`. That
+   *   is, `*(d_input + num_items - 1)` is assigned to
+   *   `*(d_output + num_items - 1)`, and, for each iterator `i` in the range
+   *   `[d_input, d_input + num_items - 1)`, the result of
+   *   `difference_op(*i, *(i + 1))` is assigned to
+   *   `*(d_output + (i - d_input))`.
+   * - Note that the behavior is undefined if the input and output ranges
+   *   overlap in any way.
+   *
+   * @par Snippet
+   * The code snippet below illustrates how to use @p DeviceAdjacentDifference
+   * to compute the difference between adjacent elements.
+   *
+   * @par
+   * @code
+   * #include <cub/cub.cuh>
+   * // or equivalently <cub/device/device_adjacent_difference.cuh>
+   *
+   * struct CustomDifference
+   * {
+   *   template <typename DataType>
+   *   __device__ DataType operator()(DataType &lhs, DataType &rhs)
+   *   {
+   *     return lhs - rhs;
+   *   }
+   * };
+   *
+   * // Declare, allocate, and initialize device-accessible pointers
+   * int  num_items;     // e.g., 8
+   * int  *d_input;      // e.g., [1, 2, 1, 2, 1, 2, 1, 2]
+   * int  *d_output;
+   * ..
+   *
+   * // Determine temporary device storage requirements
+   * void *d_temp_storage = nullptr;
+   * size_t temp_storage_bytes = 0;
+   * cub::DeviceAdjacentDifference::SubtractRightCopy(
+   *   d_temp_storage, temp_storage_bytes,
+   *   d_input, d_output, num_items, CustomDifference());
+   *
+   * // Allocate temporary storage
+   * cudaMalloc(&d_temp_storage, temp_storage_bytes);
+   *
+   * // Run operation
+   * cub::DeviceAdjacentDifference::SubtractRightCopy(
+   *   d_temp_storage, temp_storage_bytes,
+   *   d_input, d_output, num_items, CustomDifference());
+   *
+   * // d_input <-- [1, 2, 1, 2, 1, 2, 1, 2]
+   * // d_data  <-- [-1, 1, -1, 1, -1, 1, -1, 2]
+   * @endcode
+   *
+   * @tparam InputIteratorT
+   *   is a model of <a href="https://en.cppreference.com/w/cpp/iterator/input_iterator">Input Iterator</a>,
+   *   and `x` and `y` are objects of `InputIteratorT`'s `value_type`, then
+   *   `x - y` is defined, and `InputIteratorT`'s `value_type` is convertible to
+   *   a type in `OutputIteratorT`'s set of `value_types`, and the return type
+   *   of `x - y` is convertible to a type in `OutputIteratorT`'s set of
+   *   `value_types`.
+   *
+   * @tparam OutputIteratorT
+   *   is a model of <a href="https://en.cppreference.com/w/cpp/iterator/output_iterator">Output Iterator</a>.
+   *
+   * @tparam DifferenceOpT
+   *   Its `result_type` is convertible to a type in `RandomAccessIteratorT`'s
+   *   set of `value_types`.
+   *
+   * @param[in] d_temp_storage
+   *   Device-accessible allocation of temporary storage. When `nullptr`, the
+   *   required allocation size is written to `temp_storage_bytes` and no work
+   *   is done.
+   *
+   * @param[in,out] temp_storage_bytes
+   *   Reference to size in bytes of `d_temp_storage` allocation
+   *
+   * @param[in] d_input
+   *   Pointer to the input sequence
+   *
+   * @param[out] d_output
+   *   Pointer to the output sequence
+   *
+   * @param[in] num_items
+   *   Number of items in the input sequence
+   *
+   * @param[in] difference_op
+   *   The binary function used to compute differences.
+   *
+   * @param[in] stream
+   *   <b>[optional]</b> CUDA stream to launch kernels within. Default is
+   *   stream<sub>0</sub>.
+   *
+   * @param[in] debug_synchronous
+   *   <b>[optional]</b> Whether or not to synchronize the stream after every
+   *   kernel launch to check for errors. Also causes launch configurations to
+   *   be printed to the console. Default is `false`.
+   */
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename DifferenceOpT = cub::Difference>
+  static CUB_RUNTIME_FUNCTION cudaError_t
+  SubtractRightCopy(void *d_temp_storage,
+                    std::size_t &temp_storage_bytes,
+                    InputIteratorT d_input,
+                    OutputIteratorT d_output,
+                    std::size_t num_items,
+                    DifferenceOpT difference_op = {},
+                    cudaStream_t stream         = 0,
+                    bool debug_synchronous      = false)
+  {
+    constexpr bool in_place  = false;
+    constexpr bool read_left = false;
+
+    return AdjacentDifference<in_place, read_left>(d_temp_storage,
+                                                   temp_storage_bytes,
+                                                   d_input,
+                                                   d_output,
+                                                   num_items,
+                                                   difference_op,
+                                                   stream,
+                                                   debug_synchronous);
+  }
+
+  /**
+   * @brief Subtracts the right element of each adjacent pair of elements
+   *        residing within device-accessible memory.
+   *
+   * @ingroup SingleModule
+   *
+   * @par Overview
+   * Calculates the right differences of adjacent elements in `d_input`. That
+   * is, for each iterator `i` in the range
+   * `[d_input, d_input + num_items - 1)`, the result of
+   * `difference_op(*i, *(i + 1))` is assigned to
+   * `*(d_input + (i - d_input))`.
+   *
+   * @par Snippet
+   * The code snippet below illustrates how to use @p DeviceAdjacentDifference
+   * to compute the difference between adjacent elements.
+   *
+   * @par
+   * @code
+   * #include <cub/cub.cuh>
+   * // or equivalently <cub/device/device_adjacent_difference.cuh>
+   *
+   * // Declare, allocate, and initialize device-accessible pointers
+   * int  num_items;    // e.g., 8
+   * int  *d_data;      // e.g., [1, 2, 1, 2, 1, 2, 1, 2]
+   * ...
+   *
+   * // Determine temporary device storage requirements
+   * void *d_temp_storage = NULL;
+   * size_t temp_storage_bytes = 0;
+   * cub::DeviceAdjacentDifference::SubtractRight(
+   *   d_temp_storage, temp_storage_bytes, d_data, num_items);
+   *
+   * // Allocate temporary storage
+   * cudaMalloc(&d_temp_storage, temp_storage_bytes);
+   *
+   * // Run operation
+   * cub::DeviceAdjacentDifference::SubtractRight(
+   *   d_temp_storage, temp_storage_bytes, d_data, num_items);
+   *
+   * // d_data  <-- [-1, 1, -1, 1, -1, 1, -1, 2]
+   * @endcode
+   *
+   * @tparam RandomAccessIteratorT
+   *   is a model of <a href="https://en.cppreference.com/w/cpp/iterator/random_access_iterator">Random Access Iterator</a>,
+   *   `RandomAccessIteratorT` is mutable. If `x` and `y` are objects of
+   *   `RandomAccessIteratorT`'s `value_type`, and `x - y` is defined, then the
+   *   return type of `x - y` should be convertible to a type in
+   *   `RandomAccessIteratorT`'s set of `value_types`.
+   *
+   * @tparam DifferenceOpT
+   *   Its `result_type` is convertible to a type in `RandomAccessIteratorT`'s
+   *   set of `value_types`.
+   *
+   * @param[in] d_temp_storage
+   *   Device-accessible allocation of temporary storage. When `nullptr`, the
+   *   required allocation size is written to `temp_storage_bytes` and no work
+   *   is done.
+   *
+   * @param[in,out] temp_storage_bytes
+   *   Reference to size in bytes of `d_temp_storage` allocation
+   *
+   * @param[in,out] d_input
+   *   Pointer to the input sequence
+   *
+   * @param[in] num_items
+   *   Number of items in the input sequence
+   *
+   * @param[in] difference_op
+   *   The binary function used to compute differences
+   *
+   * @param[in] stream
+   *   <b>[optional]</b> CUDA stream to launch kernels within. Default is
+   *   stream<sub>0</sub>.
+   *
+   * @param[in] debug_synchronous
+   *  <b>[optional]</b> Whether or not to synchronize the stream after every
+   *  kernel launch to check for errors. Also causes launch configurations to be
+   *  printed to the console. Default is `false`.
+   */
+  template <typename RandomAccessIteratorT,
+            typename DifferenceOpT = cub::Difference>
+  static CUB_RUNTIME_FUNCTION cudaError_t
+  SubtractRight(void *d_temp_storage,
+                std::size_t &temp_storage_bytes,
+                RandomAccessIteratorT d_input,
+                std::size_t num_items,
+                DifferenceOpT difference_op = {},
+                cudaStream_t stream         = 0,
+                bool debug_synchronous      = false)
+  {
+    constexpr bool in_place = true;
+    constexpr bool read_left = false;
+
+    return AdjacentDifference<in_place, read_left>(d_temp_storage,
+                                                   temp_storage_bytes,
+                                                   d_input,
+                                                   d_input,
+                                                   num_items,
+                                                   difference_op,
+                                                   stream,
+                                                   debug_synchronous);
+  }
+};
+
+
+CUB_NAMESPACE_END

--- a/cub/device/dispatch/dispatch_adjacent_difference.cuh
+++ b/cub/device/dispatch/dispatch_adjacent_difference.cuh
@@ -1,0 +1,382 @@
+/******************************************************************************
+ * Copyright (c) 2011-2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include "../../config.cuh"
+#include "../../util_math.cuh"
+#include "../../util_device.cuh"
+#include "../../util_namespace.cuh"
+#include "../../detail/type_traits.cuh"
+#include "../../agent/agent_adjacent_difference.cuh"
+
+#include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
+
+
+CUB_NAMESPACE_BEGIN
+
+
+template <typename AgentDifferenceInitT,
+          typename InputIteratorT,
+          typename InputT,
+          typename OffsetT>
+void __global__ DeviceAdjacentDifferenceInitKernel(InputIteratorT first,
+                                                   InputT *result,
+                                                   OffsetT num_tiles,
+                                                   int items_per_tile)
+{
+  const int tile_idx = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+  AgentDifferenceInitT::Process(tile_idx,
+                                first,
+                                result,
+                                num_tiles,
+                                items_per_tile);
+}
+
+template <typename ChainedPolicyT,
+          typename InputIteratorT,
+          typename OutputIteratorT,
+          typename DifferenceOpT,
+          typename OffsetT,
+          typename InputT,
+          typename OutputT,
+          bool InPlace,
+          bool ReadLeft>
+void __global__
+DeviceAdjacentDifferenceDifferenceKernel(InputIteratorT input,
+                                         InputT *first_tile_previous,
+                                         OutputIteratorT result,
+                                         DifferenceOpT difference_op,
+                                         OffsetT num_items)
+{
+  using ActivePolicyT = 
+    typename ChainedPolicyT::ActivePolicy::AdjacentDifferencePolicy;
+
+  using Agent = AgentDifference<ActivePolicyT,
+                                InputIteratorT,
+                                OutputIteratorT,
+                                DifferenceOpT,
+                                OffsetT,
+                                InputT,
+                                OutputT,
+                                InPlace,
+                                ReadLeft>;
+
+  extern __shared__ char shmem[];
+  typename Agent::TempStorage &storage =
+    *reinterpret_cast<typename Agent::TempStorage *>(shmem);
+
+  Agent agent(storage,
+              input,
+              first_tile_previous,
+              result,
+              difference_op,
+              num_items);
+
+  int tile_idx = static_cast<int>(blockIdx.x);
+  OffsetT tile_base  = static_cast<OffsetT>(tile_idx) 
+                     * ActivePolicyT::ITEMS_PER_TILE;
+
+  agent.Process(tile_idx, tile_base);
+}
+
+template <typename InputIteratorT>
+struct DeviceAdjacentDifferencePolicy
+{
+  using ValueT = typename std::iterator_traits<InputIteratorT>::value_type;
+
+  //------------------------------------------------------------------------------
+  // Architecture-specific tuning policies
+  //------------------------------------------------------------------------------
+
+  struct Policy300 : ChainedPolicy<300, Policy300, Policy300>
+  {
+    using AdjacentDifferencePolicy =
+      AgentAdjacentDifferencePolicy<128,
+                                    Nominal8BItemsToItems<ValueT>(7),
+                                    BLOCK_LOAD_WARP_TRANSPOSE,
+                                    LOAD_DEFAULT,
+                                    BLOCK_STORE_WARP_TRANSPOSE>;
+  };
+
+  struct Policy350 : ChainedPolicy<350, Policy350, Policy300>
+  {
+    using AdjacentDifferencePolicy =
+      AgentAdjacentDifferencePolicy<128,
+                                    Nominal8BItemsToItems<ValueT>(7),
+                                    BLOCK_LOAD_WARP_TRANSPOSE,
+                                    LOAD_LDG,
+                                    BLOCK_STORE_WARP_TRANSPOSE>;
+  };
+
+  using MaxPolicy = Policy350;
+};
+
+template <typename InputIteratorT,
+          typename OutputIteratorT,
+          typename DifferenceOpT,
+          typename OffsetT,
+          bool InPlace,
+          bool ReadLeft,
+          typename SelectedPolicy =
+            DeviceAdjacentDifferencePolicy<InputIteratorT>>
+struct DispatchAdjacentDifference : public SelectedPolicy
+{
+  using InputT = typename std::iterator_traits<InputIteratorT>::value_type;
+  using OutputT = detail::invoke_result_t<DifferenceOpT, InputT, InputT>;
+
+  void *d_temp_storage;
+  std::size_t &temp_storage_bytes;
+  InputIteratorT d_input;
+  OutputIteratorT d_output;
+  OffsetT num_items;
+  DifferenceOpT difference_op;
+  cudaStream_t stream;
+  bool debug_synchronous;
+
+  CUB_RUNTIME_FUNCTION __forceinline__
+  DispatchAdjacentDifference(void *d_temp_storage,
+                             std::size_t &temp_storage_bytes,
+                             InputIteratorT d_input,
+                             OutputIteratorT d_output,
+                             OffsetT num_items,
+                             DifferenceOpT difference_op,
+                             cudaStream_t stream,
+                             bool debug_synchronous)
+      : d_temp_storage(d_temp_storage)
+      , temp_storage_bytes(temp_storage_bytes)
+      , d_input(d_input)
+      , d_output(d_output)
+      , num_items(num_items)
+      , difference_op(difference_op)
+      , stream(stream)
+      , debug_synchronous(debug_synchronous)
+  {}
+
+  /// Invocation
+  template <typename ActivePolicyT>
+  CUB_RUNTIME_FUNCTION __forceinline__ cudaError_t Invoke()
+  {
+    using AdjacentDifferencePolicyT =
+      typename ActivePolicyT::AdjacentDifferencePolicy;
+
+    using MaxPolicyT = typename DispatchAdjacentDifference::MaxPolicy;
+
+    using AgentDifferenceT = AgentDifference<AdjacentDifferencePolicyT,
+                                             InputIteratorT,
+                                             OutputIteratorT,
+                                             DifferenceOpT,
+                                             OffsetT,
+                                             InputT,
+                                             OutputT,
+                                             InPlace,
+                                             ReadLeft>;
+
+    cudaError error = cudaSuccess;
+
+    do
+    {
+      const int tile_size = AdjacentDifferencePolicyT::ITEMS_PER_TILE;
+      const int num_tiles =
+        static_cast<int>(DivideAndRoundUp(num_items, tile_size));
+
+      int shmem_size = AgentDifferenceT::SHARED_MEMORY_SIZE;
+
+      std::size_t first_tile_previous_size = InPlace * num_tiles *
+                                             sizeof(InputT);
+
+      void *allocations[1]            = {nullptr};
+      std::size_t allocation_sizes[1] = {first_tile_previous_size};
+
+      if (InPlace)
+      {
+        if (CubDebug(error = AliasTemporaries(d_temp_storage,
+                                              temp_storage_bytes,
+                                              allocations,
+                                              allocation_sizes)))
+        {
+          break;
+        }
+
+        if (d_temp_storage == nullptr)
+        {
+          // Return if the caller is simply requesting the size of the storage
+          // allocation
+
+          if (temp_storage_bytes == 0)
+          {
+            temp_storage_bytes = 1;
+          }
+
+          break;
+        }
+      }
+
+      if (num_items == OffsetT{})
+      {
+        break;
+      }
+
+      auto first_tile_previous = reinterpret_cast<InputT*>(allocations[0]);
+
+      if (InPlace)
+      {
+        using AgentDifferenceInitT =
+          AgentDifferenceInit<InputIteratorT, InputT, OffsetT, ReadLeft>;
+
+        const int init_block_size = AgentDifferenceInitT::BLOCK_THREADS;
+        const int init_grid_size = DivideAndRoundUp(num_tiles, init_block_size);
+
+        if (debug_synchronous)
+        {
+          _CubLog("Invoking DeviceAdjacentDifferenceInitKernel"
+                  "<<<%d, %d, 0, %lld>>>()\n",
+                  init_grid_size,
+                  init_block_size,
+                  reinterpret_cast<long long>(stream));
+        }
+
+        THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(init_grid_size,
+                                                                init_block_size,
+                                                                0,
+                                                                stream)
+          .doit(DeviceAdjacentDifferenceInitKernel<AgentDifferenceInitT,
+                                                   InputIteratorT,
+                                                   InputT,
+                                                   OffsetT>,
+                d_input,
+                first_tile_previous,
+                num_tiles,
+                tile_size);
+
+        if (debug_synchronous)
+        {
+          if (CubDebug(error = SyncStream(stream)))
+          {
+            break;
+          }
+        }
+
+        // Check for failure to launch
+        if (CubDebug(error = cudaPeekAtLastError()))
+        {
+          break;
+        }
+      }
+
+      if (debug_synchronous)
+      {
+        _CubLog("Invoking DeviceAdjacentDifferenceDifferenceKernel"
+                "<<<%d, %d, 0, %lld>>>()\n",
+                num_tiles,
+                AdjacentDifferencePolicyT::BLOCK_THREADS,
+                reinterpret_cast<long long>(stream));
+      }
+
+      THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(
+        num_tiles,
+        AdjacentDifferencePolicyT::BLOCK_THREADS,
+        shmem_size,
+        stream)
+        .doit(DeviceAdjacentDifferenceDifferenceKernel<MaxPolicyT,
+                                                       InputIteratorT,
+                                                       OutputIteratorT,
+                                                       DifferenceOpT,
+                                                       OffsetT,
+                                                       InputT,
+                                                       OutputT,
+                                                       InPlace,
+                                                       ReadLeft>,
+              d_input,
+              first_tile_previous,
+              d_output,
+              difference_op,
+              num_items);
+
+      if (debug_synchronous)
+      {
+        if (CubDebug(error = SyncStream(stream)))
+        {
+          break;
+        }
+      }
+
+      // Check for failure to launch
+      if (CubDebug(error = cudaPeekAtLastError()))
+      {
+        break;
+      }
+    } while (0);
+
+    return error;
+  }
+
+  CUB_RUNTIME_FUNCTION
+  static cudaError_t Dispatch(void *d_temp_storage,
+                              std::size_t &temp_storage_bytes,
+                              InputIteratorT d_input,
+                              OutputIteratorT d_output,
+                              OffsetT num_items,
+                              DifferenceOpT difference_op,
+                              cudaStream_t stream,
+                              bool debug_synchronous)
+  {
+    using MaxPolicyT = typename DispatchAdjacentDifference::MaxPolicy;
+
+    cudaError error = cudaSuccess;
+    do
+    {
+      // Get PTX version
+      int ptx_version = 0;
+      if (CubDebug(error = PtxVersion(ptx_version)))
+      {
+        break;
+      }
+
+      // Create dispatch functor
+      DispatchAdjacentDifference dispatch(d_temp_storage,
+                                          temp_storage_bytes,
+                                          d_input,
+                                          d_output,
+                                          num_items,
+                                          difference_op,
+                                          stream,
+                                          debug_synchronous);
+
+      // Dispatch to chained policy
+      if (CubDebug(error = MaxPolicyT::Invoke(ptx_version, dispatch)))
+      {
+        break;
+      }
+    } while (0);
+
+    return error;
+  }
+};
+
+
+CUB_NAMESPACE_END

--- a/cub/thread/thread_operators.cuh
+++ b/cub/thread/thread_operators.cuh
@@ -103,12 +103,38 @@ struct InequalityWrapper
  */
 struct Sum
 {
-    /// Boolean sum operator, returns <tt>a + b</tt>
+    /// Binary sum operator, returns <tt>a + b</tt>
     template <typename T>
     __host__ __device__ __forceinline__ T operator()(const T &a, const T &b) const
     {
         return a + b;
     }
+};
+
+/**
+ * \brief Default difference functor
+ */
+struct Difference
+{
+  /// Binary difference operator, returns <tt>a - b</tt>
+  template <typename T>
+  __host__ __device__ __forceinline__ T operator()(const T &a, const T &b) const
+  {
+    return a - b;
+  }
+};
+
+/**
+ * \brief Default division functor
+ */
+struct Division
+{
+  /// Binary difference operator, returns <tt>a - b</tt>
+  template <typename T>
+  __host__ __device__ __forceinline__ T operator()(const T &a, const T &b) const
+  {
+    return a / b;
+  }
 };
 
 
@@ -271,7 +297,6 @@ struct ReduceBySegmentOp
 };
 
 
-
 template <typename ReductionOpT>    ///< Binary reduction operator to apply to values
 struct ReduceByKeyOp
 {
@@ -300,10 +325,29 @@ struct ReduceByKeyOp
 };
 
 
+template <typename BinaryOpT>
+struct BinaryFlip
+{
+  BinaryOpT binary_op;
 
+  __device__ __host__ explicit BinaryFlip(BinaryOpT binary_op)
+      : binary_op(binary_op)
+  {}
 
+  template <typename T, typename U>
+  __device__ auto
+  operator()(T &&t, U &&u) -> decltype(binary_op(std::forward<U>(u),
+                                                 std::forward<T>(t)))
+  {
+    return binary_op(std::forward<U>(u), std::forward<T>(t));
+  }
+};
 
-
+template <typename BinaryOpT>
+__device__ __host__ BinaryFlip<BinaryOpT> MakeBinaryFlip(BinaryOpT binary_op)
+{
+  return BinaryFlip<BinaryOpT>(binary_op);
+}
 
 /** @} */       // end group UtilModule
 

--- a/test/test_block_adjacent_difference.cu
+++ b/test/test_block_adjacent_difference.cu
@@ -1,0 +1,900 @@
+/******************************************************************************
+ * Copyright (c) 2011-2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Test of BlockAdjacentDifference utilities
+ ******************************************************************************/
+
+// Ensure printing of CUDA runtime errors to console
+#define CUB_STDERR
+
+#include <cub/block/block_adjacent_difference.cuh>
+#include <cub/util_allocator.cuh>
+
+#include <thrust/count.h>
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/mismatch.h>
+#include <thrust/random.h>
+#include <thrust/sequence.h>
+#include <thrust/shuffle.h>
+#include <thrust/sort.h>
+#include <thrust/tabulate.h>
+
+#include <limits>
+#include <memory>
+#include <typeinfo>
+
+#include "test_util.h"
+
+
+using namespace cub;
+
+
+/**
+ * \brief Generates integer sequence \f$S_n=i(i-1)/2\f$.
+ *
+ * The adjacent difference of this sequence produce consecutive numbers:
+ * \f[
+ *   p = \frac{i(i - 1)}{2} \\
+ *   n = \frac{(i + 1) i}{2} \\
+ *   n - p = i \\
+ *   \frac{(i + 1) i}{2} - \frac{i (i - 1)}{2} = i \\
+ *   (i + 1) i - i (i - 1) = 2 i \\
+ *   (i + 1) - (i - 1) = 2 \\
+ *   2 = 2
+ * \f]
+ */
+template <typename DestT>
+struct TestSequenceGenerator
+{
+  std::size_t offset;
+
+  TestSequenceGenerator(std::size_t offset = 0)
+      : offset(offset)
+  {}
+
+  template <typename SourceT>
+  __device__ __host__ DestT operator()(SourceT index) const
+  {
+    index += static_cast<SourceT>(offset);
+    return static_cast<DestT>(index * (index - 1) / SourceT(2));
+  }
+};
+
+
+
+struct CustomType
+{
+  unsigned int key;
+  unsigned int value;
+
+  __device__ __host__ CustomType()
+    : key(0)
+    , value(0)
+  {}
+
+  __device__ __host__ CustomType(unsigned int key, unsigned int value)
+    : key(key)
+    , value(value)
+  {}
+};
+
+
+__device__ __host__ bool operator==(const CustomType& lhs,
+                                    const CustomType& rhs)
+{
+  return lhs.key == rhs.key && lhs.value == rhs.value;
+}
+
+__device__ __host__ bool operator!=(const CustomType& lhs,
+                                    const CustomType& rhs)
+{
+  return !(lhs == rhs);
+}
+
+__device__ __host__ CustomType operator-(const CustomType& lhs,
+                                         const CustomType& rhs)
+{
+  return CustomType{lhs.key - rhs.key, lhs.value - rhs.value};
+}
+
+struct CustomDifference
+{
+  template <typename DataType>
+  __device__ DataType operator()(DataType &lhs, DataType &rhs)
+  {
+    return lhs - rhs;
+  }
+};
+
+
+template <typename DataType,
+          unsigned int ThreadsInBlock,
+          unsigned int ItemsPerThread,
+          bool ReadLeft = false>
+__global__ void LastTileTestKernel(const DataType *input,
+                                   DataType *output,
+                                   unsigned int valid_items)
+{
+  using BlockAdjacentDifferenceT =
+    cub::BlockAdjacentDifference<DataType, ThreadsInBlock>;
+
+  __shared__ typename BlockAdjacentDifferenceT::TempStorage temp_storage;
+
+  DataType thread_data[ItemsPerThread];
+  DataType thread_result[ItemsPerThread];
+
+  const unsigned int thread_offset = threadIdx.x * ItemsPerThread;
+
+  for (unsigned int item = 0; item < ItemsPerThread; item++)
+  {
+    thread_data[item] = input[thread_offset + item];
+  }
+  __syncthreads();
+
+  if (ReadLeft)
+  {
+    BlockAdjacentDifferenceT(temp_storage).SubtractLeftPartialTile(
+      thread_data,
+      thread_result,
+      CustomDifference(),
+      valid_items);
+  }
+  else
+  {
+    BlockAdjacentDifferenceT(temp_storage).SubtractRightPartialTile(
+      thread_data,
+      thread_result,
+      CustomDifference(),
+      valid_items);
+  }
+
+  for (unsigned int item = 0; item < ItemsPerThread; item++)
+  {
+    output[thread_offset + item] = thread_result[item];
+  }
+}
+
+
+template <typename DataType,
+          unsigned int ThreadsInBlock,
+          unsigned int ItemsPerThread,
+          bool ReadLeft = false>
+__global__ void MiddleTileTestKernel(const DataType *input,
+                                     DataType *output,
+                                     DataType neighbour_tile_value)
+{
+  using BlockAdjacentDifferenceT =
+    cub::BlockAdjacentDifference<DataType, ThreadsInBlock>;
+
+  __shared__ typename BlockAdjacentDifferenceT::TempStorage temp_storage;
+
+  DataType thread_data[ItemsPerThread];
+  DataType thread_result[ItemsPerThread];
+
+  const unsigned int thread_offset = threadIdx.x * ItemsPerThread;
+
+  for (unsigned int item = 0; item < ItemsPerThread; item++)
+  {
+    thread_data[item] = input[thread_offset + item];
+  }
+  __syncthreads();
+
+  if (ReadLeft)
+  {
+    BlockAdjacentDifferenceT(temp_storage)
+      .SubtractLeft(thread_data,
+                    thread_result,
+                    CustomDifference(),
+                    neighbour_tile_value);
+  }
+  else
+  {
+    BlockAdjacentDifferenceT(temp_storage)
+      .SubtractRight(thread_data,
+                     thread_result,
+                     CustomDifference(),
+                     neighbour_tile_value);
+  }
+
+  for (unsigned int item = 0; item < ItemsPerThread; item++)
+  {
+    output[thread_offset + item] = thread_result[item];
+  }
+}
+
+
+template <typename DataType,
+          unsigned int ThreadsInBlock,
+          unsigned int ItemsPerThread,
+          bool ReadLeft = false>
+__global__ void MiddleTileInplaceTestKernel(const DataType *input,
+                                            DataType *output,
+                                            DataType neighbour_tile_value)
+{
+  using BlockAdjacentDifferenceT =
+    cub::BlockAdjacentDifference<DataType, ThreadsInBlock>;
+
+  __shared__ typename BlockAdjacentDifferenceT::TempStorage temp_storage;
+
+  DataType thread_data[ItemsPerThread];
+
+  const unsigned int thread_offset = threadIdx.x * ItemsPerThread;
+
+  for (unsigned int item = 0; item < ItemsPerThread; item++)
+  {
+    thread_data[item] = input[thread_offset + item];
+  }
+  __syncthreads();
+
+  if (ReadLeft)
+  {
+    BlockAdjacentDifferenceT(temp_storage)
+      .SubtractLeft(thread_data,
+                    thread_data,
+                    CustomDifference(),
+                    neighbour_tile_value);
+  }
+  else
+  {
+    BlockAdjacentDifferenceT(temp_storage)
+      .SubtractRight(thread_data,
+                     thread_data,
+                     CustomDifference(),
+                     neighbour_tile_value);
+  }
+
+  for (unsigned int item = 0; item < ItemsPerThread; item++)
+  {
+    output[thread_offset + item] = thread_data[item];
+  }
+}
+
+
+template <typename DataType,
+          unsigned int ThreadsInBlock,
+          unsigned int ItemsPerThread,
+          bool ReadLeft = false>
+__global__ void TestKernel(DataType *data)
+{
+  using BlockAdjacentDifferenceT =
+    cub::BlockAdjacentDifference<DataType, ThreadsInBlock>;
+
+  __shared__ typename BlockAdjacentDifferenceT::TempStorage temp_storage;
+
+  DataType thread_data[ItemsPerThread];
+  DataType thread_result[ItemsPerThread];
+
+  const unsigned int thread_offset = threadIdx.x * ItemsPerThread;
+
+  for (unsigned int item = 0; item < ItemsPerThread; item++)
+  {
+    thread_data[item] = data[thread_offset + item];
+  }
+  __syncthreads();
+
+  if (ReadLeft)
+  {
+    BlockAdjacentDifferenceT(temp_storage)
+      .SubtractLeft(thread_data, thread_result, CustomDifference());
+  }
+  else
+  {
+    BlockAdjacentDifferenceT(temp_storage)
+      .SubtractRight(thread_data, thread_result, CustomDifference());
+  }
+
+  for (unsigned int item = 0; item < ItemsPerThread; item++)
+  {
+    data[thread_offset + item] = thread_result[item];
+  }
+}
+
+
+template <typename DataType,
+          unsigned int ThreadsInBlock,
+          unsigned int ItemsPerThread,
+          bool ReadLeft = false>
+__global__ void LastTileTestInplaceKernel(const DataType *input,
+                                          DataType *output,
+                                          unsigned int valid_items)
+{
+  using BlockAdjacentDifferenceT =
+    cub::BlockAdjacentDifference<DataType, ThreadsInBlock>;
+
+  __shared__ typename BlockAdjacentDifferenceT::TempStorage temp_storage;
+
+  DataType thread_data[ItemsPerThread];
+
+  const unsigned int thread_offset = threadIdx.x * ItemsPerThread;
+
+  for (unsigned int item = 0; item < ItemsPerThread; item++)
+  {
+    thread_data[item] = input[thread_offset + item];
+  }
+  __syncthreads();
+
+  if (ReadLeft)
+  {
+    BlockAdjacentDifferenceT(temp_storage)
+      .SubtractLeftPartialTile(thread_data,
+                               thread_data,
+                               CustomDifference(),
+                               valid_items);
+  }
+  else
+  {
+    BlockAdjacentDifferenceT(temp_storage)
+      .SubtractRightPartialTile(thread_data,
+                                thread_data,
+                                CustomDifference(),
+                                valid_items);
+  }
+
+  for (unsigned int item = 0; item < ItemsPerThread; item++)
+  {
+    output[thread_offset + item] = thread_data[item];
+  }
+}
+
+template <typename DataType,
+          unsigned int ThreadsInBlock,
+          unsigned int ItemsPerThread,
+          bool ReadLeft = false>
+__global__ void TestInplaceKernel(DataType *data)
+{
+  using BlockAdjacentDifferenceT =
+    cub::BlockAdjacentDifference<DataType, ThreadsInBlock>;
+
+  __shared__ typename BlockAdjacentDifferenceT::TempStorage temp_storage;
+
+  DataType thread_data[ItemsPerThread];
+
+  const unsigned int thread_offset = threadIdx.x * ItemsPerThread;
+
+  for (unsigned int item = 0; item < ItemsPerThread; item++)
+  {
+    thread_data[item] = data[thread_offset + item];
+  }
+  __syncthreads();
+
+  if (ReadLeft)
+  {
+    BlockAdjacentDifferenceT(temp_storage)
+      .SubtractLeft(thread_data,
+                    thread_data,
+                    CustomDifference());
+  }
+  else
+  {
+    BlockAdjacentDifferenceT(temp_storage)
+      .SubtractRight(thread_data,
+                     thread_data,
+                     CustomDifference());
+  }
+
+  for (unsigned int item = 0; item < ItemsPerThread; item++)
+  {
+    data[thread_offset + item] = thread_data[item];
+  }
+}
+
+template <typename DataType,
+          unsigned int ItemsPerThread,
+          unsigned int ThreadsInBlock,
+          bool ReadLeft = false>
+void LastTileTest(const DataType *input,
+                  DataType *output,
+                  unsigned int valid_items)
+{
+  LastTileTestKernel<DataType, ThreadsInBlock, ItemsPerThread, ReadLeft>
+    <<<1, ThreadsInBlock>>>(input, output, valid_items);
+
+  CubDebugExit(cudaPeekAtLastError());
+  CubDebugExit(cudaDeviceSynchronize());
+}
+
+
+template <typename DataType,
+          unsigned int ItemsPerThread,
+          unsigned int ThreadsInBlock,
+          bool ReadLeft = false>
+void Test(DataType *data)
+{
+  TestKernel<DataType, ThreadsInBlock, ItemsPerThread, ReadLeft>
+    <<<1, ThreadsInBlock>>>(data);
+
+  CubDebugExit(cudaPeekAtLastError());
+  CubDebugExit(cudaDeviceSynchronize());
+}
+
+
+template <typename DataType,
+          unsigned int ItemsPerThread,
+          unsigned int ThreadsInBlock,
+          bool ReadLeft = false>
+void MiddleTileTest(const DataType *input,
+                    DataType *output,
+                    DataType neighbour_tile_value)
+{
+  MiddleTileTestKernel<DataType, ThreadsInBlock, ItemsPerThread, ReadLeft>
+    <<<1, ThreadsInBlock>>>(input, output, neighbour_tile_value);
+
+  CubDebugExit(cudaPeekAtLastError());
+  CubDebugExit(cudaDeviceSynchronize());
+}
+
+
+template <typename DataType,
+          unsigned int ItemsPerThread,
+          unsigned int ThreadsInBlock,
+          bool ReadLeft = false>
+void LastTileInplaceTest(const DataType *input,
+                         DataType *output,
+                         unsigned int valid_items)
+{
+  LastTileTestInplaceKernel<DataType, ThreadsInBlock, ItemsPerThread, ReadLeft>
+    <<<1, ThreadsInBlock>>>(input, output, valid_items);
+
+  CubDebugExit(cudaPeekAtLastError());
+  CubDebugExit(cudaDeviceSynchronize());
+}
+
+
+template <typename DataType,
+          unsigned int ItemsPerThread,
+          unsigned int ThreadsInBlock,
+          bool ReadLeft = false>
+void InplaceTest(DataType *data)
+{
+  TestInplaceKernel<DataType, ThreadsInBlock, ItemsPerThread, ReadLeft>
+    <<<1, ThreadsInBlock>>>(data);
+
+  CubDebugExit(cudaPeekAtLastError());
+  CubDebugExit(cudaDeviceSynchronize());
+}
+
+
+template <typename DataType,
+          unsigned int ItemsPerThread,
+          unsigned int ThreadsInBlock,
+          bool ReadLeft = false>
+void MiddleTileInplaceTest(const DataType *input,
+                           DataType *output,
+                           DataType neighbour_tile_value)
+{
+  MiddleTileInplaceTestKernel<DataType, ThreadsInBlock, ItemsPerThread, ReadLeft>
+    <<<1, ThreadsInBlock>>>(input, output, neighbour_tile_value);
+
+  CubDebugExit(cudaPeekAtLastError());
+  CubDebugExit(cudaDeviceSynchronize());
+}
+
+
+template <typename FirstIteratorT,
+          typename SecondOperatorT>
+bool CheckResult(FirstIteratorT first_begin,
+                 FirstIteratorT first_end,
+                 SecondOperatorT second_begin)
+{
+  auto err = thrust::mismatch(first_begin, first_end, second_begin);
+
+  if (err.first != first_end)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+
+template <typename DataType,
+          unsigned int ItemsPerThread,
+          unsigned int ThreadsInBlock>
+void TestLastTile(bool inplace,
+                  unsigned int num_items,
+                  thrust::device_vector<DataType> &d_input)
+{
+  thrust::tabulate(d_input.begin(),
+                   d_input.end(),
+                   TestSequenceGenerator<DataType>{});
+  thrust::device_vector<DataType> d_output(d_input.size());
+
+  constexpr bool read_left = true;
+  constexpr bool read_right = false;
+
+  DataType *d_input_ptr = thrust::raw_pointer_cast(d_input.data());
+  DataType *d_output_ptr = thrust::raw_pointer_cast(d_output.data());
+
+  if (inplace)
+  {
+    LastTileInplaceTest<DataType, ItemsPerThread, ThreadsInBlock, read_left>(
+      d_input_ptr,
+      d_output_ptr,
+      num_items);
+  }
+  else
+  {
+    LastTileTest<DataType, ItemsPerThread, ThreadsInBlock, read_left>(
+      d_input_ptr,
+      d_output_ptr,
+      num_items);
+  }
+
+  {
+    using CountingIteratorT =
+      typename thrust::counting_iterator<DataType,
+        thrust::use_default,
+        std::size_t,
+        std::size_t>;
+
+    AssertEquals(d_output.front(), d_input.front());
+    AssertTrue(CheckResult(d_output.begin() + 1,
+                           d_output.begin() + num_items,
+                           CountingIteratorT(DataType{0})));
+    AssertTrue(CheckResult(d_output.begin() + num_items,
+                           d_output.end(),
+                           d_input.begin() + num_items));
+  }
+
+
+  thrust::tabulate(d_input.begin(),
+                   d_input.end(),
+                   TestSequenceGenerator<DataType>{});
+
+  if (inplace)
+  {
+    LastTileInplaceTest<DataType, ItemsPerThread, ThreadsInBlock, read_right>(
+      d_input_ptr,
+      d_output_ptr,
+      num_items);
+  }
+  else
+  {
+    LastTileTest<DataType, ItemsPerThread, ThreadsInBlock, read_right>(
+      d_input_ptr,
+      d_output_ptr,
+      num_items);
+  }
+
+  {
+    thrust::device_vector<DataType> reference(num_items);
+    thrust::sequence(reference.begin(),
+                     reference.end(),
+                     static_cast<DataType>(0),
+                     static_cast<DataType>(-1));
+
+    AssertTrue(CheckResult(d_output.begin(),
+                           d_output.begin() + num_items - 1,
+                           reference.begin()));
+    AssertTrue(CheckResult(d_output.begin() + num_items - 1,
+                           d_output.end(),
+                           d_input.begin() + num_items - 1));
+  }
+}
+
+
+template <typename DataType,
+          unsigned int ItemsPerThread,
+          unsigned int ThreadsInBlock>
+void TestMiddleTile(bool inplace,
+                    thrust::device_vector<DataType> &d_input)
+{
+  thrust::tabulate(d_input.begin(),
+                   d_input.end(),
+                   TestSequenceGenerator<DataType>{std::size_t{1}});
+  thrust::device_vector<DataType> d_output(d_input.size());
+
+  constexpr bool read_left  = true;
+  constexpr bool read_right = false;
+
+  DataType *d_input_ptr  = thrust::raw_pointer_cast(d_input.data());
+  DataType *d_output_ptr = thrust::raw_pointer_cast(d_output.data());
+
+  const DataType left_tile_last_value{0};
+  const DataType right_tile_first_value{
+    TestSequenceGenerator<DataType>{}(d_input.size())
+  };
+
+  if (inplace)
+  {
+    MiddleTileInplaceTest<DataType, ItemsPerThread, ThreadsInBlock, read_left>(
+      d_input_ptr,
+      d_output_ptr,
+      left_tile_last_value);
+  }
+  else
+  {
+    MiddleTileTest<DataType, ItemsPerThread, ThreadsInBlock, read_left>(
+      d_input_ptr,
+      d_output_ptr,
+      left_tile_last_value);
+  }
+
+  {
+    using CountingIteratorT =
+      typename thrust::counting_iterator<DataType,
+                                         thrust::use_default,
+                                         std::size_t,
+                                         std::size_t>;
+
+    AssertTrue(CheckResult(d_output.begin(),
+                           d_output.end(),
+                           CountingIteratorT(DataType{0})));
+  }
+
+  thrust::tabulate(d_input.begin(),
+                   d_input.end(),
+                   TestSequenceGenerator<DataType>{});
+
+  if (inplace)
+  {
+    MiddleTileInplaceTest<DataType, ItemsPerThread, ThreadsInBlock, read_right>(
+      d_input_ptr,
+      d_output_ptr,
+      right_tile_first_value);
+  }
+  else
+  {
+    MiddleTileTest<DataType, ItemsPerThread, ThreadsInBlock, read_right>(
+      d_input_ptr,
+      d_output_ptr,
+      right_tile_first_value);
+  }
+
+  {
+    thrust::device_vector<DataType> reference(d_input.size());
+    thrust::sequence(reference.begin(),
+                     reference.end(),
+                     static_cast<DataType>(0),
+                     static_cast<DataType>(-1));
+
+    AssertTrue(CheckResult(d_output.begin(),
+                           d_output.end(),
+                           reference.begin()));
+  }
+}
+
+
+struct IntToCustomType
+{
+  unsigned int offset;
+
+  IntToCustomType()
+      : offset(0)
+  {}
+
+  explicit IntToCustomType(unsigned int offset)
+      : offset(offset)
+  {}
+
+  __device__ __host__ CustomType operator()(unsigned int idx) const
+  {
+    return { idx + offset, idx + offset };
+  }
+};
+
+
+template <typename DataType,
+          unsigned int ItemsPerThread,
+          unsigned int ThreadsInBlock>
+void TestFullTile(bool inplace,
+                  thrust::device_vector<DataType> &d_data)
+{
+  thrust::tabulate(d_data.begin(),
+                   d_data.end(),
+                   TestSequenceGenerator<DataType>{});
+
+  constexpr bool read_left  = true;
+  constexpr bool read_right = false;
+
+  DataType *d_data_ptr = thrust::raw_pointer_cast(d_data.data());
+
+  if (inplace)
+  {
+    InplaceTest<DataType, ItemsPerThread, ThreadsInBlock, read_left>(
+      d_data_ptr);
+  }
+  else
+  {
+    Test<DataType, ItemsPerThread, ThreadsInBlock, read_left>(d_data_ptr);
+  }
+
+  {
+    using CountingIteratorT =
+    typename thrust::counting_iterator<DataType,
+      thrust::use_default,
+      std::size_t,
+      std::size_t>;
+
+    AssertEquals(d_data.front(), TestSequenceGenerator<DataType>{}(0));
+    AssertTrue(CheckResult(d_data.begin() + 1,
+                           d_data.end(),
+                           CountingIteratorT(DataType{0})));
+  }
+
+  thrust::tabulate(d_data.begin(),
+                   d_data.end(),
+                   TestSequenceGenerator<DataType>{});
+
+  if (inplace)
+  {
+    InplaceTest<DataType, ItemsPerThread, ThreadsInBlock, read_right>(
+      d_data_ptr);
+  }
+  else
+  {
+    Test<DataType, ItemsPerThread, ThreadsInBlock, read_right>(d_data_ptr);
+  }
+
+  {
+    thrust::device_vector<DataType> reference(d_data.size());
+    thrust::sequence(reference.begin(),
+                     reference.end(),
+                     static_cast<DataType>(0),
+                     static_cast<DataType>(-1));
+
+    AssertTrue(CheckResult(d_data.begin(),
+                           d_data.end() - 1,
+                           reference.begin()));
+    AssertEquals(d_data.back(),
+                 TestSequenceGenerator<DataType>{}(d_data.size() - 1));
+  }
+}
+
+
+template <unsigned int ItemsPerThread,
+          unsigned int ThreadsInBlock>
+void TestCustomType(bool inplace,
+                    thrust::device_vector<CustomType> &d_data)
+{
+  thrust::tabulate(d_data.begin(), d_data.end(), IntToCustomType{1});
+  CustomType *d_data_ptr = thrust::raw_pointer_cast(d_data.data());
+
+  constexpr bool read_left  = true;
+  constexpr bool read_right = false;
+
+  if (inplace)
+  {
+    InplaceTest<CustomType, ItemsPerThread, ThreadsInBlock, read_left>(
+      d_data_ptr);
+  }
+  else
+  {
+    Test<CustomType, ItemsPerThread, ThreadsInBlock, read_left>(d_data_ptr);
+  }
+
+  {
+    const std::size_t expected_count = d_data.size();
+    const std::size_t actual_count =
+      thrust::count(d_data.begin(), d_data.end(), CustomType{1, 1});
+
+    AssertEquals(expected_count, actual_count);
+  }
+
+  thrust::tabulate(d_data.begin(), d_data.end(), IntToCustomType{});
+
+  if (inplace)
+  {
+    InplaceTest<CustomType, ItemsPerThread, ThreadsInBlock, read_right>(
+      d_data_ptr);
+  }
+  else
+  {
+    Test<CustomType, ItemsPerThread, ThreadsInBlock, read_right>(d_data_ptr);
+  }
+
+  {
+    const auto unsigned_minus_one = static_cast<unsigned int>(-1);
+
+    const std::size_t expected_count = d_data.size() - 1;
+    const std::size_t actual_count =
+      thrust::count(d_data.begin(),
+                    d_data.end() - 1,
+                    CustomType{unsigned_minus_one, unsigned_minus_one});
+
+    AssertEquals(expected_count, actual_count);
+  }
+}
+
+
+template <
+  typename ValueType,
+  unsigned int ItemsPerThread,
+  unsigned int ThreadsInBlock>
+void Test(bool inplace)
+{
+  constexpr int tile_size = ItemsPerThread * ThreadsInBlock;
+  thrust::device_vector<ValueType> d_values(tile_size);
+
+  for (unsigned int num_items = tile_size; num_items > 1; num_items /= 2)
+  {
+    TestLastTile<ValueType, ItemsPerThread, ThreadsInBlock>(inplace,
+                                                            num_items,
+                                                            d_values);
+  }
+
+  TestFullTile<ValueType, ItemsPerThread, ThreadsInBlock>(inplace, d_values);
+  TestMiddleTile<ValueType, ItemsPerThread, ThreadsInBlock>(inplace, d_values);
+}
+
+
+template <unsigned int ItemsPerThread,
+          unsigned int ThreadsInBlock>
+void TestCustomType(bool inplace)
+{
+  constexpr int tile_size = ItemsPerThread * ThreadsInBlock;
+  thrust::device_vector<CustomType> d_values(tile_size);
+  TestCustomType<ItemsPerThread, ThreadsInBlock>(inplace, d_values);
+}
+
+
+template <unsigned int ItemsPerThread, unsigned int ThreadsPerBlock>
+void Test(bool inplace)
+{
+  Test<std::uint8_t,  ItemsPerThread, ThreadsPerBlock>(inplace);
+  Test<std::uint16_t, ItemsPerThread, ThreadsPerBlock>(inplace);
+  Test<std::uint32_t, ItemsPerThread, ThreadsPerBlock>(inplace);
+  Test<std::uint64_t, ItemsPerThread, ThreadsPerBlock>(inplace);
+}
+
+
+template <unsigned int ItemsPerThread>
+void Test(bool inplace)
+{
+  Test<ItemsPerThread, 32>(inplace);
+  Test<ItemsPerThread, 256>(inplace);
+}
+
+
+template <unsigned int ItemsPerThread>
+void Test()
+{
+  Test<ItemsPerThread>(false);
+  Test<ItemsPerThread>(true);
+}
+
+
+int main(int argc, char** argv)
+{
+  CommandLineArgs args(argc, argv);
+
+  // Initialize device
+  CubDebugExit(args.DeviceInit());
+
+  Test<1>();
+  Test<2>();
+  Test<10>();
+  Test<15>();
+
+  // More of a compilation check
+  TestCustomType<5, 256>(true);
+
+  return 0;
+}

--- a/test/test_device_adjacent_difference.cu
+++ b/test/test_device_adjacent_difference.cu
@@ -1,0 +1,645 @@
+/******************************************************************************
+ * Copyright (c) 2011-2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+// Ensure printing of CUDA runtime errors to console
+#define CUB_STDERR
+
+#include <cub/device/device_adjacent_difference.cuh>
+#include <cub/thread/thread_operators.cuh>
+#include <cub/util_allocator.cuh>
+
+#include <thrust/count.h>
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/random.h>
+#include <thrust/sequence.h>
+#include <thrust/shuffle.h>
+
+#include <limits>
+#include <memory>
+
+#include "test_util.h"
+
+
+using namespace cub;
+
+
+constexpr bool READ_LEFT = true;
+constexpr bool READ_RIGHT = false;
+
+
+/**
+ * \brief Generates integer sequence \f$S_n=i(i-1)/2\f$.
+ *
+ * The adjacent difference of this sequence produce consecutive numbers:
+ * \f[
+ *   p = \frac{i(i - 1)}{2} \\
+ *   n = \frac{(i + 1) i}{2} \\
+ *   n - p = i \\
+ *   \frac{(i + 1) i}{2} - \frac{i (i - 1)}{2} = i \\
+ *   (i + 1) i - i (i - 1) = 2 i \\
+ *   (i + 1) - (i - 1) = 2 \\
+ *   2 = 2
+ * \f]
+ */
+template <typename DestT>
+struct TestSequenceGenerator
+{
+  template <typename SourceT>
+  __device__ __host__ DestT operator()(SourceT index) const
+  {
+    return static_cast<DestT>(index * (index - 1) / SourceT(2));
+  }
+};
+
+
+template <typename OutputT>
+struct CustomDifference
+{
+  template <typename InputT>
+  __device__ OutputT operator()(const InputT &lhs, const InputT &rhs)
+  {
+    return static_cast<OutputT>(lhs - rhs);
+  }
+};
+
+template <bool ReadLeft,
+          typename IteratorT,
+          typename DifferenceOpT>
+void AdjacentDifference(void *temp_storage,
+                        std::size_t &temp_storage_bytes,
+                        IteratorT it,
+                        DifferenceOpT difference_op,
+                        std::size_t num_items)
+{
+  const bool is_default_op_in_use =
+    std::is_same<DifferenceOpT, cub::Difference>::value;
+
+  if (ReadLeft)
+  {
+    if (is_default_op_in_use)
+    {
+      CubDebugExit(
+        cub::DeviceAdjacentDifference::SubtractLeft(temp_storage,
+                                                    temp_storage_bytes,
+                                                    it,
+                                                    num_items));
+    }
+    else
+    {
+      CubDebugExit(
+        cub::DeviceAdjacentDifference::SubtractLeft(temp_storage,
+                                                    temp_storage_bytes,
+                                                    it,
+                                                    num_items,
+                                                    difference_op,
+                                                    0,
+                                                    true));
+    }
+  }
+  else
+  {
+    if (is_default_op_in_use)
+    {
+      CubDebugExit(
+        cub::DeviceAdjacentDifference::SubtractRight(temp_storage,
+                                                     temp_storage_bytes,
+                                                     it,
+                                                     num_items));
+    }
+    else
+    {
+      CubDebugExit(
+        cub::DeviceAdjacentDifference::SubtractRight(temp_storage,
+                                                     temp_storage_bytes,
+                                                     it,
+                                                     num_items,
+                                                     difference_op,
+                                                     0,
+                                                     true));
+    }
+  }
+}
+
+
+template <bool ReadLeft,
+          typename InputIteratorT,
+          typename OutputIteratorT,
+          typename DifferenceOpT>
+void AdjacentDifferenceCopy(void *temp_storage,
+                            std::size_t &temp_storage_bytes,
+                            InputIteratorT input,
+                            OutputIteratorT output,
+                            DifferenceOpT difference_op,
+                            std::size_t num_items)
+{
+  const bool is_default_op_in_use =
+    std::is_same<DifferenceOpT, cub::Difference>::value;
+
+  if (ReadLeft)
+  {
+    if (is_default_op_in_use)
+    {
+      CubDebugExit(
+        cub::DeviceAdjacentDifference::SubtractLeftCopy(temp_storage,
+                                                        temp_storage_bytes,
+                                                        input,
+                                                        output,
+                                                        num_items));
+    }
+    else
+    {
+      CubDebugExit(
+        cub::DeviceAdjacentDifference::SubtractLeftCopy(temp_storage,
+                                                        temp_storage_bytes,
+                                                        input,
+                                                        output,
+                                                        num_items,
+                                                        difference_op,
+                                                        0,
+                                                        true));
+    }
+  }
+  else
+  {
+    if (is_default_op_in_use)
+    {
+      CubDebugExit(
+        cub::DeviceAdjacentDifference::SubtractRightCopy(temp_storage,
+                                                         temp_storage_bytes,
+                                                         input,
+                                                         output,
+                                                         num_items));
+    }
+    else
+    {
+      CubDebugExit(
+        cub::DeviceAdjacentDifference::SubtractRightCopy(temp_storage,
+                                                         temp_storage_bytes,
+                                                         input,
+                                                         output,
+                                                         num_items,
+                                                         difference_op,
+                                                         0,
+                                                         true));
+    }
+  }
+}
+
+template <bool ReadLeft,
+          typename IteratorT,
+          typename DifferenceOpT>
+void AdjacentDifference(IteratorT it,
+                        DifferenceOpT difference_op,
+                        std::size_t num_items)
+{
+  std::size_t temp_storage_bytes {};
+
+  AdjacentDifference<ReadLeft>(nullptr,
+                               temp_storage_bytes,
+                               it,
+                               difference_op,
+                               num_items);
+
+  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  AdjacentDifference<ReadLeft>(thrust::raw_pointer_cast(temp_storage.data()),
+                               temp_storage_bytes,
+                               it,
+                               difference_op,
+                               num_items);
+}
+
+
+template <bool ReadLeft,
+          typename InputIteratorT,
+          typename OutputIteratorT,
+          typename DifferenceOpT>
+void AdjacentDifferenceCopy(InputIteratorT input,
+                            OutputIteratorT output,
+                            DifferenceOpT difference_op,
+                            std::size_t num_items)
+{
+  std::size_t temp_storage_bytes{};
+
+  AdjacentDifferenceCopy<ReadLeft>(nullptr,
+                                   temp_storage_bytes,
+                                   input,
+                                   output,
+                                   difference_op,
+                                   num_items);
+
+  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  AdjacentDifferenceCopy<ReadLeft>(thrust::raw_pointer_cast(
+                                     temp_storage.data()),
+                                   temp_storage_bytes,
+                                   input,
+                                   output,
+                                   difference_op,
+                                   num_items);
+}
+
+template <typename FirstIteratorT,
+          typename SecondOperatorT>
+bool CheckResult(FirstIteratorT first_begin,
+                 FirstIteratorT first_end,
+                 SecondOperatorT second_begin)
+{
+  auto err = thrust::mismatch(first_begin, first_end, second_begin);
+
+  if (err.first != first_end)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+
+template <typename InputT,
+          typename OutputT,
+          typename DifferenceOpT>
+void TestCopy(std::size_t elements, DifferenceOpT difference_op)
+{
+  thrust::device_vector<InputT> input(elements);
+  thrust::tabulate(input.begin(),
+                   input.end(),
+                   TestSequenceGenerator<InputT>{});
+
+  thrust::device_vector<OutputT> output(elements, OutputT{42});
+
+  InputT *d_input = thrust::raw_pointer_cast(input.data());
+  OutputT *d_output = thrust::raw_pointer_cast(output.data());
+
+  using CountingIteratorT =
+    typename thrust::counting_iterator<OutputT,
+                                       thrust::use_default,
+                                       std::size_t,
+                                       std::size_t>;
+
+  AdjacentDifferenceCopy<READ_LEFT>(d_input,
+                                    d_output,
+                                    difference_op,
+                                    elements);
+
+  AssertTrue(CheckResult(output.begin() + 1,
+                         output.end(),
+                         CountingIteratorT(OutputT{0})));
+
+  thrust::fill(output.begin(), output.end(), OutputT{42});
+
+  AdjacentDifferenceCopy<READ_RIGHT>(d_input,
+                                     d_output,
+                                     difference_op,
+                                     elements);
+
+  thrust::device_vector<OutputT> reference(input.size());
+  thrust::sequence(reference.begin(),
+                   reference.end(),
+                   static_cast<OutputT>(0),
+                   static_cast<OutputT>(-1));
+  AssertTrue(CheckResult(output.begin(),
+                         output.end() - 1,
+                         reference.begin()));
+}
+
+
+template <typename InputT,
+          typename OutputT,
+          typename DifferenceOpT>
+void TestIteratorCopy(std::size_t elements, DifferenceOpT difference_op)
+{
+  thrust::device_vector<InputT> input(elements);
+  thrust::tabulate(input.begin(),
+                   input.end(),
+                   TestSequenceGenerator<InputT>{});
+
+  thrust::device_vector<OutputT> output(elements, OutputT{42});
+
+  using CountingIteratorT =
+  typename thrust::counting_iterator<OutputT,
+    thrust::use_default,
+    std::size_t,
+    std::size_t>;
+
+  AdjacentDifferenceCopy<READ_LEFT>(input.cbegin(),
+                                    output.begin(),
+                                    difference_op,
+                                    elements);
+
+  AssertTrue(CheckResult(output.begin() + 1,
+                         output.end(),
+                         CountingIteratorT(OutputT{0})));
+
+  thrust::fill(output.begin(), output.end(), OutputT{42});
+
+  AdjacentDifferenceCopy<READ_RIGHT>(input.cbegin(),
+                                     output.begin(),
+                                     difference_op,
+                                     elements);
+
+  thrust::device_vector<OutputT> reference(input.size());
+  thrust::sequence(reference.begin(),
+                   reference.end(),
+                   static_cast<OutputT>(0),
+                   static_cast<OutputT>(-1));
+  AssertTrue(CheckResult(output.begin(),
+                         output.end() - 1,
+                         reference.begin()));
+}
+
+
+template <typename InputT,
+          typename OutputT>
+void TestCopy(std::size_t elements)
+{
+  TestCopy<InputT, OutputT>(elements, cub::Difference{});
+  TestCopy<InputT, OutputT>(elements, CustomDifference<OutputT>{});
+
+  TestIteratorCopy<InputT, OutputT>(elements, cub::Difference{});
+  TestIteratorCopy<InputT, OutputT>(elements, CustomDifference<OutputT>{});
+}
+
+
+void TestCopy(std::size_t elements)
+{
+  TestCopy<std::uint64_t, std::int64_t >(elements);
+  TestCopy<std::uint32_t, std::int32_t>(elements);
+}
+
+
+template <typename T,
+          typename DifferenceOpT>
+void Test(std::size_t elements, DifferenceOpT difference_op)
+{
+  thrust::device_vector<T> data(elements);
+  thrust::tabulate(data.begin(),
+                   data.end(),
+                   TestSequenceGenerator<T>{});
+
+  T *d_data = thrust::raw_pointer_cast(data.data());
+
+  using CountingIteratorT =
+    typename thrust::counting_iterator<T,
+      thrust::use_default,
+      std::size_t,
+      std::size_t>;
+
+  AdjacentDifference<READ_LEFT>(d_data,
+                                difference_op,
+                                elements);
+
+  AssertTrue(CheckResult(data.begin() + 1,
+                         data.end(),
+                         CountingIteratorT(T{0})));
+
+
+  thrust::tabulate(data.begin(),
+                   data.end(),
+                   TestSequenceGenerator<T>{});
+
+  AdjacentDifference<READ_RIGHT>(d_data,
+                                 difference_op,
+                                 elements);
+
+  thrust::device_vector<T> reference(data.size());
+  thrust::sequence(reference.begin(),
+                   reference.end(),
+                   static_cast<T>(0),
+                   static_cast<T>(-1));
+  AssertTrue(CheckResult(data.begin(),
+                         data.end() - 1,
+                         reference.begin()));
+}
+
+
+template <typename T,
+          typename DifferenceOpT>
+void TestIterators(std::size_t elements, DifferenceOpT difference_op)
+{
+  thrust::device_vector<T> data(elements);
+  thrust::tabulate(data.begin(),
+                   data.end(),
+                   TestSequenceGenerator<T>{});
+
+  using CountingIteratorT =
+  typename thrust::counting_iterator<T,
+    thrust::use_default,
+    std::size_t,
+    std::size_t>;
+
+  AdjacentDifference<READ_LEFT>(data.begin(),
+                                difference_op,
+                                elements);
+
+  AssertTrue(CheckResult(data.begin() + 1,
+                         data.end(),
+                         CountingIteratorT(T{0})));
+
+
+  thrust::tabulate(data.begin(),
+                   data.end(),
+                   TestSequenceGenerator<T>{});
+
+  AdjacentDifference<READ_RIGHT>(data.begin(),
+                                 difference_op,
+                                 elements);
+
+  thrust::device_vector<T> reference(data.size());
+  thrust::sequence(reference.begin(),
+                   reference.end(),
+                   static_cast<T>(0),
+                   static_cast<T>(-1));
+
+  AssertTrue(CheckResult(data.begin(), data.end() - 1, reference.begin()));
+}
+
+
+template <typename T>
+void Test(std::size_t elements)
+{
+  Test<T>(elements, cub::Difference{});
+  Test<T>(elements, CustomDifference<T>{});
+
+  TestIterators<T>(elements, cub::Difference{});
+  TestIterators<T>(elements, CustomDifference<T>{});
+}
+
+
+void Test(std::size_t elements)
+{
+  Test<std::int32_t>(elements);
+  Test<std::uint32_t>(elements);
+  Test<std::uint64_t>(elements);
+}
+
+
+template <typename ValueT>
+void TestFancyIterators(std::size_t elements)
+{
+  thrust::counting_iterator<ValueT> count_iter(ValueT{1});
+  thrust::device_vector<ValueT> output(elements, ValueT{42});
+
+  AdjacentDifferenceCopy<READ_LEFT>(count_iter,
+                                    output.begin(),
+                                    cub::Difference{},
+                                    elements);
+  AssertEquals(elements,
+               static_cast<std::size_t>(
+                 thrust::count(output.begin(), output.end(), ValueT(1))));
+
+  thrust::fill(output.begin(), output.end(), ValueT{});
+  AdjacentDifferenceCopy<READ_RIGHT>(count_iter,
+                                     output.begin(),
+                                     cub::Difference{},
+                                     elements);
+  AssertEquals(elements - 1,
+               static_cast<std::size_t>(
+                 thrust::count(output.begin(),
+                               output.end() - 1,
+                               static_cast<ValueT>(-1))));
+  AssertEquals(output.back(), static_cast<ValueT>(elements));
+
+  thrust::constant_iterator<ValueT> const_iter(ValueT{});
+
+  AdjacentDifferenceCopy<READ_LEFT>(const_iter,
+                                    output.begin(),
+                                    cub::Difference{},
+                                    elements);
+  AssertEquals(elements,
+               static_cast<std::size_t>(
+                 thrust::count(output.begin(), output.end(), ValueT{})));
+
+  thrust::fill(output.begin(), output.end(), ValueT{});
+  AdjacentDifferenceCopy<READ_RIGHT>(const_iter,
+                                     output.begin(),
+                                     cub::Difference{},
+                                     elements);
+  AssertEquals(elements,
+               static_cast<std::size_t>(
+                 thrust::count(output.begin(), output.end(), ValueT{})));
+
+  AdjacentDifferenceCopy<READ_LEFT>(const_iter,
+                                    thrust::make_discard_iterator(),
+                                    cub::Difference{},
+                                    elements);
+
+  AdjacentDifferenceCopy<READ_RIGHT>(const_iter,
+                                     thrust::make_discard_iterator(),
+                                     cub::Difference{},
+                                     elements);
+}
+
+
+void TestFancyIterators(std::size_t elements)
+{
+  TestFancyIterators<std::uint64_t>(elements);
+}
+
+
+void TestSize(std::size_t elements)
+{
+  Test(elements);
+  TestCopy(elements);
+  TestFancyIterators(elements);
+}
+
+struct DetectWrongDifference
+{
+  bool *flag;
+
+  __host__ __device__ DetectWrongDifference operator++() const
+  {
+    return *this;
+  }
+  __host__ __device__ DetectWrongDifference operator*() const
+  {
+    return *this;
+  }
+  template <typename Difference>
+  __host__ __device__ DetectWrongDifference operator+(Difference) const
+  {
+    return *this;
+  }
+  template <typename Index>
+  __host__ __device__ DetectWrongDifference operator[](Index) const
+  {
+    return *this;
+  }
+
+  __device__ void operator=(long long difference) const
+  {
+    if (difference != 1)
+    {
+      *flag = false;
+    }
+  }
+};
+
+void TestAdjacentDifferenceWithBigIndexesHelper(int magnitude)
+{
+  const std::size_t elements = 1ll << magnitude;
+
+  thrust::device_vector<bool> all_differences_correct(1, true);
+
+  thrust::counting_iterator<long long> in(1);
+
+  DetectWrongDifference out = {
+    thrust::raw_pointer_cast(all_differences_correct.data())
+  };
+
+  AdjacentDifferenceCopy<READ_LEFT>(in, out, cub::Difference{}, elements);
+  AssertEquals(all_differences_correct.front(), true);
+}
+
+
+void TestAdjacentDifferenceWithBigIndexes()
+{
+  TestAdjacentDifferenceWithBigIndexesHelper(30);
+  TestAdjacentDifferenceWithBigIndexesHelper(31);
+  TestAdjacentDifferenceWithBigIndexesHelper(32);
+  TestAdjacentDifferenceWithBigIndexesHelper(33);
+}
+
+
+int main(int argc, char** argv)
+{
+  CommandLineArgs args(argc, argv);
+
+  // Initialize device
+  CubDebugExit(args.DeviceInit());
+
+  Test(0);
+  for (std::size_t power_of_two = 2; power_of_two < 20; power_of_two += 2)
+  {
+    Test(1ull << power_of_two);
+  }
+  TestAdjacentDifferenceWithBigIndexes();
+
+  return 0;
+}


### PR DESCRIPTION
The PR contains:

1. a port of `thrust::adjacent_difference` algorithm;
2. deprecation of `FlagHeads` and `FlagTails` methods from `BlockAdjacentDifference` structure;
3. fixed API for `BlockAdjacentDifference` along with documentation and tests.

Note that the PR is based on some of the features introduced in `MergeSort` porting. 