### PR TITLE
64-bit Offsets in DeviceRadixSort

### DIFF
--- a/cub/agent/agent_radix_sort_histogram.cuh
+++ b/cub/agent/agent_radix_sort_histogram.cuh
@@ -38,6 +38,7 @@
 #include "../block/radix_rank_sort_operations.cuh"
 #include "../config.cuh"
 #include "../thread/thread_reduce.cuh"
+#include "../util_math.cuh"
 #include "../util_type.cuh"
 
 
@@ -97,12 +98,13 @@ struct AgentRadixSortHistogram
     };
 
     typedef RadixSortTwiddle<IS_DESCENDING, KeyT> Twiddle;
-    typedef OffsetT ShmemAtomicOffsetT;
+    typedef std::uint32_t ShmemCounterT;
+    typedef ShmemCounterT ShmemAtomicCounterT;
     typedef typename Traits<KeyT>::UnsignedBits UnsignedBits;
 
     struct _TempStorage
     {
-        ShmemAtomicOffsetT bins[MAX_NUM_PASSES][RADIX_DIGITS][NUM_PARTS];
+        ShmemAtomicCounterT bins[MAX_NUM_PASSES][RADIX_DIGITS][NUM_PARTS];
     };
 
     struct TempStorage : Uninitialized<_TempStorage> {};
@@ -133,8 +135,11 @@ struct AgentRadixSortHistogram
           d_keys_in(reinterpret_cast<const UnsignedBits*>(d_keys_in)),
           num_items(num_items), begin_bit(begin_bit), end_bit(end_bit),
           num_passes((end_bit - begin_bit + RADIX_BITS - 1) / RADIX_BITS)
+    {}
+
+    __device__ __forceinline__ void Init()
     {
-        // init bins
+        // Initialize bins to 0.
         #pragma unroll
         for (int bin = threadIdx.x; bin < RADIX_DIGITS; bin += BLOCK_THREADS)
         {
@@ -219,17 +224,33 @@ struct AgentRadixSortHistogram
 
     __device__ __forceinline__ void Process()
     {
-        for (OffsetT tile_offset = blockIdx.x * TILE_ITEMS; tile_offset < num_items;
-             tile_offset += TILE_ITEMS * gridDim.x)
+        // Within a portion, avoid overflowing (u)int32 counters.
+        // Between portions, accumulate results in global memory.
+        const OffsetT MAX_PORTION_SIZE = 1 << 30;
+        OffsetT num_portions = cub::DivideAndRoundUp(num_items, MAX_PORTION_SIZE);
+        for (OffsetT portion = 0; portion < num_portions; ++portion)
         {
-            UnsignedBits keys[ITEMS_PER_THREAD];
-            LoadTileKeys(tile_offset, keys);
-            AccumulateSharedHistograms(tile_offset, keys);
-        }
-        CTA_SYNC();
+            // Reset the counters.
+            Init();
+            CTA_SYNC();
 
-        // accumulate in global memory
-        AccumulateGlobalHistograms();
+            // Process the tiles.
+            OffsetT portion_offset = portion * MAX_PORTION_SIZE;
+            OffsetT portion_end =
+                portion_offset + CUB_MIN(MAX_PORTION_SIZE, num_items - portion_offset);
+            for (OffsetT tile_offset = portion_offset + blockIdx.x * TILE_ITEMS;
+                 tile_offset < portion_end; tile_offset += TILE_ITEMS * gridDim.x)
+            {
+                UnsignedBits keys[ITEMS_PER_THREAD];
+                LoadTileKeys(tile_offset, keys);
+                AccumulateSharedHistograms(tile_offset, keys);
+            }
+            CTA_SYNC();
+            
+            // Accumulate the result in global memory.
+            AccumulateGlobalHistograms();
+            CTA_SYNC();
+        }
     }
 };
 

--- a/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/agent/agent_radix_sort_onesweep.cuh
@@ -92,7 +92,8 @@ template <
     bool IS_DESCENDING,
     typename KeyT,
     typename ValueT,
-    typename OffsetT>
+    typename OffsetT,
+    typename PortionOffsetT>
 struct AgentRadixSortOnesweep
 {
     // constants
@@ -110,14 +111,14 @@ struct AgentRadixSortOnesweep
         WARP_THREADS = CUB_PTX_WARP_THREADS,
         BLOCK_WARPS = BLOCK_THREADS / WARP_THREADS,
         WARP_MASK = ~0,
-        LOOKBACK_PARTIAL_MASK = 1 << (OffsetT(sizeof(OffsetT)) * 8 - 2),
-        LOOKBACK_GLOBAL_MASK = 1 << (OffsetT(sizeof(OffsetT)) * 8 - 1),
+        LOOKBACK_PARTIAL_MASK = 1 << (PortionOffsetT(sizeof(PortionOffsetT)) * 8 - 2),
+        LOOKBACK_GLOBAL_MASK = 1 << (PortionOffsetT(sizeof(PortionOffsetT)) * 8 - 1),
         LOOKBACK_KIND_MASK = LOOKBACK_PARTIAL_MASK | LOOKBACK_GLOBAL_MASK,
         LOOKBACK_VALUE_MASK = ~LOOKBACK_KIND_MASK,
     };
 
     typedef typename Traits<KeyT>::UnsignedBits UnsignedBits;
-    typedef OffsetT AtomicOffsetT;
+    typedef PortionOffsetT AtomicOffsetT;
   
     static const RadixRankAlgorithm RANK_ALGORITHM =
                                     AgentRadixSortOnesweepPolicy::RANK_ALGORITHM;
@@ -165,7 +166,7 @@ struct AgentRadixSortOnesweep
         union
         {
             OffsetT global_offsets[RADIX_DIGITS];
-            OffsetT block_idx;
+            PortionOffsetT block_idx;
         };
     };
 
@@ -183,13 +184,13 @@ struct AgentRadixSortOnesweep
     const UnsignedBits* d_keys_in;
     ValueT* d_values_out;
     const ValueT* d_values_in;
-    OffsetT num_items;
+    PortionOffsetT num_items;
     ShiftDigitExtractor<KeyT> digit_extractor;
 
     // other thread variables
     int warp;
     int lane;
-    OffsetT block_idx;
+    PortionOffsetT block_idx;
     bool full_block;
 
     // helper methods
@@ -213,7 +214,7 @@ struct AgentRadixSortOnesweep
             {
                 // write the local sum into the bin
                 AtomicOffsetT& loc = d_lookback[block_idx * RADIX_DIGITS + bin];
-                OffsetT value = bins[u] | LOOKBACK_PARTIAL_MASK;
+                PortionOffsetT value = bins[u] | LOOKBACK_PARTIAL_MASK;
                 ThreadStore<STORE_VOLATILE>(&loc, value);
             }
         }
@@ -222,7 +223,7 @@ struct AgentRadixSortOnesweep
     struct CountsCallback
     {
         typedef AgentRadixSortOnesweep<AgentRadixSortOnesweepPolicy, IS_DESCENDING, KeyT,
-                                       ValueT, OffsetT> AgentT;
+                                       ValueT, OffsetT, PortionOffsetT> AgentT;
         AgentT& agent;
         int (&bins)[BINS_PER_THREAD];
         UnsignedBits (&keys)[ITEMS_PER_THREAD];
@@ -251,13 +252,13 @@ struct AgentRadixSortOnesweep
             int bin = ThreadBin(u);
             if (FULL_BINS || bin < RADIX_DIGITS)
             {
-                OffsetT inc_sum = bins[u];
+                PortionOffsetT inc_sum = bins[u];
                 int want_mask = ~0;
                 // backtrack as long as necessary
-                for (OffsetT block_jdx = block_idx - 1; block_jdx >= 0; --block_jdx)
+                for (PortionOffsetT block_jdx = block_idx - 1; block_jdx >= 0; --block_jdx)
                 {
                     // wait for some value to appear
-                    OffsetT value_j = 0;
+                    PortionOffsetT value_j = 0;
                     AtomicOffsetT& loc_j = d_lookback[block_jdx * RADIX_DIGITS + bin];
                     do {
                         __threadfence_block(); // prevent hoisting loads from loop
@@ -269,7 +270,7 @@ struct AgentRadixSortOnesweep
                     if (value_j & LOOKBACK_GLOBAL_MASK) break;
                 }
                 AtomicOffsetT& loc_i = d_lookback[block_idx * RADIX_DIGITS + bin];
-                OffsetT value_i = inc_sum | LOOKBACK_GLOBAL_MASK;
+                PortionOffsetT value_i = inc_sum | LOOKBACK_GLOBAL_MASK;
                 ThreadStore<STORE_VOLATILE>(&loc_i, value_i);
                 s.global_offsets[bin] += inc_sum - bins[u];
             }
@@ -638,7 +639,7 @@ struct AgentRadixSortOnesweep
                            const KeyT *d_keys_in,
                            ValueT *d_values_out,
                            const ValueT *d_values_in,
-                           OffsetT num_items,
+                           PortionOffsetT num_items,
                            int current_bit,
                            int num_bits)
         : s(temp_storage.Alias())

--- a/cub/device/device_radix_sort.cuh
+++ b/cub/device/device_radix_sort.cuh
@@ -36,12 +36,29 @@
 
 #include <stdio.h>
 #include <iterator>
+#include <type_traits>
 
 #include "dispatch/dispatch_radix_sort.cuh"
 #include "../config.cuh"
 
 CUB_NAMESPACE_BEGIN
 
+namespace detail {
+/** ChooseOffsetT checks NumItemsT, the type of the num_items parameter, and
+ * selects the offset type based on it. */
+template <typename NumItemsT>
+struct ChooseOffsetT
+{
+    // NumItemsT must be an integral type (but not bool).
+    static_assert(std::is_integral<NumItemsT>::value &&
+                  !std::is_same<typename std::remove_cv<NumItemsT>::type, bool>::value,
+                  "NumItemsT must be an integral type, but not bool");
+
+    // Unsigned integer type for global offsets.
+    using Type = typename std::conditional<sizeof(NumItemsT) <= 4, uint32_t, unsigned long long>::type;
+};
+
+}  // namespace detail
 
 /**
  * \brief DeviceRadixSort provides device-wide, parallel operations for computing a radix sort across a sequence of data items residing within device-accessible memory. ![](sorting_logo.png)
@@ -181,10 +198,12 @@ struct DeviceRadixSort
      *
      * \tparam KeyT      <b>[inferred]</b> KeyT type
      * \tparam ValueT    <b>[inferred]</b> ValueT type
+     * \tparam NumItemsT <b>[inferred]</b> Type of num_items
      */
     template <
         typename            KeyT,
-        typename            ValueT>
+        typename            ValueT,
+        typename            NumItemsT>
     CUB_RUNTIME_FUNCTION
     static cudaError_t SortPairs(
         void                *d_temp_storage,                        ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
@@ -193,15 +212,15 @@ struct DeviceRadixSort
         KeyT                *d_keys_out,                            ///< [out] Pointer to the sorted output sequence of key data
         const ValueT        *d_values_in,                           ///< [in] Pointer to the corresponding input sequence of associated value items
         ValueT              *d_values_out,                          ///< [out] Pointer to the correspondingly-reordered output sequence of associated value items
-        int                 num_items,                              ///< [in] Number of items to sort
+        NumItemsT           num_items,                              ///< [in] Number of items to sort
         int                 begin_bit           = 0,                ///< [in] <b>[optional]</b> The least-significant bit index (inclusive)  needed for key comparison
         int                 end_bit             = sizeof(KeyT) * 8, ///< [in] <b>[optional]</b> The most-significant bit index (exclusive) needed for key comparison (e.g., sizeof(unsigned int) * 8)
         cudaStream_t        stream              = 0,                ///< [in] <b>[optional]</b> CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
         bool                debug_synchronous   = false)            ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
-        // Signed integer type for global offsets
-        typedef int OffsetT;
-
+        // Unsigned integer type for global offsets.
+        using OffsetT = typename detail::ChooseOffsetT<NumItemsT>::Type;
+        
         // We cast away const-ness, but will *not* write to these arrays.
         // `DispatchRadixSort::Dispatch` will allocate temporary storage and
         // create a new double-buffer internally when the `is_overwrite_ok` flag
@@ -215,7 +234,7 @@ struct DeviceRadixSort
             temp_storage_bytes,
             d_keys,
             d_values,
-            num_items,
+            static_cast<OffsetT>(num_items),
             begin_bit,
             end_bit,
             is_overwrite_okay,
@@ -293,24 +312,26 @@ struct DeviceRadixSort
      *
      * \tparam KeyT      <b>[inferred]</b> KeyT type
      * \tparam ValueT    <b>[inferred]</b> ValueT type
+     * \tparam NumItemsT <b>[inferred]</b> Type of num_items
      */
     template <
         typename            KeyT,
-        typename            ValueT>
+        typename            ValueT,
+        typename            NumItemsT>
     CUB_RUNTIME_FUNCTION
     static cudaError_t SortPairs(
         void                    *d_temp_storage,                        ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
         size_t                  &temp_storage_bytes,                    ///< [in,out] Reference to size in bytes of \p d_temp_storage allocation
         DoubleBuffer<KeyT>      &d_keys,                                ///< [in,out] Reference to the double-buffer of keys whose "current" device-accessible buffer contains the unsorted input keys and, upon return, is updated to point to the sorted output keys
         DoubleBuffer<ValueT>    &d_values,                              ///< [in,out] Double-buffer of values whose "current" device-accessible buffer contains the unsorted input values and, upon return, is updated to point to the sorted output values
-        int                     num_items,                              ///< [in] Number of items to sort
+        NumItemsT               num_items,                              ///< [in] Number of items to sort
         int                     begin_bit           = 0,                ///< [in] <b>[optional]</b> The least-significant bit index (inclusive)  needed for key comparison
         int                     end_bit             = sizeof(KeyT) * 8, ///< [in] <b>[optional]</b> The most-significant bit index (exclusive) needed for key comparison (e.g., sizeof(unsigned int) * 8)
         cudaStream_t            stream              = 0,                ///< [in] <b>[optional]</b> CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
         bool                    debug_synchronous   = false)            ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
-        // Signed integer type for global offsets
-        typedef int OffsetT;
+        // Unsigned integer type for global offsets.
+        using OffsetT = typename detail::ChooseOffsetT<NumItemsT>::Type;
 
         constexpr bool is_overwrite_okay = true;
 
@@ -383,10 +404,12 @@ struct DeviceRadixSort
      *
      * \tparam KeyT      <b>[inferred]</b> KeyT type
      * \tparam ValueT    <b>[inferred]</b> ValueT type
+     * \tparam NumItemsT <b>[inferred]</b> Type of num_items
      */
     template <
         typename            KeyT,
-        typename            ValueT>
+        typename            ValueT,
+        typename            NumItemsT>
     CUB_RUNTIME_FUNCTION
     static cudaError_t SortPairsDescending(
         void                *d_temp_storage,                        ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
@@ -395,14 +418,14 @@ struct DeviceRadixSort
         KeyT                *d_keys_out,                            ///< [out] Pointer to the sorted output sequence of key data
         const ValueT        *d_values_in,                           ///< [in] Pointer to the corresponding input sequence of associated value items
         ValueT              *d_values_out,                          ///< [out] Pointer to the correspondingly-reordered output sequence of associated value items
-        int                 num_items,                              ///< [in] Number of items to sort
+        NumItemsT           num_items,                              ///< [in] Number of items to sort
         int                 begin_bit           = 0,                ///< [in] <b>[optional]</b> The least-significant bit index (inclusive)  needed for key comparison
         int                 end_bit             = sizeof(KeyT) * 8, ///< [in] <b>[optional]</b> The most-significant bit index (exclusive) needed for key comparison (e.g., sizeof(unsigned int) * 8)
         cudaStream_t        stream              = 0,                ///< [in] <b>[optional]</b> CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
         bool                debug_synchronous   = false)            ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
-        // Signed integer type for global offsets
-        typedef int OffsetT;
+        // Unsigned integer type for global offsets.
+        using OffsetT = typename detail::ChooseOffsetT<NumItemsT>::Type;
 
         // We cast away const-ness, but will *not* write to these arrays.
         // `DispatchRadixSort::Dispatch` will allocate temporary storage and
@@ -490,24 +513,26 @@ struct DeviceRadixSort
      *
      * \tparam KeyT      <b>[inferred]</b> KeyT type
      * \tparam ValueT    <b>[inferred]</b> ValueT type
+     * \tparam NumItemsT <b>[inferred]</b> Type of num_items
      */
     template <
         typename            KeyT,
-        typename            ValueT>
+        typename            ValueT,
+        typename            NumItemsT>
     CUB_RUNTIME_FUNCTION
     static cudaError_t SortPairsDescending(
         void                    *d_temp_storage,                        ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
         size_t                  &temp_storage_bytes,                    ///< [in,out] Reference to size in bytes of \p d_temp_storage allocation
         DoubleBuffer<KeyT>      &d_keys,                                ///< [in,out] Reference to the double-buffer of keys whose "current" device-accessible buffer contains the unsorted input keys and, upon return, is updated to point to the sorted output keys
         DoubleBuffer<ValueT>    &d_values,                              ///< [in,out] Double-buffer of values whose "current" device-accessible buffer contains the unsorted input values and, upon return, is updated to point to the sorted output values
-        int                     num_items,                              ///< [in] Number of items to sort
+        NumItemsT               num_items,                              ///< [in] Number of items to sort
         int                     begin_bit           = 0,                ///< [in] <b>[optional]</b> The least-significant bit index (inclusive)  needed for key comparison
         int                     end_bit             = sizeof(KeyT) * 8, ///< [in] <b>[optional]</b> The most-significant bit index (exclusive) needed for key comparison (e.g., sizeof(unsigned int) * 8)
         cudaStream_t            stream              = 0,                ///< [in] <b>[optional]</b> CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
         bool                    debug_synchronous   = false)            ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
-        // Signed integer type for global offsets
-        typedef int OffsetT;
+        // Unsigned integer type for global offsets.
+        using OffsetT = typename detail::ChooseOffsetT<NumItemsT>::Type;
 
         constexpr bool is_overwrite_okay = true;
 
@@ -582,22 +607,25 @@ struct DeviceRadixSort
      * \endcode
      *
      * \tparam KeyT      <b>[inferred]</b> KeyT type
+     * \tparam NumItemsT <b>[inferred]</b> Type of num_items
+     * \tparam NumItemsT <b>[inferred]</b> Type of num_items
      */
-    template <typename KeyT>
+    template <typename KeyT,
+              typename NumItemsT>
     CUB_RUNTIME_FUNCTION
     static cudaError_t SortKeys(
         void                *d_temp_storage,                        ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
         size_t              &temp_storage_bytes,                    ///< [in,out] Reference to size in bytes of \p d_temp_storage allocation
         const KeyT          *d_keys_in,                             ///< [in] Pointer to the input data of key data to sort
         KeyT                *d_keys_out,                            ///< [out] Pointer to the sorted output sequence of key data
-        int                 num_items,                              ///< [in] Number of items to sort
+        NumItemsT           num_items,                              ///< [in] Number of items to sort
         int                 begin_bit           = 0,                ///< [in] <b>[optional]</b> The least-significant bit index (inclusive)  needed for key comparison
         int                 end_bit             = sizeof(KeyT) * 8, ///< [in] <b>[optional]</b> The most-significant bit index (exclusive) needed for key comparison (e.g., sizeof(unsigned int) * 8)
         cudaStream_t        stream              = 0,                ///< [in] <b>[optional]</b> CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
         bool                debug_synchronous   = false)            ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
-        // Signed integer type for global offsets
-        typedef int OffsetT;
+        // Unsigned integer type for global offsets.
+        using OffsetT = typename detail::ChooseOffsetT<NumItemsT>::Type;
 
         // We cast away const-ness, but will *not* write to these arrays.
         // `DispatchRadixSort::Dispatch` will allocate temporary storage and
@@ -613,7 +641,7 @@ struct DeviceRadixSort
             temp_storage_bytes,
             d_keys,
             d_values,
-            num_items,
+            static_cast<OffsetT>(num_items),
             begin_bit,
             end_bit,
             is_overwrite_okay,
@@ -680,21 +708,23 @@ struct DeviceRadixSort
      * \endcode
      *
      * \tparam KeyT      <b>[inferred]</b> KeyT type
+     * \tparam NumItemsT <b>[inferred]</b> Type of num_items
      */
-    template <typename KeyT>
+    template <typename KeyT,
+              typename NumItemsT>
     CUB_RUNTIME_FUNCTION
     static cudaError_t SortKeys(
         void                *d_temp_storage,                        ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
         size_t              &temp_storage_bytes,                    ///< [in,out] Reference to size in bytes of \p d_temp_storage allocation
         DoubleBuffer<KeyT>  &d_keys,                                ///< [in,out] Reference to the double-buffer of keys whose "current" device-accessible buffer contains the unsorted input keys and, upon return, is updated to point to the sorted output keys
-        int                 num_items,                              ///< [in] Number of items to sort
+        NumItemsT           num_items,                              ///< [in] Number of items to sort
         int                 begin_bit           = 0,                ///< [in] <b>[optional]</b> The least-significant bit index (inclusive)  needed for key comparison
         int                 end_bit             = sizeof(KeyT) * 8, ///< [in] <b>[optional]</b> The most-significant bit index (exclusive) needed for key comparison (e.g., sizeof(unsigned int) * 8)
         cudaStream_t        stream              = 0,                ///< [in] <b>[optional]</b> CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
         bool                debug_synchronous   = false)            ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
-        // Signed integer type for global offsets
-        typedef int OffsetT;
+        // Unsigned integer type for global offsets.
+        using OffsetT = typename detail::ChooseOffsetT<NumItemsT>::Type;
 
         constexpr bool is_overwrite_okay = true;
 
@@ -763,22 +793,24 @@ struct DeviceRadixSort
      * \endcode
      *
      * \tparam KeyT      <b>[inferred]</b> KeyT type
+     * \tparam NumItemsT <b>[inferred]</b> Type of num_items
      */
-    template <typename KeyT>
+    template <typename KeyT,
+              typename NumItemsT>
     CUB_RUNTIME_FUNCTION
     static cudaError_t SortKeysDescending(
         void                *d_temp_storage,                        ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
         size_t              &temp_storage_bytes,                    ///< [in,out] Reference to size in bytes of \p d_temp_storage allocation
         const KeyT          *d_keys_in,                             ///< [in] Pointer to the input data of key data to sort
         KeyT                *d_keys_out,                            ///< [out] Pointer to the sorted output sequence of key data
-        int                 num_items,                              ///< [in] Number of items to sort
+        NumItemsT           num_items,                              ///< [in] Number of items to sort
         int                 begin_bit           = 0,                ///< [in] <b>[optional]</b> The least-significant bit index (inclusive)  needed for key comparison
         int                 end_bit             = sizeof(KeyT) * 8, ///< [in] <b>[optional]</b> The most-significant bit index (exclusive) needed for key comparison (e.g., sizeof(unsigned int) * 8)
         cudaStream_t        stream              = 0,                ///< [in] <b>[optional]</b> CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
         bool                debug_synchronous   = false)            ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
-        // Signed integer type for global offsets
-        typedef int OffsetT;
+        // Unsigned integer type for global offsets.
+        using OffsetT = typename detail::ChooseOffsetT<NumItemsT>::Type;
 
         // We cast away const-ness, but will *not* write to these arrays.
         // `DispatchRadixSort::Dispatch` will allocate temporary storage and
@@ -856,21 +888,23 @@ struct DeviceRadixSort
      * \endcode
      *
      * \tparam KeyT      <b>[inferred]</b> KeyT type
+     * \tparam NumItemsT <b>[inferred]</b> Type of num_items
      */
-    template <typename KeyT>
+    template <typename KeyT,
+              typename NumItemsT>
     CUB_RUNTIME_FUNCTION
     static cudaError_t SortKeysDescending(
         void                *d_temp_storage,                        ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
         size_t              &temp_storage_bytes,                    ///< [in,out] Reference to size in bytes of \p d_temp_storage allocation
         DoubleBuffer<KeyT>  &d_keys,                                ///< [in,out] Reference to the double-buffer of keys whose "current" device-accessible buffer contains the unsorted input keys and, upon return, is updated to point to the sorted output keys
-        int                 num_items,                              ///< [in] Number of items to sort
+        NumItemsT           num_items,                              ///< [in] Number of items to sort
         int                 begin_bit           = 0,                ///< [in] <b>[optional]</b> The least-significant bit index (inclusive)  needed for key comparison
         int                 end_bit             = sizeof(KeyT) * 8, ///< [in] <b>[optional]</b> The most-significant bit index (exclusive) needed for key comparison (e.g., sizeof(unsigned int) * 8)
         cudaStream_t        stream              = 0,                ///< [in] <b>[optional]</b> CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
         bool                debug_synchronous   = false)            ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
-        // Signed integer type for global offsets
-        typedef int OffsetT;
+        // Unsigned integer type for global offsets.
+        using OffsetT = typename detail::ChooseOffsetT<NumItemsT>::Type;
 
         constexpr bool is_overwrite_okay = true;
 

--- a/test/test_device_radix_sort.cu
+++ b/test/test_device_radix_sort.cu
@@ -37,6 +37,7 @@
 #include <cstdio>
 #include <memory>
 #include <random>
+#include <type_traits>
 #include <typeinfo>
 #include <vector>
 
@@ -107,7 +108,8 @@ static const char* BackendToString(Backend b)
 /**
  * Dispatch to CUB sorting entrypoint (specialized for ascending)
  */
-template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT,
+          typename NumItemsT>
 CUB_RUNTIME_FUNCTION
 __forceinline__
 cudaError_t Dispatch(
@@ -121,7 +123,7 @@ cudaError_t Dispatch(
     size_t&                 temp_storage_bytes,
     DoubleBuffer<KeyT>      &d_keys,
     DoubleBuffer<ValueT>    &d_values,
-    std::size_t             num_items,
+    NumItemsT               num_items,
     int                     /*num_segments*/,
     BeginOffsetIteratorT    /*d_segment_begin_offsets*/,
     EndOffsetIteratorT      /*d_segment_end_offsets*/,
@@ -133,13 +135,14 @@ cudaError_t Dispatch(
     return DeviceRadixSort::SortPairs(
         d_temp_storage, temp_storage_bytes,
         d_keys, d_values,
-        static_cast<int>(num_items), begin_bit, end_bit, stream, debug_synchronous);
+        num_items, begin_bit, end_bit, stream, debug_synchronous);
 }
 
 /**
  * Dispatch to CUB_NO_OVERWRITE sorting entrypoint (specialized for ascending)
  */
-template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT,
+          typename NumItemsT>
 CUB_RUNTIME_FUNCTION
 __forceinline__
 cudaError_t Dispatch(
@@ -153,7 +156,7 @@ cudaError_t Dispatch(
     size_t&                 temp_storage_bytes,
     DoubleBuffer<KeyT>      &d_keys,
     DoubleBuffer<ValueT>    &d_values,
-    std::size_t             num_items,
+    NumItemsT               num_items,
     int                     /*num_segments*/,
     BeginOffsetIteratorT    /*d_segment_begin_offsets*/,
     EndOffsetIteratorT      /*d_segment_end_offsets*/,
@@ -168,7 +171,7 @@ cudaError_t Dispatch(
     cudaError_t retval = DeviceRadixSort::SortPairs(
         d_temp_storage, temp_storage_bytes,
         const_keys_itr, d_keys.Alternate(), const_values_itr, d_values.Alternate(),
-        static_cast<int>(num_items), begin_bit, end_bit, stream, debug_synchronous);
+        num_items, begin_bit, end_bit, stream, debug_synchronous);
 
     d_keys.selector ^= 1;
     d_values.selector ^= 1;
@@ -178,7 +181,8 @@ cudaError_t Dispatch(
 /**
  * Dispatch to CUB sorting entrypoint (specialized for descending)
  */
-template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT,
+          typename NumItemsT>
 CUB_RUNTIME_FUNCTION
 __forceinline__
 cudaError_t Dispatch(
@@ -192,7 +196,7 @@ cudaError_t Dispatch(
     size_t&                 temp_storage_bytes,
     DoubleBuffer<KeyT>      &d_keys,
     DoubleBuffer<ValueT>    &d_values,
-    std::size_t             num_items,
+    NumItemsT               num_items,
     int                     /*num_segments*/,
     BeginOffsetIteratorT    /*d_segment_begin_offsets*/,
     EndOffsetIteratorT      /*d_segment_end_offsets*/,
@@ -203,7 +207,7 @@ cudaError_t Dispatch(
 {
     return DeviceRadixSort::SortPairsDescending(
         d_temp_storage, temp_storage_bytes,
-        d_keys, d_values, static_cast<int>(num_items),
+        d_keys, d_values, num_items,
         begin_bit, end_bit, stream, debug_synchronous);
 }
 
@@ -211,7 +215,8 @@ cudaError_t Dispatch(
 /**
  * Dispatch to CUB_NO_OVERWRITE sorting entrypoint (specialized for descending)
  */
-template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT,
+          typename NumItemsT>
 CUB_RUNTIME_FUNCTION
 __forceinline__
 cudaError_t Dispatch(
@@ -225,7 +230,7 @@ cudaError_t Dispatch(
     size_t&                 temp_storage_bytes,
     DoubleBuffer<KeyT>      &d_keys,
     DoubleBuffer<ValueT>    &d_values,
-    std::size_t             num_items,
+    NumItemsT               num_items,
     int                     /*num_segments*/,
     BeginOffsetIteratorT    /*d_segment_begin_offsets*/,
     EndOffsetIteratorT      /*d_segment_end_offsets*/,
@@ -240,7 +245,7 @@ cudaError_t Dispatch(
     cudaError_t retval = DeviceRadixSort::SortPairsDescending(
         d_temp_storage, temp_storage_bytes,
         const_keys_itr, d_keys.Alternate(), const_values_itr, d_values.Alternate(),
-        static_cast<int>(num_items), begin_bit, end_bit, stream, debug_synchronous);
+        num_items, begin_bit, end_bit, stream, debug_synchronous);
 
     d_keys.selector ^= 1;
     d_values.selector ^= 1;
@@ -254,7 +259,8 @@ cudaError_t Dispatch(
 /**
  * Dispatch to CUB_SEGMENTED sorting entrypoint (specialized for ascending)
  */
-template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT,
+          typename NumItemsT>
 CUB_RUNTIME_FUNCTION
 __forceinline__
 cudaError_t Dispatch(
@@ -268,7 +274,7 @@ cudaError_t Dispatch(
     size_t&                 temp_storage_bytes,
     DoubleBuffer<KeyT>      &d_keys,
     DoubleBuffer<ValueT>    &d_values,
-    std::size_t             num_items,
+    NumItemsT               num_items,
     int                     num_segments,
     BeginOffsetIteratorT    d_segment_begin_offsets,
     EndOffsetIteratorT      d_segment_end_offsets,
@@ -279,7 +285,7 @@ cudaError_t Dispatch(
 {
     return DeviceSegmentedRadixSort::SortPairs(
         d_temp_storage, temp_storage_bytes,
-        d_keys, d_values, static_cast<int>(num_items),
+        d_keys, d_values, num_items,
         num_segments, d_segment_begin_offsets, d_segment_end_offsets,
         begin_bit, end_bit, stream, debug_synchronous);
 }
@@ -287,7 +293,8 @@ cudaError_t Dispatch(
 /**
  * Dispatch to CUB_SEGMENTED_NO_OVERWRITE sorting entrypoint (specialized for ascending)
  */
-template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT,
+          typename NumItemsT>
 CUB_RUNTIME_FUNCTION
 __forceinline__
 cudaError_t Dispatch(
@@ -301,7 +308,7 @@ cudaError_t Dispatch(
     size_t&                 temp_storage_bytes,
     DoubleBuffer<KeyT>      &d_keys,
     DoubleBuffer<ValueT>    &d_values,
-    std::size_t             num_items,
+    NumItemsT               num_items,
     int                     num_segments,
     BeginOffsetIteratorT    d_segment_begin_offsets,
     EndOffsetIteratorT      d_segment_end_offsets,
@@ -316,7 +323,7 @@ cudaError_t Dispatch(
     cudaError_t retval = DeviceSegmentedRadixSort::SortPairs(
         d_temp_storage, temp_storage_bytes,
         const_keys_itr, d_keys.Alternate(), const_values_itr, d_values.Alternate(),
-        static_cast<int>(num_items), num_segments, d_segment_begin_offsets, d_segment_end_offsets,
+        num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets,
         begin_bit, end_bit, stream, debug_synchronous);
 
     d_keys.selector ^= 1;
@@ -328,7 +335,8 @@ cudaError_t Dispatch(
 /**
  * Dispatch to CUB_SEGMENTED sorting entrypoint (specialized for descending)
  */
-template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT,
+          typename NumItemsT>
 CUB_RUNTIME_FUNCTION
 __forceinline__
 cudaError_t Dispatch(
@@ -342,7 +350,7 @@ cudaError_t Dispatch(
     size_t&                 temp_storage_bytes,
     DoubleBuffer<KeyT>      &d_keys,
     DoubleBuffer<ValueT>    &d_values,
-    std::size_t             num_items,
+    NumItemsT               num_items,
     int                     num_segments,
     BeginOffsetIteratorT    d_segment_begin_offsets,
     EndOffsetIteratorT      d_segment_end_offsets,
@@ -353,7 +361,7 @@ cudaError_t Dispatch(
 {
     return DeviceSegmentedRadixSort::SortPairsDescending(
         d_temp_storage, temp_storage_bytes,
-        d_keys, d_values, static_cast<int>(num_items),
+        d_keys, d_values, num_items,
         num_segments, d_segment_begin_offsets, d_segment_end_offsets,
         begin_bit, end_bit, stream, debug_synchronous);
 }
@@ -361,7 +369,8 @@ cudaError_t Dispatch(
 /**
  * Dispatch to CUB_SEGMENTED_NO_OVERWRITE sorting entrypoint (specialized for descending)
  */
-template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+template <typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT,
+          typename NumItemsT>
 CUB_RUNTIME_FUNCTION
 __forceinline__
 cudaError_t Dispatch(
@@ -375,7 +384,7 @@ cudaError_t Dispatch(
     size_t&                 temp_storage_bytes,
     DoubleBuffer<KeyT>      &d_keys,
     DoubleBuffer<ValueT>    &d_values,
-    std::size_t             num_items,
+    NumItemsT               num_items,
     int                     num_segments,
     BeginOffsetIteratorT    d_segment_begin_offsets,
     EndOffsetIteratorT      d_segment_end_offsets,
@@ -390,7 +399,7 @@ cudaError_t Dispatch(
     cudaError_t retval = DeviceSegmentedRadixSort::SortPairsDescending(
         d_temp_storage, temp_storage_bytes,
         const_keys_itr, d_keys.Alternate(), const_values_itr, d_values.Alternate(),
-        static_cast<int>(num_items), num_segments, d_segment_begin_offsets, d_segment_end_offsets,
+        num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets,
         begin_bit, end_bit, stream, debug_synchronous);
 
     d_keys.selector ^= 1;
@@ -405,7 +414,8 @@ cudaError_t Dispatch(
 /**
  * Simple wrapper kernel to invoke DeviceRadixSort
  */
-template <int IS_DESCENDING, typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+template <int IS_DESCENDING, typename KeyT, typename ValueT, typename BeginOffsetIteratorT,
+          typename EndOffsetIteratorT, typename NumItemsT>
 __global__ void CnpDispatchKernel(
     Int2Type<IS_DESCENDING> is_descending,
     int                     *d_selector,
@@ -416,7 +426,7 @@ __global__ void CnpDispatchKernel(
     size_t                  temp_storage_bytes,
     DoubleBuffer<KeyT>      d_keys,
     DoubleBuffer<ValueT>    d_values,
-    std::size_t             num_items,
+    NumItemsT               num_items,
     int                     num_segments,
     BeginOffsetIteratorT    d_segment_begin_offsets,
     EndOffsetIteratorT      d_segment_end_offsets,
@@ -456,7 +466,8 @@ __global__ void CnpDispatchKernel(
 /**
  * Dispatch to CDP kernel
  */
-template <int IS_DESCENDING, typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+template <int IS_DESCENDING, typename KeyT, typename ValueT, typename BeginOffsetIteratorT,
+          typename EndOffsetIteratorT, typename NumItemsT>
 cudaError_t Dispatch(
     Int2Type<IS_DESCENDING> is_descending,
     Int2Type<CDP>           dispatch_to,
@@ -468,7 +479,7 @@ cudaError_t Dispatch(
     size_t                  &temp_storage_bytes,
     DoubleBuffer<KeyT>      &d_keys,
     DoubleBuffer<ValueT>    &d_values,
-    std::size_t             num_items,
+    NumItemsT               num_items,
     int                     num_segments,
     BeginOffsetIteratorT    d_segment_begin_offsets,
     EndOffsetIteratorT      d_segment_end_offsets,
@@ -541,14 +552,14 @@ struct Pair<bool, ValueT>
 /**
  * Initialize key data
  */
-template <typename KeyT>
+template <typename KeyT, typename NumItemsT>
 void InitializeKeyBits(
     GenMode         gen_mode,
     KeyT            *h_keys,
-    std::size_t     num_items,
+    NumItemsT       num_items,
     int             /*entropy_reduction*/)
 {
-    for (std::size_t i = 0; i < num_items; ++i)
+    for (NumItemsT i = 0; i < num_items; ++i)
         InitValue(gen_mode, h_keys[i], i);
 }
 
@@ -562,10 +573,10 @@ UnsignedBits KeyBits(KeyT key)
 }
 
 /** Initialize the reference array monotonically. */
-template <typename KeyT>
+template <typename KeyT, typename NumItemsT>
 void InitializeKeysSorted(
     KeyT            *h_keys,
-    std::size_t     num_items)
+    NumItemsT       num_items)
 {
     using TraitsT = cub::Traits<KeyT>;
     using UnsignedBits = typename TraitsT::UnsignedBits;
@@ -575,12 +586,12 @@ void InitializeKeysSorted(
                                  (sizeof(UnsignedBits) < 8 ? 14 : 24));
     UnsignedBits min_bits = TraitsT::TwiddleIn(KeyBits(TraitsT::Lowest()));
     UnsignedBits max_bits = TraitsT::TwiddleIn(KeyBits(TraitsT::Max()));
-    std::size_t max_run = std::max(
-        std::size_t(double(num_items) * (max_inc + 1) / max_bits),
-        std::size_t(1 << 14));
+    NumItemsT max_run = std::max(
+        NumItemsT(double(num_items) * (max_inc + 1) / max_bits),
+        NumItemsT(1 << 14));
 
     UnsignedBits *h_key_bits = reinterpret_cast<UnsignedBits*>(h_keys);
-    std::size_t i = 0;
+    NumItemsT i = 0;
     // Start with the minimum twiddled key.
     UnsignedBits twiddled_key = min_bits;
     while (i < num_items)
@@ -593,11 +604,11 @@ void InitializeKeysSorted(
         twiddled_key += inc;
 
         // Generate random run length (ensure there are enough values to fill the rest).
-        std::size_t run_bits = 0;
+        NumItemsT run_bits = 0;
         RandomBits(run_bits);
-        std::size_t run_length = std::min(1 + run_bits % max_run, num_items - i);
+        NumItemsT run_length = std::min(1 + run_bits % max_run, num_items - i);
         if (twiddled_key == max_bits) run_length = num_items - i;
-        std::size_t run_end = i + run_length;
+        NumItemsT run_end = i + run_length;
 
         // Fill the array.
         UnsignedBits key = TraitsT::TwiddleOut(twiddled_key);
@@ -619,17 +630,17 @@ void InitializeKeysSorted(
 /**
  * Initialize solution
  */
-template <bool IS_DESCENDING, typename KeyT, typename OffsetT>
+template <bool IS_DESCENDING, typename KeyT, typename NumItemsT>
 void InitializeSolution(
-    KeyT    *h_keys,
-    OffsetT num_items,
-    int     num_segments,
-    bool    pre_sorted,
-    OffsetT *h_segment_offsets,
-    int     begin_bit,
-    int     end_bit,
-    OffsetT *&h_reference_ranks,
-    KeyT    *&h_reference_keys)
+    KeyT       *h_keys,
+    NumItemsT  num_items,
+    int        num_segments,
+    bool       pre_sorted,
+    NumItemsT  *h_segment_offsets,
+    int        begin_bit,
+    int        end_bit,
+    NumItemsT  *&h_reference_ranks,
+    KeyT       *&h_reference_keys)
 {
     if (pre_sorted)
     {
@@ -652,7 +663,7 @@ void InitializeSolution(
         if (IS_DESCENDING)
         {
             // Copy in reverse.
-            for (OffsetT i = 0; i < num_items; ++i)
+            for (NumItemsT i = 0; i < num_items; ++i)
             {
                 h_reference_keys[i] = h_keys[num_items - 1 - i];
             }
@@ -668,14 +679,14 @@ void InitializeSolution(
         struct Element
         {
             KeyT key;
-            std::size_t num;
-            std::size_t index;
+            NumItemsT num;
+            NumItemsT index;
         };
 
         std::vector<Element> summary;
         KeyT cur_key = h_reference_keys[0];
         summary.push_back(Element{cur_key, 1, 0});
-        for (std::size_t i = 1; i < num_items; ++i)
+        for (NumItemsT i = 1; i < num_items; ++i)
         {
             KeyT key = h_reference_keys[i];
             if (key == cur_key)
@@ -693,17 +704,17 @@ void InitializeSolution(
         // Generate a random permutation from the summary. Such a complicated
         // approach is used to permute the array and compute ranks in a
         // cache-friendly way and in a short time.
-        h_reference_ranks = new std::size_t[num_items];
-        std::size_t max_run = 32, run = 0, i = 0;
+        h_reference_ranks = new NumItemsT[num_items];
+        NumItemsT max_run = 32, run = 0, i = 0;
         while (summary.size() > 0)
         {
             // Pick up a random element and a run.
-            std::size_t bits = 0;
+            NumItemsT bits = 0;
             RandomBits(bits);
-            std::size_t summary_id = bits % summary.size();
+            NumItemsT summary_id = bits % summary.size();
             Element& element = summary[summary_id];
             run = std::min(1 + bits % (max_run - 1), element.num);
-            for (std::size_t j = 0; j < run; ++j)
+            for (NumItemsT j = 0; j < run; ++j)
             {
                 h_keys[i + j] = element.key;
                 h_reference_ranks[element.index + j] = i + j;
@@ -722,12 +733,12 @@ void InitializeSolution(
     }
     else
     {
-        typedef Pair<KeyT, OffsetT> PairT;
+        typedef Pair<KeyT, NumItemsT> PairT;
 
         PairT *h_pairs = new PairT[num_items];
 
         int num_bits = end_bit - begin_bit;
-        for (OffsetT i = 0; i < num_items; ++i)
+        for (NumItemsT i = 0; i < num_items; ++i)
         {
 
             // Mask off unwanted portions
@@ -757,10 +768,10 @@ void InitializeSolution(
 
         printf(" Done.\n"); fflush(stdout);
 
-        h_reference_ranks  = new OffsetT[num_items];
+        h_reference_ranks  = new NumItemsT[num_items];
         h_reference_keys   = new KeyT[num_items];
 
-        for (OffsetT i = 0; i < num_items; ++i)
+        for (NumItemsT i = 0; i < num_items; ++i)
         {
             h_reference_ranks[i]    = h_pairs[i].value;
             h_reference_keys[i]     = h_keys[h_pairs[i].value];
@@ -770,8 +781,8 @@ void InitializeSolution(
     }
 }
 
-template <bool IS_DESCENDING, typename KeyT>
-void ResetKeys(KeyT *h_keys, std::size_t num_items, bool pre_sorted, KeyT *reference_keys)
+template <bool IS_DESCENDING, typename KeyT, typename NumItemsT>
+void ResetKeys(KeyT *h_keys, NumItemsT num_items, bool pre_sorted, KeyT *reference_keys)
 {
     if (!pre_sorted) return;
 
@@ -779,7 +790,7 @@ void ResetKeys(KeyT *h_keys, std::size_t num_items, bool pre_sorted, KeyT *refer
     if (IS_DESCENDING)
     {
         // Keys need to be copied in reverse.
-        for (std::size_t i = 0; i < num_items; ++i)
+        for (NumItemsT i = 0; i < num_items; ++i)
         {
             h_keys[i] = reference_keys[num_items - 1 - i];
         }
@@ -823,11 +834,12 @@ template <
     typename    KeyT,
     typename    ValueT,
     typename    BeginOffsetIteratorT,
-    typename    EndOffsetIteratorT>
+    typename    EndOffsetIteratorT,
+    typename    NumItemsT>
 void Test(
     KeyT                 *h_keys,
     ValueT               *h_values,
-    std::size_t          num_items,
+    NumItemsT            num_items,
     int                  num_segments,
     BeginOffsetIteratorT d_segment_begin_offsets,
     EndOffsetIteratorT   d_segment_end_offsets,
@@ -846,7 +858,7 @@ void Test(
            "begin_bit %d, end_bit %d\n",
            BackendToString(BACKEND),
            (KEYS_ONLY) ? "keys-only" : "key-value",
-           num_items,
+           static_cast<std::size_t>(num_items),
            num_segments,
            static_cast<int>(sizeof(KeyT)),
            typeid(KeyT).name(),
@@ -988,65 +1000,79 @@ void Test(
 
 // Returns whether there is enough memory for the test.
 template <typename KeyT, typename ValueT>
-bool HasEnoughMemory(std::size_t num_items)
+bool HasEnoughMemory(std::size_t num_items, bool overwrite)
 {
     std::size_t total_mem = TotalGlobalMem();
     std::size_t value_size = std::is_same<ValueT, NullType>::value
                            ? 0
                            : sizeof(ValueT);
     // A conservative estimate of the amount of memory required.
-    std::size_t test_mem = 4 * num_items * (sizeof(KeyT) + value_size);
+    double factor = overwrite ? 2.25 : 3.25;
+    std::size_t test_mem = static_cast<std::size_t>
+      (num_items * (sizeof(KeyT) + value_size) * factor);
     return test_mem < total_mem;
 }
 
 /**
  * Test backend
  */
-template <bool IS_DESCENDING, typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+template <bool IS_DESCENDING, typename KeyT, typename ValueT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT, typename NumItemsT>
 void TestBackend(
     KeyT                 *h_keys,
-    std::size_t          num_items,
+    NumItemsT            num_items,
     int                  num_segments,
     BeginOffsetIteratorT d_segment_begin_offsets,
     EndOffsetIteratorT   d_segment_end_offsets,
     int                  begin_bit,
     int                  end_bit,
     KeyT                 *h_reference_keys,
-    std::size_t          *h_reference_ranks)
+    NumItemsT            *h_reference_ranks)
 {
     const bool KEYS_ONLY = std::is_same<ValueT, NullType>::value;
 
-    ValueT *h_values             = NULL;
-    ValueT *h_reference_values   = NULL;
-
-    // Skip tests for which we don't have enough memory.
-    if (!HasEnoughMemory<KeyT, ValueT>(num_items))
+    // A conservative check assuming overwrite is allowed.
+    if (!HasEnoughMemory<KeyT, ValueT>(static_cast<std::size_t>(num_items), true))
     {
-      printf("Skipping test due to insufficient device memory.\n");
-      return;
+        printf("Skipping the test due to insufficient device memory\n");
+        return;
     }
 
+    ValueT *h_values             = NULL;
+    ValueT *h_reference_values   = NULL;
+    
     if (!KEYS_ONLY)
     {
         h_values            = new ValueT[num_items];
         h_reference_values  = new ValueT[num_items];
 
-        for (std::size_t i = 0; i < num_items; ++i)
+        for (NumItemsT i = 0; i < num_items; ++i)
         {
             InitValue(INTEGER_SEED, h_values[i], i);
             InitValue(INTEGER_SEED, h_reference_values[i], h_reference_ranks[i]);
         }
     }
 
-    Test<CUB_SEGMENTED, IS_DESCENDING>(               h_keys, h_values, num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit, h_reference_keys, h_reference_values);
-    Test<CUB_SEGMENTED_NO_OVERWRITE, IS_DESCENDING>(  h_keys, h_values, num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit, h_reference_keys, h_reference_values);
+    // Skip segmented sort if num_items isn't int.
+    // TODO(canonizer): re-enable these tests once num_items is templated for segmented sort.
+    if (std::is_same<NumItemsT, int>::value)
+    {
+        Test<CUB_SEGMENTED, IS_DESCENDING>(               h_keys, h_values, num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit, h_reference_keys, h_reference_values);
+        Test<CUB_SEGMENTED_NO_OVERWRITE, IS_DESCENDING>(  h_keys, h_values, num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit, h_reference_keys, h_reference_values);
+    }
 
     if (num_segments == 1)
     {
         Test<CUB, IS_DESCENDING>(               h_keys, h_values, num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit, h_reference_keys, h_reference_values);
-        Test<CUB_NO_OVERWRITE, IS_DESCENDING>(  h_keys, h_values, num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit, h_reference_keys, h_reference_values);
+        if (HasEnoughMemory<KeyT, ValueT>(static_cast<std::size_t>(num_items), false))
+        {
+            Test<CUB_NO_OVERWRITE, IS_DESCENDING>(  h_keys, h_values, num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit, h_reference_keys, h_reference_values);
+        }
+        else
+        {
+            printf("Skipping CUB_NO_OVERWRITE tests due to insufficient memory\n");
+        }
     #ifdef CUB_CDP
-        Test<CDP, IS_DESCENDING>(               h_keys, h_values, num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit, h_reference_keys, h_reference_values);
+            Test<CDP, IS_DESCENDING>(               h_keys, h_values, num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit, h_reference_keys, h_reference_values);
     #endif
     }
 
@@ -1054,51 +1080,49 @@ void TestBackend(
     if (h_reference_values) delete[] h_reference_values;
 }
 
+// Smallest value type for TEST_VALUE_TYPE.
+// Unless TEST_VALUE_TYPE == 3, this is the only value type tested.
+#if TEST_VALUE_TYPE == 0
+// Test keys-only
+using SmallestValueT = NullType;
+#elif TEST_VALUE_TYPE == 1
+// Test with 8b value
+using SmallestValueT = unsigned char;
+#elif TEST_VALUE_TYPE == 2
+// Test with 32b value
+using SmallestValueT = unsigned int;
+// Test with 64b value
+#elif TEST_VALUE_TYPE == 3
+using SmallestValueT = unsigned long long;
+#endif
+
 
 /**
  * Test value type
  */
-template <bool IS_DESCENDING, typename KeyT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+template <bool IS_DESCENDING, typename KeyT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT, typename NumItemsT>
 void TestValueTypes(
     KeyT                 *h_keys,
-    std::size_t          num_items,
+    NumItemsT            num_items,
     int                  num_segments,
     bool                 pre_sorted,
-    std::size_t          *h_segment_offsets,
+    NumItemsT            *h_segment_offsets,
     BeginOffsetIteratorT d_segment_begin_offsets,
     EndOffsetIteratorT   d_segment_end_offsets,
     int                  begin_bit,
     int                  end_bit)
 {
     // Initialize the solution
-    std::size_t *h_reference_ranks = NULL;
+    NumItemsT *h_reference_ranks = NULL;
     KeyT *h_reference_keys = NULL;
     InitializeSolution<IS_DESCENDING>(h_keys, num_items, num_segments, pre_sorted, h_segment_offsets, begin_bit, end_bit, h_reference_ranks, h_reference_keys);
 
-#if TEST_VALUE_TYPE == 0
+    TestBackend<IS_DESCENDING, KeyT, SmallestValueT>          (h_keys, num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit, h_reference_keys, h_reference_ranks);
 
-    // Test keys-only
-    TestBackend<IS_DESCENDING, KeyT, NullType>          (h_keys, num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit, h_reference_keys, h_reference_ranks);
-
-#elif TEST_VALUE_TYPE == 1
-
-    // Test with 8b value
-    TestBackend<IS_DESCENDING, KeyT, unsigned char>     (h_keys, num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit, h_reference_keys, h_reference_ranks);
-
-#elif TEST_VALUE_TYPE == 2
-
-    // Test with 32b value
-    TestBackend<IS_DESCENDING, KeyT, unsigned int>      (h_keys, num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit, h_reference_keys, h_reference_ranks);
-
-#elif TEST_VALUE_TYPE == 3
-
-    // Test with 64b value
-    TestBackend<IS_DESCENDING, KeyT, unsigned long long>(h_keys, num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit, h_reference_keys, h_reference_ranks);
-
+#if TEST_VALUE_TYPE == 3
     // Test with non-trivially-constructable value
     // These are cheap to build, so lump them in with the 64b value tests.
     TestBackend<IS_DESCENDING, KeyT, TestBar>           (h_keys, num_items, num_segments, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit, h_reference_keys, h_reference_ranks);
-
 #endif
 
     // Cleanup
@@ -1112,13 +1136,14 @@ void TestValueTypes(
 /**
  * Test ascending/descending
  */
-template <typename KeyT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+template <typename KeyT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT,
+          typename NumItemsT>
 void TestDirection(
     KeyT                 *h_keys,
-    std::size_t          num_items,
+    NumItemsT            num_items,
     int                  num_segments,
     bool                 pre_sorted,
-    std::size_t          *h_segment_offsets,
+    NumItemsT            *h_segment_offsets,
     BeginOffsetIteratorT d_segment_begin_offsets,
     EndOffsetIteratorT   d_segment_end_offsets,
     int                  begin_bit,
@@ -1132,13 +1157,14 @@ void TestDirection(
 /**
  * Test different bit ranges
  */
-template <typename KeyT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT>
+template <typename KeyT, typename BeginOffsetIteratorT, typename EndOffsetIteratorT,
+          typename NumItemsT>
 void TestBits(
     KeyT                 *h_keys,
-    std::size_t          num_items,
+    NumItemsT            num_items,
     int                  num_segments,
     bool                 pre_sorted,
-    std::size_t          *h_segment_offsets,
+    NumItemsT            *h_segment_offsets,
     BeginOffsetIteratorT d_segment_begin_offsets,
     EndOffsetIteratorT   d_segment_end_offsets)
 {
@@ -1186,17 +1212,17 @@ struct TransformFunctor2
 /**
 * Test different segment iterators
 */
-template <typename KeyT>
+template <typename KeyT, typename NumItemsT>
 void TestSegmentIterators(
     KeyT           *h_keys,
-    std::size_t    num_items,
+    NumItemsT      num_items,
     int            num_segments,
     bool           pre_sorted,
-    std::size_t    *h_segment_offsets,
-    std::size_t    *d_segment_offsets)
+    NumItemsT     *h_segment_offsets,
+    NumItemsT     *d_segment_offsets)
 {
     InitializeSegments(num_items, num_segments, h_segment_offsets);
-    CubDebugExit(cudaMemcpy(d_segment_offsets, h_segment_offsets, sizeof(std::size_t) * (num_segments + 1), cudaMemcpyHostToDevice));
+    CubDebugExit(cudaMemcpy(d_segment_offsets, h_segment_offsets, sizeof(NumItemsT) * (num_segments + 1), cudaMemcpyHostToDevice));
 
     // Test with segment pointer.
     // This is also used to test non-segmented sort.
@@ -1205,11 +1231,11 @@ void TestSegmentIterators(
     if (num_segments > 1)
     {
         // Test with transform iterators of different types
-        typedef TransformFunctor1<std::size_t> TransformFunctor1T;
-        typedef TransformFunctor2<std::size_t> TransformFunctor2T;
+        typedef TransformFunctor1<NumItemsT> TransformFunctor1T;
+        typedef TransformFunctor2<NumItemsT> TransformFunctor2T;
 
-        TransformInputIterator<std::size_t, TransformFunctor1T, std::size_t*, std::size_t> d_segment_begin_offsets_itr(d_segment_offsets, TransformFunctor1T());
-        TransformInputIterator<std::size_t, TransformFunctor2T, std::size_t*, std::size_t> d_segment_end_offsets_itr(d_segment_offsets + 1, TransformFunctor2T());
+        TransformInputIterator<NumItemsT, TransformFunctor1T, NumItemsT*, NumItemsT> d_segment_begin_offsets_itr(d_segment_offsets, TransformFunctor1T());
+        TransformInputIterator<NumItemsT, TransformFunctor2T, NumItemsT*, NumItemsT> d_segment_end_offsets_itr(d_segment_offsets + 1, TransformFunctor2T());
 
         TestBits(h_keys, num_items, num_segments, pre_sorted, h_segment_offsets, d_segment_begin_offsets_itr, d_segment_end_offsets_itr);
     }
@@ -1219,18 +1245,18 @@ void TestSegmentIterators(
 /**
  * Test different segment compositions
  */
-template <typename KeyT>
+template <typename KeyT, typename NumItemsT>
 void TestSegments(
     KeyT         *h_keys,
-    std::size_t  num_items,
+    NumItemsT    num_items,
     int          max_segments,
     bool         pre_sorted)
 {
-    max_segments = static_cast<int>(CUB_MIN(num_items, static_cast<std::size_t>(max_segments)));
-    std::size_t *h_segment_offsets = new std::size_t[max_segments + 1];
+    max_segments = static_cast<int>(CUB_MIN(num_items, static_cast<NumItemsT>(max_segments)));
+    NumItemsT *h_segment_offsets = new NumItemsT[max_segments + 1];
 
-    std::size_t *d_segment_offsets = nullptr;
-    CubDebugExit(g_allocator.DeviceAllocate((void**)&d_segment_offsets, sizeof(std::size_t) * (max_segments + 1)));
+    NumItemsT *d_segment_offsets = nullptr;
+    CubDebugExit(g_allocator.DeviceAllocate((void**)&d_segment_offsets, sizeof(NumItemsT) * (max_segments + 1)));
 
     for (int num_segments = max_segments; num_segments > 1; num_segments = cub::DivideAndRoundUp(num_segments, 64))
     {
@@ -1261,6 +1287,22 @@ void TestSegments(
     if (d_segment_offsets) CubDebugExit(g_allocator.DeviceFree(d_segment_offsets));
 }
 
+/** 
+ * Test different NumItemsT, i.e. types of num_items 
+ */
+template <typename KeyT>
+void TestNumItems(KeyT         *h_keys,
+                  std::size_t  num_items,
+                  int          max_segments,
+                  bool         pre_sorted)
+{
+    if (!pre_sorted && num_items <= std::size_t(std::numeric_limits<int>::max()))
+    {
+        TestSegments<KeyT, int>(h_keys, static_cast<int>(num_items), max_segments, pre_sorted);
+    }
+    TestSegments<KeyT, std::size_t>(h_keys, num_items, max_segments, pre_sorted);
+}
+
 
 /**
  * Test different (sub)lengths and number of segments
@@ -1275,7 +1317,7 @@ void TestSizes(KeyT* h_keys,
          num_items > 1;
          num_items = cub::DivideAndRoundUp(num_items, 64))
     {
-        TestSegments(h_keys, num_items, max_segments, pre_sorted);
+        TestNumItems(h_keys, num_items, max_segments, pre_sorted);
     }
 }
 
@@ -1301,8 +1343,8 @@ void TestGen(
 
     // Test trivial problems sizes
     h_keys[0] = static_cast<KeyT>(42);
-    TestSegments(h_keys.get(), 0, 0, false);
-    TestSegments(h_keys.get(), 1, 1, false);
+    TestNumItems(h_keys.get(), 0, 0, false);
+    TestNumItems(h_keys.get(), 1, 1, false);
 
     for (int entropy_reduction = 0; entropy_reduction <= 6; entropy_reduction += 6)
     {
@@ -1317,7 +1359,7 @@ void TestGen(
         fflush(stdout);
         InitializeKeyBits(RANDOM_MINUS_PLUS_ZERO, h_keys.get(), max_items, 0);
         // This just tests +/- 0 handling -- don't need to test multiple sizes
-        TestSegments(h_keys.get(), max_items, max_segments, false);
+        TestNumItems(h_keys.get(), max_items, max_segments, false);
     }
 
     printf("\nTesting uniform %s keys\n", typeid(KeyT).name()); fflush(stdout);
@@ -1331,8 +1373,16 @@ void TestGen(
     if (WITH_PRE_SORTED)
     {
         // Presorting is only used for testing large input arrays.
-        // Increase above 2^32 once 64-bit indexing is enabled.
-        const std::size_t large_num_items = 200000003;
+        const std::size_t large_num_items = std::size_t(4350000007ull);
+
+        // A conservative check for memory, as we don't know ValueT or whether
+        // the overwrite is allowed until later.
+        // For ValueT, the check is actually exact unless TEST_VALUE_TYPE == 3.
+        if (!HasEnoughMemory<KeyT, SmallestValueT>(large_num_items, true))
+        {
+            printf("Skipping the permutation-based test due to insufficient device memory\n");
+            return;
+        }
 
         h_keys.reset(nullptr); // Explicitly free old buffer before allocating.
         h_keys.reset(new KeyT[large_num_items]);
@@ -1341,7 +1391,7 @@ void TestGen(
         fflush(stdout);
         InitializeKeysSorted(h_keys.get(), large_num_items);
         fflush(stdout);
-        TestSegments(h_keys.get(), large_num_items, max_segments, true);
+        TestNumItems(h_keys.get(), large_num_items, max_segments, true);
         fflush(stdout);
     }
 


### PR DESCRIPTION
- 64-bit `OffsetT` is supported for onesweep sorting
- for decoupled look-back, the partition kernel is broken into smaller parts (as before), and a separate 32-bit type is used there
- for histograms, 32-bit counters are used in shared memory and `OffsetT`-sized counters in global memory