### PR TITLE
cub::DeviceSpmv: Various fixes and tests

### DIFF
--- a/cub/agent/agent_spmv_orig.cuh
+++ b/cub/agent/agent_spmv_orig.cuh
@@ -44,7 +44,6 @@
 #include "../thread/thread_operators.cuh"
 #include "../iterator/cache_modified_input_iterator.cuh"
 #include "../iterator/counting_input_iterator.cuh"
-#include "../iterator/tex_obj_input_iterator.cuh"
 
 CUB_NAMESPACE_BEGIN
 
@@ -104,8 +103,6 @@ struct SpmvParams
     int             num_nonzeros;        ///< Number of nonzero elements of matrix <b>A</b>.
     ValueT          alpha;               ///< Alpha multiplicand
     ValueT          beta;                ///< Beta addend-multiplicand
-
-    TexObjInputIterator<ValueT, OffsetT>  t_vector_x;
 };
 
 
@@ -328,10 +325,8 @@ struct AgentSpmv
             OffsetT column_idx          = wd_column_indices[nonzero_idx];
             ValueT  value               = wd_values[nonzero_idx];
 
-            ValueT  vector_value        = spmv_params.t_vector_x[column_idx];
-#if (CUB_PTX_ARCH >= 350)
-            vector_value                = wd_vector_x[column_idx];
-#endif
+            ValueT  vector_value        = wd_vector_x[column_idx];
+
             ValueT  nonzero             = value * vector_value;
 
             OffsetT row_end_offset      = s_tile_row_end_offsets[thread_current_coord.x];
@@ -437,8 +432,7 @@ struct AgentSpmv
                 OffsetT column_idx              = *ci;
                 ValueT  value                   = *a;
 
-                ValueT  vector_value            = spmv_params.t_vector_x[column_idx];
-                vector_value                    = wd_vector_x[column_idx];
+                ValueT  vector_value            = wd_vector_x[column_idx];
 
                 ValueT  nonzero                 = value * vector_value;
 
@@ -464,10 +458,8 @@ struct AgentSpmv
                 OffsetT column_idx              = wd_column_indices[tile_start_coord.y + nonzero_idx];
                 ValueT  value                   = wd_values[tile_start_coord.y + nonzero_idx];
 
-                ValueT  vector_value            = spmv_params.t_vector_x[column_idx];
-#if (CUB_PTX_ARCH >= 350)
-                vector_value                    = wd_vector_x[column_idx];
-#endif
+                ValueT  vector_value            = wd_vector_x[column_idx];
+
                 ValueT  nonzero                 = value * vector_value;
 
                 s_tile_nonzeros[nonzero_idx]    = nonzero;

--- a/cub/agent/agent_spmv_orig.cuh
+++ b/cub/agent/agent_spmv_orig.cuh
@@ -291,9 +291,12 @@ struct AgentSpmv
         OffsetT*    s_tile_row_end_offsets  = &temp_storage.aliasable.merge_items[0].row_end_offset;
 
         // Gather the row end-offsets for the merge tile into shared memory
-        for (int item = threadIdx.x; item <= tile_num_rows; item += BLOCK_THREADS)
+        for (int item = threadIdx.x; item < tile_num_rows + ITEMS_PER_THREAD; item += BLOCK_THREADS)
         {
-            s_tile_row_end_offsets[item] = wd_row_end_offsets[tile_start_coord.x + item];
+            const OffsetT offset =
+              (cub::min)(static_cast<OffsetT>(tile_start_coord.x + item),
+                         static_cast<OffsetT>(spmv_params.num_rows - 1));
+            s_tile_row_end_offsets[item] = wd_row_end_offsets[offset];
         }
 
         CTA_SYNC();
@@ -470,9 +473,12 @@ struct AgentSpmv
 
         // Gather the row end-offsets for the merge tile into shared memory
         #pragma unroll 1
-        for (int item = threadIdx.x; item <= tile_num_rows; item += BLOCK_THREADS)
+        for (int item = threadIdx.x; item < tile_num_rows + ITEMS_PER_THREAD; item += BLOCK_THREADS)
         {
-            s_tile_row_end_offsets[item] = wd_row_end_offsets[tile_start_coord.x + item];
+            const OffsetT offset =
+              (cub::min)(static_cast<OffsetT>(tile_start_coord.x + item),
+                         static_cast<OffsetT>(spmv_params.num_rows - 1));
+            s_tile_row_end_offsets[item] = wd_row_end_offsets[offset];
         }
 
         CTA_SYNC();

--- a/cub/agent/agent_spmv_orig.cuh
+++ b/cub/agent/agent_spmv_orig.cuh
@@ -94,10 +94,10 @@ template <
     typename        OffsetT>             ///< Signed integer type for sequence offsets
 struct SpmvParams
 {
-    ValueT*         d_values;            ///< Pointer to the array of \p num_nonzeros values of the corresponding nonzero elements of matrix <b>A</b>.
-    OffsetT*        d_row_end_offsets;   ///< Pointer to the array of \p m offsets demarcating the end of every row in \p d_column_indices and \p d_values
-    OffsetT*        d_column_indices;    ///< Pointer to the array of \p num_nonzeros column-indices of the corresponding nonzero elements of matrix <b>A</b>.  (Indices are zero-valued.)
-    ValueT*         d_vector_x;          ///< Pointer to the array of \p num_cols values corresponding to the dense input vector <em>x</em>
+    const ValueT*   d_values;            ///< Pointer to the array of \p num_nonzeros values of the corresponding nonzero elements of matrix <b>A</b>.
+    const OffsetT*  d_row_end_offsets;   ///< Pointer to the array of \p m offsets demarcating the end of every row in \p d_column_indices and \p d_values
+    const OffsetT*  d_column_indices;    ///< Pointer to the array of \p num_nonzeros column-indices of the corresponding nonzero elements of matrix <b>A</b>.  (Indices are zero-valued.)
+    const ValueT*   d_vector_x;          ///< Pointer to the array of \p num_cols values corresponding to the dense input vector <em>x</em>
     ValueT*         d_vector_y;          ///< Pointer to the array of \p num_rows values corresponding to the dense output vector <em>y</em>
     int             num_rows;            ///< Number of rows of matrix <b>A</b>.
     int             num_cols;            ///< Number of columns of matrix <b>A</b>.

--- a/cub/device/device_spmv.cuh
+++ b/cub/device/device_spmv.cuh
@@ -128,10 +128,10 @@ struct DeviceSpmv
     static cudaError_t CsrMV(
         void*               d_temp_storage,                     ///< [in] %Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
         size_t&             temp_storage_bytes,                 ///< [in,out] Reference to size in bytes of \p d_temp_storage allocation
-        ValueT*             d_values,                           ///< [in] Pointer to the array of \p num_nonzeros values of the corresponding nonzero elements of matrix <b>A</b>.
-        int*                d_row_offsets,                      ///< [in] Pointer to the array of \p m + 1 offsets demarcating the start of every row in \p d_column_indices and \p d_values (with the final entry being equal to \p num_nonzeros)
-        int*                d_column_indices,                   ///< [in] Pointer to the array of \p num_nonzeros column-indices of the corresponding nonzero elements of matrix <b>A</b>.  (Indices are zero-valued.)
-        ValueT*             d_vector_x,                         ///< [in] Pointer to the array of \p num_cols values corresponding to the dense input vector <em>x</em>
+        const ValueT*       d_values,                           ///< [in] Pointer to the array of \p num_nonzeros values of the corresponding nonzero elements of matrix <b>A</b>.
+        const int*          d_row_offsets,                      ///< [in] Pointer to the array of \p m + 1 offsets demarcating the start of every row in \p d_column_indices and \p d_values (with the final entry being equal to \p num_nonzeros)
+        const int*          d_column_indices,                   ///< [in] Pointer to the array of \p num_nonzeros column-indices of the corresponding nonzero elements of matrix <b>A</b>.  (Indices are zero-valued.)
+        const ValueT*       d_vector_x,                         ///< [in] Pointer to the array of \p num_cols values corresponding to the dense input vector <em>x</em>
         ValueT*             d_vector_y,                         ///< [out] Pointer to the array of \p num_rows values corresponding to the dense output vector <em>y</em>
         int                 num_rows,                           ///< [in] number of rows of matrix <b>A</b>.
         int                 num_cols,                           ///< [in] number of columns of matrix <b>A</b>.

--- a/cub/device/device_spmv.cuh
+++ b/cub/device/device_spmv.cuh
@@ -148,8 +148,8 @@ struct DeviceSpmv
         spmv_params.num_rows             = num_rows;
         spmv_params.num_cols             = num_cols;
         spmv_params.num_nonzeros         = num_nonzeros;
-        spmv_params.alpha                = 1.0;
-        spmv_params.beta                 = 0.0;
+        spmv_params.alpha                = ValueT{1};
+        spmv_params.beta                 = ValueT{0};
 
         return DispatchSpmv<ValueT, int>::Dispatch(
             d_temp_storage,

--- a/cub/device/dispatch/dispatch_spmv_orig.cuh
+++ b/cub/device/dispatch/dispatch_spmv_orig.cuh
@@ -618,14 +618,6 @@ struct DispatchSpmv
             int search_block_size   = INIT_KERNEL_THREADS;
             int search_grid_size    = cub::DivideAndRoundUp(num_merge_tiles + 1, search_block_size);
 
-            #if CUB_INCLUDE_HOST_CODE
-                if (CUB_IS_HOST_CODE)
-                {
-                    // Init textures
-                    if (CubDebug(error = spmv_params.t_vector_x.BindTexture(spmv_params.d_vector_x, spmv_params.num_cols * sizeof(ValueT)))) break;
-                }
-            #endif
-
             if (search_grid_size < sm_count)
 //            if (num_merge_tiles < spmv_sm_occupancy * sm_count)
             {
@@ -700,14 +692,6 @@ struct DispatchSpmv
                 // Sync the stream if specified to flush runtime errors
                 if (debug_synchronous && (CubDebug(error = SyncStream(stream)))) break;
             }
-
-            #if CUB_INCLUDE_HOST_CODE
-                if (CUB_IS_HOST_CODE)
-                {
-                    // Free textures
-                    if (CubDebug(error = spmv_params.t_vector_x.UnbindTexture())) break;
-                }
-            #endif
         }
         while (0);
 

--- a/cub/device/dispatch/dispatch_spmv_orig.cuh
+++ b/cub/device/dispatch/dispatch_spmv_orig.cuh
@@ -497,6 +497,21 @@ struct DispatchSpmv
         cudaError error = cudaSuccess;
         do
         {
+            if (spmv_params.num_rows < 0 || spmv_params.num_cols < 0)
+            {
+              return cudaErrorInvalidValue;
+            }
+
+            if (spmv_params.num_rows == 0 || spmv_params.num_cols == 0)
+            { // Empty problem, no-op.
+                if (d_temp_storage == NULL)
+                {
+                    temp_storage_bytes = 1;
+                }
+
+                break;
+            }
+
             if (spmv_params.num_cols == 1)
             {
                 if (d_temp_storage == NULL)

--- a/cub/iterator/tex_obj_input_iterator.cuh
+++ b/cub/iterator/tex_obj_input_iterator.cuh
@@ -161,7 +161,7 @@ public:
         size_t          tex_offset = 0)     ///< OffsetT (in items) from \p ptr denoting the position of the iterator
     {
         this->ptr = const_cast<typename RemoveQualifiers<QualifiedT>::Type *>(ptr);
-        this->tex_offset = tex_offset;
+        this->tex_offset = static_cast<difference_type>(tex_offset);
 
         cudaChannelFormatDesc   channel_desc = cudaCreateChannelDesc<TextureWord>();
         cudaResourceDesc        res_desc;

--- a/test/test_device_spmv.cu
+++ b/test/test_device_spmv.cu
@@ -1,0 +1,597 @@
+/******************************************************************************
+ * Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+// Ensure printing of CUDA runtime errors to console
+#define CUB_STDERR
+
+#include <thrust/device_vector.h>
+#include <thrust/distance.h>
+#include <thrust/host_vector.h>
+#include <thrust/mismatch.h>
+#include <thrust/scan.h>
+
+#include <cub/device/device_spmv.cuh>
+#include <cub/util_debug.cuh>
+
+#include <iostream>
+#include <type_traits>
+#include <typeinfo>
+
+#include "test_util.h"
+
+bool g_verbose = false;
+
+//==============================================================================
+// Casts char types to int for numeric printing
+template <typename T>
+T print_cast(T val)
+{
+  return val;
+}
+
+int print_cast(char val) { return static_cast<int>(val); }
+
+int print_cast(signed char val) { return static_cast<int>(val); }
+
+int print_cast(unsigned char val) { return static_cast<int>(val); }
+
+//==============================================================================
+// Print a vector to out
+template <typename VectorT>
+void print_vector(std::ostream& out, const VectorT& vec)
+{
+  bool first = true;
+  for (const auto& val : vec)
+  {
+    if (!first)
+    {
+      out << ", ";
+    }
+    first = false;
+    out << print_cast(val);
+  }
+}
+
+//==============================================================================
+// Simple CSR matrix implementation.
+// HostStorage controls whether data is stored on the host or device.
+// Use the host_csr_matrix and device_csr_matrix aliases for code clarity.
+template <typename ValueT, bool HostStorage>
+struct csr_matrix
+{
+  csr_matrix(int num_rows, int num_cols)
+      : m_row_offsets(static_cast<size_t>(num_rows + 1), 0)
+      , m_num_rows(num_rows)
+      , m_num_columns(num_cols)
+  {}
+
+  // host/device conversion constructor
+  explicit csr_matrix(const csr_matrix<ValueT, !HostStorage>& other)
+      : m_values(other.m_values)
+      , m_row_offsets(other.m_row_offsets)
+      , m_column_indices(other.m_column_indices)
+      , m_num_rows(other.m_num_rows)
+      , m_num_columns(other.m_num_columns)
+      , m_num_nonzeros(other.m_num_nonzeros)
+  {}
+
+  // Note that this must append to the values array. Finish filling each row
+  // before adding to the next, and each row's columns must be added in order.
+  // Must call `finalize` once all items are added.
+  void append_value(int row, int col, ValueT value)
+  {
+    ++m_num_nonzeros;
+    ++m_row_offsets[row];
+    m_column_indices.push_back(col);
+    m_values.push_back(std::move(value));
+  }
+
+  void finalize()
+  {
+    thrust::exclusive_scan(m_row_offsets.cbegin(),
+                           m_row_offsets.cend(),
+                           m_row_offsets.begin());
+    AssertEquals(m_row_offsets.back(), m_num_nonzeros);
+  }
+
+  const ValueT* get_values() const
+  {
+    return thrust::raw_pointer_cast(m_values.data());
+  }
+
+  const int* get_row_offsets() const
+  {
+    return thrust::raw_pointer_cast(m_row_offsets.data());
+  }
+
+  int get_row_offset(int row) const { return m_row_offsets[row]; }
+
+  int get_row_num_nonzero(int row) const
+  {
+    return m_row_offsets[row + 1] - m_row_offsets[row];
+  }
+
+  const int* get_column_indices() const
+  {
+    return thrust::raw_pointer_cast(m_column_indices.data());
+  }
+
+  int get_num_rows() const { return m_num_rows; }
+
+  int get_num_columns() const { return m_num_columns; }
+
+  int get_num_nonzeros() const { return m_num_nonzeros; }
+
+  void print_internals(std::ostream& out) const
+  {
+    out << (HostStorage ? "host" : "device") << "_csr_matrix"
+        << "(" << m_num_rows << ", " << m_num_columns << ")\n"
+        << " - num_elems:   " << (m_num_rows * m_num_columns) << "\n"
+        << " - num_nonzero: " << m_num_nonzeros << "\n"
+        << " - row_offsets:\n     [";
+    print_vector(out, m_row_offsets);
+    out << "]\n"
+        << " - column_indices:\n     [";
+    print_vector(out, m_column_indices);
+    out << "]\n"
+        << " - values:\n     [";
+    print_vector(out, m_values);
+    out << "]\n";
+  }
+
+  void print_summary(std::ostream& out) const
+  {
+    const int num_elems = m_num_rows * m_num_columns;
+    const float fill_ratio =
+      num_elems == 0
+        ? 0.f
+        : (static_cast<float>(m_num_nonzeros) / static_cast<float>(num_elems));
+
+    out << m_num_rows << "x" << m_num_columns << ", " << m_num_nonzeros << "/"
+        << num_elems << " (" << fill_ratio << ")\n";
+  }
+
+  friend class csr_matrix<ValueT, !HostStorage>;
+
+private:
+  template <typename VecValueT>
+  using vector_t =
+    typename std::conditional<HostStorage,
+                              thrust::host_vector<VecValueT>,
+                              thrust::device_vector<VecValueT>>::type;
+
+  vector_t<ValueT> m_values;
+  vector_t<int> m_row_offsets;
+  vector_t<int> m_column_indices;
+
+  int m_num_rows{0};
+  int m_num_columns{0};
+  int m_num_nonzeros{0};
+};
+
+//==============================================================================
+// Convenience aliases for host/device csr_matrix types.
+template <typename ValueT>
+using host_csr_matrix = csr_matrix<ValueT, true>;
+
+template <typename ValueT>
+using device_csr_matrix = csr_matrix<ValueT, false>;
+
+//==============================================================================
+// Compare two floats within a tolerance.
+// This mimics the approach used by Thrust's ASSERT_ALMOST_EQUAL checks.
+template <typename ValueT>
+struct fp_almost_equal_functor
+{
+  __host__ __device__ bool operator()(ValueT v1, ValueT v2) const
+  {
+    constexpr double r_tol = 1e-3;
+    constexpr double a_tol = 1e-2;
+    const double limit     = r_tol * (std::fabs(v1) + std::fabs(v2)) + a_tol;
+    return std::fabs(v1 - v2) <= limit;
+  }
+};
+
+//==============================================================================
+// Compare the reference and cub output vectors.
+// Use fuzzy check for floating point values.
+template <typename ValueT>
+bool compare_results(std::true_type /* is_fp */,
+                     const thrust::host_vector<ValueT>& h_vec1,
+                     const thrust::device_vector<ValueT>& d_vec2)
+{
+  thrust::device_vector<ValueT> d_vec1(h_vec1);
+  auto err = thrust::mismatch(d_vec1.cbegin(),
+                              d_vec1.cend(),
+                              d_vec2.cbegin(),
+                              fp_almost_equal_functor<ValueT>{});
+  if (err.first == d_vec1.cend() || err.second == d_vec2.cend())
+  {
+    return true;
+  }
+  else
+  {
+    thrust::host_vector<ValueT> h_vec2(d_vec2);
+    const auto idx = thrust::distance(d_vec1.cbegin(), err.first);
+    std::cerr << "Mismatch at position " << idx << ": "
+              << print_cast(ValueT{h_vec1[idx]}) << " vs "
+              << print_cast(ValueT{h_vec2[idx]}) << std::endl;
+    return false;
+  }
+};
+
+template <typename ValueT>
+bool compare_results(std::false_type /* is_fp */,
+                     const thrust::host_vector<ValueT>& h_vec1,
+                     const thrust::device_vector<ValueT>& d_vec2)
+{
+
+  thrust::device_vector<ValueT> d_vec1(h_vec1);
+  auto err = thrust::mismatch(d_vec1.cbegin(), d_vec1.cend(), d_vec2.cbegin());
+  if (err.first == d_vec1.cend() || err.second == d_vec2.cend())
+  {
+    return true;
+  }
+  else
+  {
+    thrust::host_vector<ValueT> h_vec2(d_vec2);
+    const auto idx = thrust::distance(d_vec1.cbegin(), err.first);
+    std::cerr << "Mismatch at position " << idx << ": "
+              << print_cast(ValueT{h_vec1[idx]}) << " vs "
+              << print_cast(ValueT{h_vec2[idx]}) << std::endl;
+    return false;
+  }
+}
+
+//==============================================================================
+// Generate a random host_csr_matrix<ValueT> with the specified dimensions.
+// target_fill_ratio is the target fraction of non-zero elements (may be more
+// or less in the output).
+template <typename ValueT>
+host_csr_matrix<ValueT> make_random_csr_matrix(int num_rows,
+                                               int num_cols,
+                                               float target_fill_ratio)
+{
+  host_csr_matrix<ValueT> mat{num_rows, num_cols};
+
+  for (int row = 0; row < num_rows; ++row)
+  {
+    for (int col = 0; col < num_cols; ++col)
+    {
+      const bool is_non_zero = RandomValue<float>(1.f) < target_fill_ratio;
+      if (!is_non_zero)
+      {
+        continue;
+      }
+
+      if (std::is_floating_point<ValueT>::value)
+      {
+        // Keep fp numbers somewhat small, from -100 -> 100; otherwise we run
+        // into issues with nans/infs
+        ValueT value =
+          (RandomValue(static_cast<ValueT>(200)) - static_cast<ValueT>(100));
+        mat.append_value(row, col, value);
+      }
+      else
+      {
+        ValueT value{};
+        InitValue(RANDOM, value);
+        mat.append_value(row, col, value);
+      }
+    }
+  }
+
+  mat.finalize();
+
+  const int num_elements        = num_rows * num_cols;
+  const float actual_fill_ratio = static_cast<float>(mat.get_num_nonzeros()) /
+                                  static_cast<float>(num_elements);
+
+  if (g_verbose)
+  {
+    printf("Created host_csr_matrix<%s>(%d, %d)\n"
+           " - NumElements: %d\n"
+           " - NumNonZero:  %d\n"
+           " - Target fill: %0.2f%%\n"
+           " - Actual fill: %0.2f%%\n",
+           typeid(ValueT).name(),
+           num_rows,
+           num_cols,
+           num_elements,
+           mat.get_num_nonzeros(),
+           target_fill_ratio,
+           actual_fill_ratio);
+  }
+
+  return mat;
+}
+
+//==============================================================================
+// Fill a vector with random values.
+template <typename ValueT>
+thrust::host_vector<ValueT> make_random_vector(int len)
+{
+  thrust::host_vector<ValueT> vec(len);
+  for (auto& val : vec)
+  {
+    if (std::is_floating_point<ValueT>::value)
+    { // Keep fp numbers somewhat small; otherwise we run into issues with
+      // nans/infs
+      val = RandomValue(static_cast<ValueT>(200)) - static_cast<ValueT>(100);
+    }
+    else
+    {
+      InitValue(RANDOM, val);
+    }
+  }
+  return vec;
+}
+
+//==============================================================================
+// Serial y = Ax computation
+template <typename ValueT>
+void compute_reference_solution(const host_csr_matrix<ValueT>& a,
+                                const thrust::host_vector<ValueT>& x,
+                                thrust::host_vector<ValueT>& y)
+{
+  if (a.get_num_rows() == 0 || a.get_num_columns() == 0)
+  {
+    return;
+  }
+
+  for (int row = 0; row < a.get_num_rows(); ++row)
+  {
+    const int row_offset = a.get_row_offset(row);
+    const int row_length = a.get_row_num_nonzero(row);
+    const int* cols      = a.get_column_indices() + row_offset;
+    const int* cols_end  = cols + row_length;
+    const ValueT* values = a.get_values() + row_offset;
+
+    ValueT accum{};
+    while (cols < cols_end)
+    {
+      accum += (*values++) * x[*cols++];
+    }
+    y[row] = accum;
+  }
+}
+
+//==============================================================================
+// cub::DeviceSpmv::CsrMV y = Ax computation
+template <typename ValueT>
+void compute_cub_solution(const device_csr_matrix<ValueT>& a,
+                          const thrust::device_vector<ValueT>& x,
+                          thrust::device_vector<ValueT>& y)
+{
+  thrust::device_vector<char> temp_storage;
+  std::size_t temp_storage_bytes{};
+  auto err = cub::DeviceSpmv::CsrMV(nullptr,
+                                    temp_storage_bytes,
+                                    a.get_values(),
+                                    a.get_row_offsets(),
+                                    a.get_column_indices(),
+                                    thrust::raw_pointer_cast(x.data()),
+                                    thrust::raw_pointer_cast(y.data()),
+                                    a.get_num_rows(),
+                                    a.get_num_columns(),
+                                    a.get_num_nonzeros());
+  CubDebugExit(err);
+
+  temp_storage.resize(temp_storage_bytes);
+
+  err = cub::DeviceSpmv::CsrMV(thrust::raw_pointer_cast(temp_storage.data()),
+                               temp_storage_bytes,
+                               a.get_values(),
+                               a.get_row_offsets(),
+                               a.get_column_indices(),
+                               thrust::raw_pointer_cast(x.data()),
+                               thrust::raw_pointer_cast(y.data()),
+                               a.get_num_rows(),
+                               a.get_num_columns(),
+                               a.get_num_nonzeros(),
+                               0,
+                               true);
+  CubDebugExit(err);
+}
+
+//==============================================================================
+// Compute y = Ax twice, one reference and one cub::DeviceSpmv, and compare the
+// results.
+template <typename ValueT>
+void test_spmv(const host_csr_matrix<ValueT>& h_a,
+               const thrust::host_vector<ValueT>& h_x)
+{
+  if (g_verbose)
+  {
+    std::cout << "Testing cub::DeviceSpmv on inputs:\n";
+    h_a.print_internals(std::cout);
+    std::cout << "x vector:\n  [";
+    print_vector(std::cout, h_x);
+    std::cout << "]" << std::endl;
+  }
+  else
+  {
+    h_a.print_summary(std::cout);
+  }
+
+  const device_csr_matrix<ValueT> d_a(h_a);
+  const thrust::device_vector<ValueT> d_x(h_x);
+
+  thrust::host_vector<ValueT> h_y(h_a.get_num_rows());
+  thrust::device_vector<ValueT> d_y(d_a.get_num_rows());
+
+  compute_reference_solution(h_a, h_x, h_y);
+  compute_cub_solution(d_a, d_x, d_y);
+
+  if (g_verbose)
+  {
+    std::cout << "reference output:\n  [";
+    print_vector(std::cout, h_y);
+    std::cout << "]\n";
+    thrust::host_vector<ValueT> tmp_y(d_y);
+    std::cout << "cub::DeviceSpmv output:\n  [";
+    print_vector(std::cout, tmp_y);
+    std::cout << "]" << std::endl;
+  }
+
+  constexpr auto is_fp = std::is_floating_point<ValueT>{};
+  AssertTrue(compare_results(is_fp, h_y, d_y));
+}
+
+//==============================================================================
+// Test example from cub::DeviceSpmv documentation
+template <typename ValueT>
+void test_doc_example()
+{
+  std::cout << "\n\ntest_doc_example<" << typeid(ValueT).name() << ">()"
+            << std::endl;
+
+  host_csr_matrix<ValueT> h_a(9, 9);
+  h_a.append_value(0, 1, ValueT{1});
+  h_a.append_value(0, 3, ValueT{1});
+  h_a.append_value(1, 0, ValueT{1});
+  h_a.append_value(1, 2, ValueT{1});
+  h_a.append_value(1, 4, ValueT{1});
+  h_a.append_value(2, 1, ValueT{1});
+  h_a.append_value(2, 5, ValueT{1});
+  h_a.append_value(3, 0, ValueT{1});
+  h_a.append_value(3, 4, ValueT{1});
+  h_a.append_value(3, 6, ValueT{1});
+  h_a.append_value(4, 1, ValueT{1});
+  h_a.append_value(4, 3, ValueT{1});
+  h_a.append_value(4, 5, ValueT{1});
+  h_a.append_value(4, 7, ValueT{1});
+  h_a.append_value(5, 2, ValueT{1});
+  h_a.append_value(5, 4, ValueT{1});
+  h_a.append_value(5, 8, ValueT{1});
+  h_a.append_value(6, 3, ValueT{1});
+  h_a.append_value(6, 7, ValueT{1});
+  h_a.append_value(7, 4, ValueT{1});
+  h_a.append_value(7, 6, ValueT{1});
+  h_a.append_value(7, 8, ValueT{1});
+  h_a.append_value(8, 5, ValueT{1});
+  h_a.append_value(8, 7, ValueT{1});
+  h_a.finalize();
+
+  thrust::host_vector<ValueT> h_x(9, ValueT{1});
+
+  test_spmv(h_a, h_x);
+}
+
+//==============================================================================
+// Generate and test a random SpMV operation with the given parameters.
+template <typename ValueT>
+void test_random(int rows, int cols, float target_fill_ratio)
+{
+  std::cout << "\n\ntest_random<" << typeid(ValueT).name() << ">(" << rows
+            << ", " << cols << ", " << target_fill_ratio << ")" << std::endl;
+
+  host_csr_matrix<ValueT> h_a =
+    make_random_csr_matrix<ValueT>(rows, cols, target_fill_ratio);
+  thrust::host_vector<ValueT> h_x = make_random_vector<ValueT>(cols);
+
+  test_spmv(h_a, h_x);
+}
+
+//==============================================================================
+// Dispatch many random SpMV tests over a variety of parameters.
+template <typename ValueT>
+void test_random()
+{
+  test_random<ValueT>(0, 0, 1.f);
+  test_random<ValueT>(0, 1, 1.f);
+  test_random<ValueT>(1, 0, 1.f);
+
+  const int dim_min = 1;
+  const int dim_max = 10000;
+
+  const int max_num_elems = 100000;
+
+  const float ratio_min  = 0.f;
+  const float ratio_max  = 1.1f; // a lil over to account for fp errors
+  const float ratio_step = 0.3334f;
+
+  for (int rows = dim_min; rows < dim_max; rows <<= 1)
+  {
+    for (int cols = dim_min; cols < dim_max; cols <<= 1)
+    {
+      if (rows * cols >= max_num_elems)
+      {
+        continue;
+      }
+
+      for (float ratio = ratio_min; ratio < ratio_max; ratio += ratio_step)
+      {
+        test_random<ValueT>(rows, cols, ratio);
+        // Test nearby non-power-of-two dims:
+        test_random<ValueT>(rows + 97, cols + 83, ratio);
+      }
+    }
+  }
+}
+
+//==============================================================================
+// Dispatch many SpMV tests for a given ValueT.
+template <typename ValueT>
+void test_type()
+{
+  test_doc_example<ValueT>();
+  test_random<ValueT>();
+}
+
+//==============================================================================
+// Dispatch many SpMV tests over a variety of types.
+void test_types()
+{
+  test_type<float>();
+  test_type<double>();
+  test_type<char>();
+  test_type<int>();
+  test_type<unsigned long long>();
+}
+
+int main(int argc, char** argv)
+{
+  // Initialize command line
+  CommandLineArgs args(argc, argv);
+  g_verbose = args.CheckCmdLineFlag("v");
+
+  // Print usage
+  if (args.CheckCmdLineFlag("help"))
+  {
+    printf("%s "
+           "[--device=<device-id>] "
+           "[--v] verbose"
+           "\n",
+           argv[0]);
+    exit(0);
+  }
+
+  CubDebugExit(args.DeviceInit());
+
+  test_types();
+}

--- a/test/test_util.h
+++ b/test/test_util.h
@@ -83,10 +83,23 @@ T SafeBitCast(const U& in)
 /**
  * Assert equals
  */
-#define AssertEquals(a, b) if ((a) != (b)) { std::cerr << "\n(" << __FILE__ << ": " << __LINE__ << ")\n"; exit(1);}
+#define AssertEquals(a, b)                                                     \
+  if ((a) != (b))                                                              \
+  {                                                                            \
+    std::cerr << "\n"                                                          \
+              << __FILE__ << ": " << __LINE__                                  \
+              << ": AssertEquals(" #a ", " #b ") failed.\n";                   \
+    exit(1);                                                                   \
+  }
 
-#define AssertTrue(a) if (!(a)) { std::cerr << "\n(" << __FILE__ << ": " << __LINE__ << ")\n"; exit(1);}
-
+#define AssertTrue(a)                                                          \
+  if (!(a))                                                                    \
+  {                                                                            \
+    std::cerr << "\n"                                                          \
+              << __FILE__ << ": " << __LINE__                                  \
+              << ": AssertTrue(" #a ") failed.\n";                             \
+    exit(1);                                                                   \
+  }
 
 /******************************************************************************
  * Command-line parsing functionality


### PR DESCRIPTION
Fixes #139 and #285. Includes #160.

This is blocking #276, since we need tests to validate the if-target update for `DeviceSpmv`.