### PR TITLE
Docs update: how to use dynamic shared mem with block reduce

### DIFF
--- a/cub/block/block_discontinuity.cuh
+++ b/cub/block/block_discontinuity.cuh
@@ -94,6 +94,13 @@ CUB_NAMESPACE_BEGIN
  * \par Performance Considerations
  * - Incurs zero bank conflicts for most types
  *
+ * \par Re-using dynamically allocating shared memory
+ * The following example under the examples/block folder illustrates usage of
+ * dynamically shared memory with BlockReduce and how to re-purpose
+ * the same memory region:
+ * <a href="../../examples/block/example_block_reduce_dyn_smem.cu">example_block_reduce_dyn_smem.cu</a>
+ *
+ * This example can be easily adapted to the storage required by BlockDiscontinuity.
  */
 template <
     typename    T,

--- a/cub/block/block_exchange.cuh
+++ b/cub/block/block_exchange.cuh
@@ -98,6 +98,13 @@ CUB_NAMESPACE_BEGIN
  * \par Performance Considerations
  * - Proper device-specific padding ensures zero bank conflicts for most types.
  *
+ * \par Re-using dynamically allocating shared memory
+ * The following example under the examples/block folder illustrates usage of
+ * dynamically shared memory with BlockReduce and how to re-purpose
+ * the same memory region:
+ * <a href="../../examples/block/example_block_reduce_dyn_smem.cu">example_block_reduce_dyn_smem.cu</a>
+ *
+ * This example can be easily adapted to the storage required by BlockExchange.
  */
 template <
     typename    InputT,

--- a/cub/block/block_histogram.cuh
+++ b/cub/block/block_histogram.cuh
@@ -139,6 +139,13 @@ enum BlockHistogramAlgorithm
  * - The histogram output can be constructed in shared or device-accessible memory
  * - See cub::BlockHistogramAlgorithm for performance details regarding algorithmic alternatives
  *
+ * \par Re-using dynamically allocating shared memory
+ * The following example under the examples/block folder illustrates usage of
+ * dynamically shared memory with BlockReduce and how to re-purpose
+ * the same memory region:
+ * <a href="../../examples/block/example_block_reduce_dyn_smem.cu">example_block_reduce_dyn_smem.cu</a>
+ *
+ * This example can be easily adapted to the storage required by BlockHistogram.
  */
 template <
     typename                T,

--- a/cub/block/block_load.cuh
+++ b/cub/block/block_load.cuh
@@ -625,6 +625,13 @@ enum BlockLoadAlgorithm
  * The set of \p thread_data across the block of threads in those threads will be
  * <tt>{ [0,1,2,3], [4,5,6,7], ..., [508,509,510,511] }</tt>.
  *
+ * \par Re-using dynamically allocating shared memory
+ * The following example under the examples/block folder illustrates usage of
+ * dynamically shared memory with BlockReduce and how to re-purpose
+ * the same memory region:
+ * <a href="../../examples/block/example_block_reduce_dyn_smem.cu">example_block_reduce_dyn_smem.cu</a>
+ *
+ * This example can be easily adapted to the storage required by BlockLoad.
  */
 template <
     typename            InputT,

--- a/cub/block/block_merge_sort.cuh
+++ b/cub/block/block_merge_sort.cuh
@@ -165,6 +165,13 @@ __device__ __forceinline__ void SerialMerge(KeyT *keys_shared,
  * The corresponding output \p thread_keys in those threads will be
  * <tt>{ [0,1,2,3], [4,5,6,7], [8,9,10,11], ..., [508,509,510,511] }</tt>.
  *
+ * \par Re-using dynamically allocating shared memory
+ * The following example under the examples/block folder illustrates usage of
+ * dynamically shared memory with BlockReduce and how to re-purpose
+ * the same memory region:
+ * <a href="../../examples/block/example_block_reduce_dyn_smem.cu">example_block_reduce_dyn_smem.cu</a>
+ *
+ * This example can be easily adapted to the storage required by BlockMergeSort.
  */
 template <
   typename  KeyT,

--- a/cub/block/block_radix_rank.cuh
+++ b/cub/block/block_radix_rank.cuh
@@ -125,6 +125,14 @@ struct BlockRadixRankEmptyCallback
  *      {
  *
  *      \endcode
+ *
+ * \par Re-using dynamically allocating shared memory
+ * The following example under the examples/block folder illustrates usage of
+ * dynamically shared memory with BlockReduce and how to re-purpose
+ * the same memory region:
+ * <a href="../../examples/block/example_block_reduce_dyn_smem.cu">example_block_reduce_dyn_smem.cu</a>
+ *
+ * This example can be easily adapted to the storage required by BlockRadixRank.
  */
 template <
     int                     BLOCK_DIM_X,

--- a/cub/block/block_radix_sort.cuh
+++ b/cub/block/block_radix_sort.cuh
@@ -151,6 +151,13 @@ CUB_NAMESPACE_BEGIN
  * corresponding output \p thread_keys in those threads will be
  * <tt>{ [0,1,2,3], [4,5,6,7], [8,9,10,11], ..., [508,509,510,511] }</tt>.
  *
+ * \par Re-using dynamically allocating shared memory
+ * The following example under the examples/block folder illustrates usage of
+ * dynamically shared memory with BlockReduce and how to re-purpose
+ * the same memory region:
+ * <a href="../../examples/block/example_block_reduce_dyn_smem.cu">example_block_reduce_dyn_smem.cu</a>
+ *
+ * This example can be easily adapted to the storage required by BlockRadixSort.
  */
 template <
     typename                KeyT,

--- a/cub/block/block_reduce.cuh
+++ b/cub/block/block_reduce.cuh
@@ -207,8 +207,9 @@ enum BlockReduceAlgorithm
  * \endcode
  *
  * \par Re-using dynamically allocating shared memory
- * The following example illustrates usage of dynamically shared memory
- * with BlockReduce and how to re-purpose the same memory region:
+ * The following example under the examples/block folder illustrates usage of
+ * dynamically shared memory with BlockReduce and how to re-purpose
+ * the same memory region:
  * <a href="../../examples/block/example_block_reduce_dyn_smem.cu">example_block_reduce_dyn_smem.cu</a>
  */
 template <

--- a/cub/block/block_reduce.cuh
+++ b/cub/block/block_reduce.cuh
@@ -207,48 +207,9 @@ enum BlockReduceAlgorithm
  * \endcode
  *
  * \par Re-using dynamically allocating shared memory
- * The code snippet below illustrates usage of dynamically shared memory
- * with BlockReduce and how to re-purpose the same memory region
- * \par
- * \code
- * #include <cub/cub.cuh>   // or equivalently <cub/block/block_reduce.cuh>
- *
- * __global__ void ExampleKernel(...)
- * {
- *     typedef cub::BlockReduce<int, 128> BlockReduce;
- *
- *     // shared memory byte-array
- *     extern __shared__ char smem[];
- *     // cast to lvalue reference of expected type
- *     auto& temp_storage = *reinterpret_cast<typename BlockReduce::TempStorage*>(smem);
- *
- *     // use as in example above
- *     int aggregate = BlockReduce(temp_storage).Sum(...)
- *     ...
- *
- *     // block-wide sync barrier necessary to re-use shared mem safely
- *     __syncthreads();
- *     int* smem_integers = reinterpret_cast<int*>(smem);
- *     if (threadIdx.x == 0) smem_integers[0] = 42;
- *     ...
- * }
- *
- * void host_code(...)
- * {
- *     // the size of temporary storage can be deduced automatically
- *     // from device code only. On the host side, the architecture must be
- *     // specified explicitly. For a range of architectures, one could
- *     // perform a max op over several values (600, 700, 800 etc.)
- *     // Additionally, we specify type, block size (x dim), reduce algorithm,
- *     // and the block sizes in y/z dim
- *     constexpr int ARCH = 700;
- *     // we need at least size for 1 integer in our kernel
- *     auto smem_size = max(sizeof(int), sizeof(typename cub::BlockReduce<
- *         int, 128, cub::BLOCK_REDUCE_WARP_REDUCTIONS,
- *         1, 1, ARCH>::TempStorage));
- *     ExampleKernel<<<num_blocks, 128, smem_size, stream>>>(...);
- *
- * \endcode
+ * The following example illustrates usage of dynamically shared memory
+ * with BlockReduce and how to re-purpose the same memory region:
+ * <a href="../../examples/block/example_block_reduce_dyn_smem.cu">example_block_reduce_dyn_smem.cu</a>
  */
 template <
     typename                T,

--- a/cub/block/block_scan.cuh
+++ b/cub/block/block_scan.cuh
@@ -177,6 +177,13 @@ enum BlockScanAlgorithm
  * The corresponding output \p thread_data in those threads will be
  * <tt>{[0,1,2,3], [4,5,6,7], ..., [508,509,510,511]}</tt>.
  *
+ * \par Re-using dynamically allocating shared memory
+ * The following example under the examples/block folder illustrates usage of
+ * dynamically shared memory with BlockReduce and how to re-purpose
+ * the same memory region:
+ * <a href="../../examples/block/example_block_reduce_dyn_smem.cu">example_block_reduce_dyn_smem.cu</a>
+ *
+ * This example can be easily adapted to the storage required by BlockScan.
  */
 template <
     typename            T,

--- a/cub/block/block_store.cuh
+++ b/cub/block/block_store.cuh
@@ -514,6 +514,13 @@ enum BlockStoreAlgorithm
  * <tt>{ [0,1,2,3], [4,5,6,7], ..., [508,509,510,511] }</tt>.
  * The output \p d_data will be <tt>0, 1, 2, 3, 4, 5, ...</tt>.
  *
+ * \par Re-using dynamically allocating shared memory
+ * The following example under the examples/block folder illustrates usage of
+ * dynamically shared memory with BlockReduce and how to re-purpose
+ * the same memory region:
+ * <a href="../../examples/block/example_block_reduce_dyn_smem.cu">example_block_reduce_dyn_smem.cu</a>
+ *
+ * This example can be easily adapted to the storage required by BlockStore.
  */
 template <
     typename                T,

--- a/examples/block/example_block_reduce_dyn_smem.cu
+++ b/examples/block/example_block_reduce_dyn_smem.cu
@@ -73,7 +73,7 @@ constexpr std::size_t arch_bytes_size = sizeof(
         ARCH>::TempStorage
 );
 template <typename T, int BLOCK_THREADS, int... Archs>
-constexpr auto archs_max_bytes = std::max(
+constexpr auto archs_max_bytes = (std::max)(
     {arch_bytes_size<T, BLOCK_THREADS, Archs>...,});
 
 
@@ -177,7 +177,7 @@ void Test()
         int, BLOCK_THREADS, 600, 700, 800>;
     // finally, we need to make sure that we can hold at least one integer
     // needed in the kernel to exchange data after reduction
-    auto smem_size = std::max(1 * sizeof(int), block_reduce_temp_bytes);
+    auto smem_size = (std::max)(1 * sizeof(int), block_reduce_temp_bytes);
 
     // use default stream
     cudaStream_t stream = NULL;

--- a/examples/block/example_block_reduce_dyn_smem.cu
+++ b/examples/block/example_block_reduce_dyn_smem.cu
@@ -46,6 +46,9 @@
 
 #include "../../test/test_util.h"
 
+// Some implementation details rely on c++14
+#if CUB_CPP_DIALECT >= 2014
+
 using namespace cub;
 
 //---------------------------------------------------------------------
@@ -244,3 +247,9 @@ int main(int argc, char** argv)
 
     return 0;
 }
+
+#else // < C++14
+
+int main() {}
+
+#endif

--- a/examples/block/example_block_reduce_dyn_smem.cu
+++ b/examples/block/example_block_reduce_dyn_smem.cu
@@ -95,14 +95,14 @@ __global__ void BlockReduceKernel(
     )
 {
     // Specialize BlockReduce type for our thread block
-    typedef cub::BlockReduce<int, BLOCK_THREADS> BlockReduceT;
+    using BlockReduceT = cub::BlockReduce<int, BLOCK_THREADS>;
+    using TempStorageT = typename BlockReduceT::TempStorage;
 
     // shared memory byte-array
     extern __shared__ char smem[];
     
     // cast to lvalue reference of expected type
-    auto& temp_storage = *reinterpret_cast<typename BlockReduceT::TempStorage*>(
-        smem);
+    auto& temp_storage = reinterpret_cast<TempStorageT&>(smem);
 
     int data = d_in[threadIdx.x];
 

--- a/examples/block/example_block_reduce_dyn_smem.cu
+++ b/examples/block/example_block_reduce_dyn_smem.cu
@@ -83,10 +83,10 @@ constexpr auto archs_max_bytes = std::max(
 //---------------------------------------------------------------------
 
 /**
- * Simple kernel for performing a block-wide exclusive prefix sum over integers
+ * Simple kernel for performing a block-wide reduction.
  */
 template <int BLOCK_THREADS>
-__global__ void BlockSumKernel(
+__global__ void BlockReduceKernel(
     int         *d_in,          // Tile of input
     int         *d_out          // Tile aggregate
     )
@@ -182,8 +182,8 @@ void Test()
     // use default stream
     cudaStream_t stream = NULL;
 
-    // Run aggregate/prefix kernel
-    BlockSumKernel<BLOCK_THREADS>
+    // Run reduction kernel
+    BlockReduceKernel<BLOCK_THREADS>
         <<<g_grid_size, BLOCK_THREADS, smem_size, stream>>>(
             d_in,
             d_out);

--- a/examples/block/example_block_reduce_dyn_smem.cu
+++ b/examples/block/example_block_reduce_dyn_smem.cu
@@ -1,0 +1,246 @@
+/******************************************************************************
+ * Copyright (c) 2011-2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Simple demonstration of cub::BlockReduce with dynamic shared memory
+ *
+ * To compile using the command line:
+ *   nvcc -arch=sm_XX example_block_reduce_dyn_smem.cu -I../.. -lcudart -O3 -std=c++14
+ *
+ ******************************************************************************/
+
+// Ensure printing of CUDA runtime errors to console (define before including cub.h)
+#define CUB_STDERR
+
+#include <stdio.h>
+#include <algorithm>
+#include <iostream>
+
+#include <cub/block/block_load.cuh>
+#include <cub/block/block_store.cuh>
+#include <cub/block/block_reduce.cuh>
+
+#include "../../test/test_util.h"
+
+using namespace cub;
+
+//---------------------------------------------------------------------
+// Globals, constants and typedefs
+//---------------------------------------------------------------------
+
+/// Verbose output
+bool g_verbose = false;
+
+/// Default grid size
+int g_grid_size = 1;
+
+// The following templated variables are helpers to get the shared memory
+// This requires C++ 14 (template variables and constexpr max)
+// but it's possible to work around these constructs for older C++ versions.
+// we use default arguments from cub's block reduce for most parameters
+template <typename T, int BLOCK_THREADS, int ARCH>
+constexpr std::size_t arch_bytes_size = sizeof(
+    typename cub::BlockReduce<
+        T,
+        BLOCK_THREADS,
+        BLOCK_REDUCE_WARP_REDUCTIONS /* ALGORITHM */,
+        1 /* BLOCK_DIM_Y */,
+        1 /* BLOCK_DIM_Z */,
+        ARCH>::TempStorage
+);
+template <typename T, int BLOCK_THREADS, int... Archs>
+constexpr auto archs_max_bytes = std::max(
+    {arch_bytes_size<T, BLOCK_THREADS, Archs>...,});
+
+
+
+//---------------------------------------------------------------------
+// Kernels
+//---------------------------------------------------------------------
+
+/**
+ * Simple kernel for performing a block-wide exclusive prefix sum over integers
+ */
+template <int BLOCK_THREADS>
+__global__ void BlockSumKernel(
+    int         *d_in,          // Tile of input
+    int         *d_out          // Tile aggregate
+    )
+{
+    // Specialize BlockReduce type for our thread block
+    typedef cub::BlockReduce<int, BLOCK_THREADS> BlockReduceT;
+
+    // shared memory byte-array
+    extern __shared__ char smem[];
+    
+    // cast to lvalue reference of expected type
+    auto& temp_storage = *reinterpret_cast<typename BlockReduceT::TempStorage*>(
+        smem);
+
+    int data = d_in[threadIdx.x];
+
+    // Compute sum
+    int aggregate = BlockReduceT(temp_storage).Sum(data);
+
+    // block-wide sync barrier necessary to re-use shared mem safely
+    __syncthreads();
+    int* smem_integers = reinterpret_cast<int*>(smem);
+    if (threadIdx.x == 0) smem_integers[0] = aggregate;
+
+    // sync to make new shared value available to all threads
+    __syncthreads();
+    aggregate = smem_integers[0];
+
+    // all threads write the aggregate to output
+    d_out[threadIdx.x] = aggregate;
+}
+
+
+
+//---------------------------------------------------------------------
+// Host utilities
+//---------------------------------------------------------------------
+
+/**
+ * Initialize reduction problem (and solution).
+ * Returns the aggregate
+ */
+int Initialize(int *h_in, int num_items)
+{
+    int inclusive = 0;
+
+    for (int i = 0; i < num_items; ++i)
+    {
+        h_in[i] = i % 17;
+        inclusive += h_in[i];
+    }
+
+    return inclusive;
+}
+
+/**
+ * Test thread block reduction
+ */
+template <int BLOCK_THREADS>
+void Test()
+{
+    // Allocate host arrays
+    int *h_in = new int[BLOCK_THREADS];
+
+    // Initialize problem and reference output on host
+    int h_aggregate = Initialize(h_in, BLOCK_THREADS);
+
+    // Initialize device arrays
+    int *d_in           = NULL;
+    int *d_out          = NULL;
+    cudaMalloc((void**)&d_in,          sizeof(int) * BLOCK_THREADS);
+    cudaMalloc((void**)&d_out,         sizeof(int) * BLOCK_THREADS);
+
+    // Display input problem data
+    if (g_verbose)
+    {
+        printf("Input data: ");
+        for (int i = 0; i < BLOCK_THREADS; i++)
+            printf("%d, ", h_in[i]);
+        printf("\n\n");
+    }
+
+    // Copy problem to device
+    cudaMemcpy(d_in, h_in, sizeof(int) * BLOCK_THREADS, cudaMemcpyHostToDevice);
+
+    // determine necessary storage for a few architectures
+    auto block_reduce_temp_bytes = archs_max_bytes<
+        int, BLOCK_THREADS, 600, 700, 800>;
+    // finally, we need to make sure that we can hold at least one integer
+    // needed in the kernel to exchange data after reduction
+    auto smem_size = std::max(1 * sizeof(int), block_reduce_temp_bytes);
+
+    // use default stream
+    cudaStream_t stream = NULL;
+
+    // Run aggregate/prefix kernel
+    BlockSumKernel<BLOCK_THREADS>
+        <<<g_grid_size, BLOCK_THREADS, smem_size, stream>>>(
+            d_in,
+            d_out);
+
+    // Check total aggregate
+    printf("\tAggregate: ");
+    int compare = 0;
+    for (int i = 0; i < BLOCK_THREADS; i++) {
+        compare = compare || CompareDeviceResults(
+            &h_aggregate, d_out + i, 1, g_verbose, g_verbose);
+    }
+    printf("%s\n", compare ? "FAIL" : "PASS");
+    AssertEquals(0, compare);
+
+    // Check for kernel errors and STDIO from the kernel, if any
+    CubDebugExit(cudaPeekAtLastError());
+    CubDebugExit(cudaDeviceSynchronize());
+
+    // Cleanup
+    if (h_in) delete[] h_in;
+    if (d_in) cudaFree(d_in);
+    if (d_out) cudaFree(d_out);
+}
+
+
+/**
+ * Main
+ */
+int main(int argc, char** argv)
+{
+    // Initialize command line
+    CommandLineArgs args(argc, argv);
+    g_verbose = args.CheckCmdLineFlag("v");
+    args.GetCmdLineArgument("grid-size", g_grid_size);
+
+    // Print usage
+    if (args.CheckCmdLineFlag("help"))
+    {
+        printf("%s "
+            "[--device=<device-id>] "
+            "[--grid-size=<grid size>] "
+            "[--v] "
+            "\n", argv[0]);
+        exit(0);
+    }
+
+    // Initialize device
+    CubDebugExit(args.DeviceInit());
+
+    // Run tests
+    Test<1024>();
+    Test<512>();
+    Test<256>();
+    Test<128>();
+    Test<64>();
+    Test<32>();
+    Test<16>();
+
+    return 0;
+}


### PR DESCRIPTION
As mentioned in https://github.com/NVIDIA/cub/issues/344, I created this PR to add a simple example of how to correctly use dynamic shared memory with `BlockReduce`.

I hope I followed the PR process correctly, I wasn't able to re-build the docs because the full build (for thrust) took longer than my allocated time on the machine when I was working on this, and I'm not familiar enough with the build process s.t. I can simply only build the docs for cub.
I'll amend the pull request, of course, if needed.

Plus, do you want me to add a similar example to classes like `BlockScan` ? In this case, it may be better to add an actual example file and link to it from the various inline docs.