### PR TITLE
Remove Equals and friends

### DIFF
--- a/cub/agent/agent_histogram.cuh
+++ b/cub/agent/agent_histogram.cuh
@@ -111,13 +111,13 @@ struct AgentHistogram
     //---------------------------------------------------------------------
 
     /// The sample type of the input iterator
-    typedef typename std::iterator_traits<SampleIteratorT>::value_type SampleT;
+    using SampleT = cub::detail::value_t<SampleIteratorT>;
 
     /// The pixel type of SampleT
-    typedef typename CubVector<SampleT, NUM_CHANNELS>::Type PixelT;
+    using PixelT = typename CubVector<SampleT, NUM_CHANNELS>::Type;
 
     /// The quad type of SampleT
-    typedef typename CubVector<SampleT, 4>::Type QuadT;
+    using QuadT = typename CubVector<SampleT, 4>::Type;
 
     /// Constants
     enum
@@ -145,10 +145,12 @@ struct AgentHistogram
 
 
     /// Input iterator wrapper type (for applying cache modifier)
-    typedef typename If<IsPointer<SampleIteratorT>::VALUE,
-            CacheModifiedInputIterator<LOAD_MODIFIER, SampleT, OffsetT>,     // Wrap the native input pointer with CacheModifiedInputIterator
-            SampleIteratorT>::Type                                           // Directly use the supplied input iterator type
-        WrappedSampleIteratorT;
+    // Wrap the native input pointer with CacheModifiedInputIterator
+    // or directly use the supplied input iterator type
+    using WrappedSampleIteratorT = cub::detail::conditional_t<
+      std::is_pointer<SampleIteratorT>::value,
+      CacheModifiedInputIterator<LOAD_MODIFIER, SampleT, OffsetT>,
+      SampleIteratorT>;
 
     /// Pixel input iterator type (for applying cache modifier)
     typedef CacheModifiedInputIterator<LOAD_MODIFIER, PixelT, OffsetT>

--- a/cub/agent/agent_merge_sort.cuh
+++ b/cub/agent/agent_merge_sort.cuh
@@ -72,7 +72,7 @@ struct AgentBlockSort
   // Types and constants
   //---------------------------------------------------------------------
 
-  static constexpr bool KEYS_ONLY = Equals<ValueT, NullType>::VALUE;
+  static constexpr bool KEYS_ONLY = std::is_same<ValueT, NullType>::value;
 
   using BlockMergeSortT =
     BlockMergeSort<KeyT, Policy::BLOCK_THREADS, Policy::ITEMS_PER_THREAD, ValueT>;
@@ -415,7 +415,7 @@ struct AgentMerge
   /// Alias wrapper allowing storage to be unioned
   struct TempStorage : Uninitialized<_TempStorage> {};
 
-  static constexpr bool KEYS_ONLY = Equals<ValueT, NullType>::VALUE;
+  static constexpr bool KEYS_ONLY = std::is_same<ValueT, NullType>::value;
   static constexpr int BLOCK_THREADS = Policy::BLOCK_THREADS;
   static constexpr int ITEMS_PER_THREAD = Policy::ITEMS_PER_THREAD;
   static constexpr int ITEMS_PER_TILE = Policy::ITEMS_PER_TILE;

--- a/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/agent/agent_radix_sort_downsweep.cuh
@@ -28,23 +28,25 @@
 
 /**
  * \file
- * AgentRadixSortDownsweep implements a stateful abstraction of CUDA thread blocks for participating in device-wide radix sort downsweep .
+ * AgentRadixSortDownsweep implements a stateful abstraction of CUDA thread
+ * blocks for participating in device-wide radix sort downsweep .
  */
 
 
 #pragma once
 
 #include <stdint.h>
+#include <type_traits>
 
-#include "../thread/thread_load.cuh"
-#include "../block/block_load.cuh"
-#include "../block/block_store.cuh"
-#include "../block/block_radix_rank.cuh"
-#include "../block/block_exchange.cuh"
-#include "../block/radix_rank_sort_operations.cuh"
-#include "../config.cuh"
-#include "../util_type.cuh"
-#include "../iterator/cache_modified_input_iterator.cuh"
+#include <cub/thread/thread_load.cuh>
+#include <cub/block/block_load.cuh>
+#include <cub/block/block_store.cuh>
+#include <cub/block/block_radix_rank.cuh>
+#include <cub/block/block_exchange.cuh>
+#include <cub/block/radix_rank_sort_operations.cuh>
+#include <cub/config.cuh>
+#include <cub/util_type.cuh>
+#include <cub/iterator/cache_modified_input_iterator.cuh>
 
 CUB_NAMESPACE_BEGIN
 
@@ -123,36 +125,41 @@ struct AgentRadixSortDownsweep
         TILE_ITEMS              = BLOCK_THREADS * ITEMS_PER_THREAD,
 
         RADIX_DIGITS            = 1 << RADIX_BITS,
-        KEYS_ONLY               = Equals<ValueT, NullType>::VALUE,
+        KEYS_ONLY               = std::is_same<ValueT, NullType>::value,
         LOAD_WARP_STRIPED       = RANK_ALGORITHM == RADIX_RANK_MATCH ||
                                   RANK_ALGORITHM == RADIX_RANK_MATCH_EARLY_COUNTS_ANY ||
                                   RANK_ALGORITHM == RADIX_RANK_MATCH_EARLY_COUNTS_ATOMIC_OR,
     };
 
     // Input iterator wrapper type (for applying cache modifier)s
-    typedef CacheModifiedInputIterator<LOAD_MODIFIER, UnsignedBits, OffsetT>    KeysItr;
-    typedef CacheModifiedInputIterator<LOAD_MODIFIER, ValueT, OffsetT>          ValuesItr;
+    using KeysItr = CacheModifiedInputIterator<LOAD_MODIFIER, UnsignedBits, OffsetT>;
+    using ValuesItr = CacheModifiedInputIterator<LOAD_MODIFIER, ValueT, OffsetT>;
 
     // Radix ranking type to use
-    typedef typename If<(RANK_ALGORITHM == RADIX_RANK_BASIC),
-            BlockRadixRank<BLOCK_THREADS, RADIX_BITS, IS_DESCENDING, false, SCAN_ALGORITHM>,
-            typename If<(RANK_ALGORITHM == RADIX_RANK_MEMOIZE),
-                BlockRadixRank<BLOCK_THREADS, RADIX_BITS, IS_DESCENDING, true, SCAN_ALGORITHM>,
-                typename If<(RANK_ALGORITHM == RADIX_RANK_MATCH),
-                    BlockRadixRankMatch<BLOCK_THREADS, RADIX_BITS, IS_DESCENDING, SCAN_ALGORITHM>,
-                    typename If<(RANK_ALGORITHM == RADIX_RANK_MATCH_EARLY_COUNTS_ANY),
-                        BlockRadixRankMatchEarlyCounts<BLOCK_THREADS, RADIX_BITS, IS_DESCENDING,
-                                                       SCAN_ALGORITHM, WARP_MATCH_ANY>,
-                        BlockRadixRankMatchEarlyCounts<BLOCK_THREADS, RADIX_BITS, IS_DESCENDING,
-                                                       SCAN_ALGORITHM, WARP_MATCH_ATOMIC_OR>
-                    >::Type
-                >::Type
-            >::Type
-        >::Type BlockRadixRankT;
+    using BlockRadixRankT = cub::detail::conditional_t<
+      RANK_ALGORITHM == RADIX_RANK_BASIC,
+      BlockRadixRank<BLOCK_THREADS, RADIX_BITS, IS_DESCENDING, false, SCAN_ALGORITHM>,
+      cub::detail::conditional_t<
+        RANK_ALGORITHM == RADIX_RANK_MEMOIZE,
+        BlockRadixRank<BLOCK_THREADS, RADIX_BITS, IS_DESCENDING, true, SCAN_ALGORITHM>,
+        cub::detail::conditional_t<
+          RANK_ALGORITHM == RADIX_RANK_MATCH,
+          BlockRadixRankMatch<BLOCK_THREADS, RADIX_BITS, IS_DESCENDING, SCAN_ALGORITHM>,
+          cub::detail::conditional_t<
+            RANK_ALGORITHM == RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
+            BlockRadixRankMatchEarlyCounts<BLOCK_THREADS,
+                                           RADIX_BITS,
+                                           IS_DESCENDING,
+                                           SCAN_ALGORITHM,
+                                           WARP_MATCH_ANY>,
+            BlockRadixRankMatchEarlyCounts<BLOCK_THREADS,
+                                           RADIX_BITS,
+                                           IS_DESCENDING,
+                                           SCAN_ALGORITHM,
+                                           WARP_MATCH_ATOMIC_OR>>>>>;
 
     // Digit extractor type
-    typedef BFEDigitExtractor<KeyT> DigitExtractorT;
-
+    using DigitExtractorT = BFEDigitExtractor<KeyT>;
 
     enum
     {
@@ -161,18 +168,12 @@ struct AgentRadixSortDownsweep
     };
 
     // BlockLoad type (keys)
-    typedef BlockLoad<
-        UnsignedBits,
-        BLOCK_THREADS,
-        ITEMS_PER_THREAD,
-        LOAD_ALGORITHM> BlockLoadKeysT;
+    using BlockLoadKeysT =
+      BlockLoad<UnsignedBits, BLOCK_THREADS, ITEMS_PER_THREAD, LOAD_ALGORITHM>;
 
     // BlockLoad type (values)
-    typedef BlockLoad<
-        ValueT,
-        BLOCK_THREADS,
-        ITEMS_PER_THREAD,
-        LOAD_ALGORITHM> BlockLoadValuesT;
+    using BlockLoadValuesT =
+      BlockLoad<ValueT, BLOCK_THREADS, ITEMS_PER_THREAD, LOAD_ALGORITHM>;
 
     // Value exchange array type
     typedef ValueT ValueExchangeT[TILE_ITEMS];

--- a/cub/agent/agent_reduce.cuh
+++ b/cub/agent/agent_reduce.cuh
@@ -101,21 +101,22 @@ struct AgentReduce
     //---------------------------------------------------------------------
 
     /// The input value type
-    typedef typename std::iterator_traits<InputIteratorT>::value_type InputT;
+    using InputT = cub::detail::value_t<InputIteratorT>;
 
     /// The output value type
-    typedef typename If<(Equals<typename std::iterator_traits<OutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-        typename std::iterator_traits<InputIteratorT>::value_type,                                          // ... then the input iterator's value type,
-        typename std::iterator_traits<OutputIteratorT>::value_type>::Type OutputT;                          // ... else the output iterator's value type
+    using OutputT = cub::detail::non_void_value_t<OutputIteratorT, InputT>;
 
     /// Vector type of InputT for data movement
-    typedef typename CubVector<InputT, AgentReducePolicy::VECTOR_LOAD_LENGTH>::Type VectorT;
+    using VectorT =
+      typename CubVector<InputT, AgentReducePolicy::VECTOR_LOAD_LENGTH>::Type;
 
     /// Input iterator wrapper type (for applying cache modifier)
-    typedef typename If<IsPointer<InputIteratorT>::VALUE,
-            CacheModifiedInputIterator<AgentReducePolicy::LOAD_MODIFIER, InputT, OffsetT>,      // Wrap the native input pointer with CacheModifiedInputIterator
-            InputIteratorT>::Type                                                               // Directly use the supplied input iterator type
-        WrappedInputIteratorT;
+    // Wrap the native input pointer with CacheModifiedInputIterator
+    // or directly use the supplied input iterator type
+    using WrappedInputIteratorT = cub::detail::conditional_t<
+      std::is_pointer<InputIteratorT>::value,
+      CacheModifiedInputIterator<AgentReducePolicy::LOAD_MODIFIER, InputT, OffsetT>,
+      InputIteratorT>;
 
     /// Constants
     enum
@@ -128,7 +129,7 @@ struct AgentReduce
         // Can vectorize according to the policy if the input iterator is a native pointer to a primitive type
         ATTEMPT_VECTORIZATION   = (VECTOR_LOAD_LENGTH > 1) &&
                                     (ITEMS_PER_THREAD % VECTOR_LOAD_LENGTH == 0) &&
-                                    (IsPointer<InputIteratorT>::VALUE) && Traits<InputT>::PRIMITIVE,
+                                    (std::is_pointer<InputIteratorT>::value) && Traits<InputT>::PRIMITIVE,
 
     };
 
@@ -136,7 +137,8 @@ struct AgentReduce
     static const BlockReduceAlgorithm BLOCK_ALGORITHM = AgentReducePolicy::BLOCK_ALGORITHM;
 
     /// Parameterized BlockReduce primitive
-    typedef BlockReduce<OutputT, BLOCK_THREADS, AgentReducePolicy::BLOCK_ALGORITHM> BlockReduceT;
+    using BlockReduceT =
+      BlockReduce<OutputT, BLOCK_THREADS, AgentReducePolicy::BLOCK_ALGORITHM>;
 
     /// Shared memory type required by this thread block
     struct _TempStorage

--- a/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/agent/agent_reduce_by_key.cuh
@@ -98,29 +98,27 @@ struct AgentReduceByKey
     //---------------------------------------------------------------------
 
     // The input keys type
-    typedef typename std::iterator_traits<KeysInputIteratorT>::value_type KeyInputT;
+    using KeyInputT = cub::detail::value_t<KeysInputIteratorT>;
 
     // The output keys type
-    typedef typename If<(Equals<typename std::iterator_traits<UniqueOutputIteratorT>::value_type, void>::VALUE),    // KeyOutputT =  (if output iterator's value type is void) ?
-        typename std::iterator_traits<KeysInputIteratorT>::value_type,                                              // ... then the input iterator's value type,
-        typename std::iterator_traits<UniqueOutputIteratorT>::value_type>::Type KeyOutputT;                         // ... else the output iterator's value type
+    using KeyOutputT =
+      cub::detail::non_void_value_t<UniqueOutputIteratorT, KeyInputT>;
 
     // The input values type
-    typedef typename std::iterator_traits<ValuesInputIteratorT>::value_type ValueInputT;
+    using ValueInputT = cub::detail::value_t<ValuesInputIteratorT>;
 
     // The output values type
-    typedef typename If<(Equals<typename std::iterator_traits<AggregatesOutputIteratorT>::value_type, void>::VALUE),    // ValueOutputT =  (if output iterator's value type is void) ?
-        typename std::iterator_traits<ValuesInputIteratorT>::value_type,                                                // ... then the input iterator's value type,
-        typename std::iterator_traits<AggregatesOutputIteratorT>::value_type>::Type ValueOutputT;                       // ... else the output iterator's value type
+    using ValueOutputT =
+      cub::detail::non_void_value_t<AggregatesOutputIteratorT, ValueInputT>;
 
     // Tuple type for scanning (pairs accumulated segment-value with segment-index)
-    typedef KeyValuePair<OffsetT, ValueOutputT> OffsetValuePairT;
+    using OffsetValuePairT = KeyValuePair<OffsetT, ValueOutputT>;
 
     // Tuple type for pairing keys and values
-    typedef KeyValuePair<KeyOutputT, ValueOutputT> KeyValuePairT;
+    using KeyValuePairT = KeyValuePair<KeyOutputT, ValueOutputT>;
 
     // Tile status descriptor interface type
-    typedef ReduceByKeyScanTileState<ValueOutputT, OffsetT> ScanTileStateT;
+    using ScanTileStateT = ReduceByKeyScanTileState<ValueOutputT, OffsetT>;
 
     // Guarded inequality functor
     template <typename _EqualityOpT>
@@ -149,71 +147,73 @@ struct AgentReduceByKey
     // Constants
     enum
     {
-        BLOCK_THREADS       = AgentReduceByKeyPolicyT::BLOCK_THREADS,
-        ITEMS_PER_THREAD    = AgentReduceByKeyPolicyT::ITEMS_PER_THREAD,
-        TILE_ITEMS          = BLOCK_THREADS * ITEMS_PER_THREAD,
-        TWO_PHASE_SCATTER   = (ITEMS_PER_THREAD > 1),
+      BLOCK_THREADS     = AgentReduceByKeyPolicyT::BLOCK_THREADS,
+      ITEMS_PER_THREAD  = AgentReduceByKeyPolicyT::ITEMS_PER_THREAD,
+      TILE_ITEMS        = BLOCK_THREADS * ITEMS_PER_THREAD,
+      TWO_PHASE_SCATTER = (ITEMS_PER_THREAD > 1),
 
-        // Whether or not the scan operation has a zero-valued identity value (true if we're performing addition on a primitive type)
-        HAS_IDENTITY_ZERO   = (Equals<ReductionOpT, cub::Sum>::VALUE) && (Traits<ValueOutputT>::PRIMITIVE),
+      // Whether or not the scan operation has a zero-valued identity value (true if we're performing addition on a primitive type)
+      HAS_IDENTITY_ZERO = (std::is_same<ReductionOpT, cub::Sum>::value) &&
+                          (Traits<ValueOutputT>::PRIMITIVE),
     };
 
     // Cache-modified Input iterator wrapper type (for applying cache modifier) for keys
-    typedef typename If<IsPointer<KeysInputIteratorT>::VALUE,
-            CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER, KeyInputT, OffsetT>,     // Wrap the native input pointer with CacheModifiedValuesInputIterator
-            KeysInputIteratorT>::Type                                                                   // Directly use the supplied input iterator type
-        WrappedKeysInputIteratorT;
+    // Wrap the native input pointer with CacheModifiedValuesInputIterator
+    // or directly use the supplied input iterator type
+    using WrappedKeysInputIteratorT = cub::detail::conditional_t<
+      std::is_pointer<KeysInputIteratorT>::value,
+      CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER,
+                                 KeyInputT,
+                                 OffsetT>,
+      KeysInputIteratorT>;
 
     // Cache-modified Input iterator wrapper type (for applying cache modifier) for values
-    typedef typename If<IsPointer<ValuesInputIteratorT>::VALUE,
-            CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER, ValueInputT, OffsetT>,   // Wrap the native input pointer with CacheModifiedValuesInputIterator
-            ValuesInputIteratorT>::Type                                                                 // Directly use the supplied input iterator type
-        WrappedValuesInputIteratorT;
+    // Wrap the native input pointer with CacheModifiedValuesInputIterator
+    // or directly use the supplied input iterator type
+    using WrappedValuesInputIteratorT = cub::detail::conditional_t<
+      std::is_pointer<ValuesInputIteratorT>::value,
+      CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER,
+                                 ValueInputT,
+                                 OffsetT>,
+      ValuesInputIteratorT>;
 
     // Cache-modified Input iterator wrapper type (for applying cache modifier) for fixup values
-    typedef typename If<IsPointer<AggregatesOutputIteratorT>::VALUE,
-            CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER, ValueInputT, OffsetT>,   // Wrap the native input pointer with CacheModifiedValuesInputIterator
-            AggregatesOutputIteratorT>::Type                                                            // Directly use the supplied input iterator type
-        WrappedFixupInputIteratorT;
+    // Wrap the native input pointer with CacheModifiedValuesInputIterator
+    // or directly use the supplied input iterator type
+    using WrappedFixupInputIteratorT = cub::detail::conditional_t<
+      std::is_pointer<AggregatesOutputIteratorT>::value,
+      CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER,
+                                 ValueInputT,
+                                 OffsetT>,
+      AggregatesOutputIteratorT>;
 
     // Reduce-value-by-segment scan operator
-    typedef ReduceBySegmentOp<ReductionOpT> ReduceBySegmentOpT;
+    using ReduceBySegmentOpT = ReduceBySegmentOp<ReductionOpT>;
 
     // Parameterized BlockLoad type for keys
-    typedef BlockLoad<
-            KeyOutputT,
-            BLOCK_THREADS,
-            ITEMS_PER_THREAD,
-            AgentReduceByKeyPolicyT::LOAD_ALGORITHM>
-        BlockLoadKeysT;
+    using BlockLoadKeysT = BlockLoad<KeyOutputT,
+                                     BLOCK_THREADS,
+                                     ITEMS_PER_THREAD,
+                                     AgentReduceByKeyPolicyT::LOAD_ALGORITHM>;
 
     // Parameterized BlockLoad type for values
-    typedef BlockLoad<
-            ValueOutputT,
-            BLOCK_THREADS,
-            ITEMS_PER_THREAD,
-            AgentReduceByKeyPolicyT::LOAD_ALGORITHM>
-        BlockLoadValuesT;
+    using BlockLoadValuesT = BlockLoad<ValueOutputT,
+                                       BLOCK_THREADS,
+                                       ITEMS_PER_THREAD,
+                                       AgentReduceByKeyPolicyT::LOAD_ALGORITHM>;
 
     // Parameterized BlockDiscontinuity type for keys
-    typedef BlockDiscontinuity<
-            KeyOutputT,
-            BLOCK_THREADS>
-        BlockDiscontinuityKeys;
+    using BlockDiscontinuityKeys =
+      BlockDiscontinuity<KeyOutputT, BLOCK_THREADS>;
 
     // Parameterized BlockScan type
-    typedef BlockScan<
-            OffsetValuePairT,
-            BLOCK_THREADS,
-            AgentReduceByKeyPolicyT::SCAN_ALGORITHM>
-        BlockScanT;
+    using BlockScanT = BlockScan<OffsetValuePairT,
+                                 BLOCK_THREADS,
+                                 AgentReduceByKeyPolicyT::SCAN_ALGORITHM>;
 
     // Callback type for obtaining tile prefix during block scan
-    typedef TilePrefixCallbackOp<
-            OffsetValuePairT,
-            ReduceBySegmentOpT,
-            ScanTileStateT>
-        TilePrefixCallbackOpT;
+    using TilePrefixCallbackOpT =
+      TilePrefixCallbackOp<OffsetValuePairT, ReduceBySegmentOpT, ScanTileStateT>;
 
     // Key and value exchange types
     typedef KeyOutputT    KeyExchangeT[TILE_ITEMS + 1];

--- a/cub/agent/agent_rle.cuh
+++ b/cub/agent/agent_rle.cuh
@@ -102,18 +102,17 @@ struct AgentRle
     //---------------------------------------------------------------------
 
     /// The input value type
-    typedef typename std::iterator_traits<InputIteratorT>::value_type T;
+    using T = cub::detail::value_t<InputIteratorT>;
 
     /// The lengths output value type
-    typedef typename If<(Equals<typename std::iterator_traits<LengthsOutputIteratorT>::value_type, void>::VALUE),   // LengthT =  (if output iterator's value type is void) ?
-        OffsetT,                                                                                                    // ... then the OffsetT type,
-        typename std::iterator_traits<LengthsOutputIteratorT>::value_type>::Type LengthT;                           // ... else the output iterator's value type
+    using LengthT =
+      cub::detail::non_void_value_t<LengthsOutputIteratorT, OffsetT>;
 
     /// Tuple type for scanning (pairs run-length and run-index)
-    typedef KeyValuePair<OffsetT, LengthT> LengthOffsetPair;
+    using LengthOffsetPair = KeyValuePair<OffsetT, LengthT>;
 
     /// Tile status descriptor interface type
-    typedef ReduceByKeyScanTileState<LengthT, OffsetT> ScanTileStateT;
+    using ScanTileStateT = ReduceByKeyScanTileState<LengthT, OffsetT>;
 
     // Constants
     enum
@@ -165,42 +164,42 @@ struct AgentRle
 
 
     // Cache-modified Input iterator wrapper type (for applying cache modifier) for data
-    typedef typename If<IsPointer<InputIteratorT>::VALUE,
-            CacheModifiedInputIterator<AgentRlePolicyT::LOAD_MODIFIER, T, OffsetT>,      // Wrap the native input pointer with CacheModifiedVLengthnputIterator
-            InputIteratorT>::Type                                                       // Directly use the supplied input iterator type
-        WrappedInputIteratorT;
+    // Wrap the native input pointer with CacheModifiedVLengthnputIterator
+    // Directly use the supplied input iterator type
+    using WrappedInputIteratorT = cub::detail::conditional_t<
+      std::is_pointer<InputIteratorT>::value,
+      CacheModifiedInputIterator<AgentRlePolicyT::LOAD_MODIFIER, T, OffsetT>,
+      InputIteratorT>;
 
     // Parameterized BlockLoad type for data
-    typedef BlockLoad<
-            T,
-            AgentRlePolicyT::BLOCK_THREADS,
-            AgentRlePolicyT::ITEMS_PER_THREAD,
-            AgentRlePolicyT::LOAD_ALGORITHM>
-        BlockLoadT;
+    using BlockLoadT = BlockLoad<T,
+                                 AgentRlePolicyT::BLOCK_THREADS,
+                                 AgentRlePolicyT::ITEMS_PER_THREAD,
+                                 AgentRlePolicyT::LOAD_ALGORITHM>;
 
     // Parameterized BlockDiscontinuity type for data
-    typedef BlockDiscontinuity<T, BLOCK_THREADS> BlockDiscontinuityT;
+    using BlockDiscontinuityT = BlockDiscontinuity<T, BLOCK_THREADS> ;
 
     // Parameterized WarpScan type
-    typedef WarpScan<LengthOffsetPair> WarpScanPairs;
+    using WarpScanPairs = WarpScan<LengthOffsetPair>;
 
     // Reduce-length-by-run scan operator
-    typedef ReduceBySegmentOp<cub::Sum> ReduceBySegmentOpT;
+    using ReduceBySegmentOpT = ReduceBySegmentOp<cub::Sum>;
 
     // Callback type for obtaining tile prefix during block scan
-    typedef TilePrefixCallbackOp<
-            LengthOffsetPair,
-            ReduceBySegmentOpT,
-            ScanTileStateT>
-        TilePrefixCallbackOpT;
+    using TilePrefixCallbackOpT =
+      TilePrefixCallbackOp<LengthOffsetPair, ReduceBySegmentOpT, ScanTileStateT>;
 
     // Warp exchange types
-    typedef WarpExchange<LengthOffsetPair, ITEMS_PER_THREAD>        WarpExchangePairs;
+    using WarpExchangePairs = WarpExchange<LengthOffsetPair, ITEMS_PER_THREAD>;
 
-    typedef typename If<STORE_WARP_TIME_SLICING, typename WarpExchangePairs::TempStorage, NullType>::Type WarpExchangePairsStorage;
+    using WarpExchangePairsStorage =
+      cub::detail::conditional_t<STORE_WARP_TIME_SLICING,
+                                 typename WarpExchangePairs::TempStorage,
+                                 NullType>;
 
-    typedef WarpExchange<OffsetT, ITEMS_PER_THREAD>                 WarpExchangeOffsets;
-    typedef WarpExchange<LengthT, ITEMS_PER_THREAD>                 WarpExchangeLengths;
+    using WarpExchangeOffsets = WarpExchange<OffsetT, ITEMS_PER_THREAD>;
+    using WarpExchangeLengths = WarpExchange<LengthT, ITEMS_PER_THREAD>;
 
     typedef LengthOffsetPair WarpAggregates[WARPS];
 

--- a/cub/agent/agent_scan.cuh
+++ b/cub/agent/agent_scan.cuh
@@ -96,27 +96,32 @@ struct AgentScan
     //---------------------------------------------------------------------
 
     // The input value type
-    using InputT = typename std::iterator_traits<InputIteratorT>::value_type;
+    using InputT = cub::detail::value_t<InputIteratorT>;
 
     // The output value type -- used as the intermediate accumulator
     // Per https://wg21.link/P0571, use InitValueT if provided, otherwise the
     // input iterator's value type.
     using OutputT =
-      typename If<Equals<InitValueT, NullType>::VALUE, InputT, InitValueT>::Type;
+      cub::detail::conditional_t<std::is_same<InitValueT, NullType>::value,
+                                 InputT,
+                                 InitValueT>;
 
     // Tile status descriptor interface type
-    typedef ScanTileState<OutputT> ScanTileStateT;
+    using ScanTileStateT = ScanTileState<OutputT>;
 
     // Input iterator wrapper type (for applying cache modifier)
-    typedef typename If<IsPointer<InputIteratorT>::VALUE,
-            CacheModifiedInputIterator<AgentScanPolicyT::LOAD_MODIFIER, InputT, OffsetT>,   // Wrap the native input pointer with CacheModifiedInputIterator
-            InputIteratorT>::Type                                                           // Directly use the supplied input iterator type
-        WrappedInputIteratorT;
+    // Wrap the native input pointer with CacheModifiedInputIterator
+    // or directly use the supplied input iterator type
+    using WrappedInputIteratorT = cub::detail::conditional_t<
+      std::is_pointer<InputIteratorT>::value,
+      CacheModifiedInputIterator<AgentScanPolicyT::LOAD_MODIFIER, InputT, OffsetT>,
+      InputIteratorT>;
 
     // Constants
     enum
     {
-        IS_INCLUSIVE        = Equals<InitValueT, NullType>::VALUE,            // Inclusive scan if no init_value type is provided
+        // Inclusive scan if no init_value type is provided
+        IS_INCLUSIVE        = std::is_same<InitValueT, NullType>::value,
         BLOCK_THREADS       = AgentScanPolicyT::BLOCK_THREADS,
         ITEMS_PER_THREAD    = AgentScanPolicyT::ITEMS_PER_THREAD,
         TILE_ITEMS          = BLOCK_THREADS * ITEMS_PER_THREAD,

--- a/cub/agent/agent_segment_fixup.cuh
+++ b/cub/agent/agent_segment_fixup.cuh
@@ -95,68 +95,71 @@ struct AgentSegmentFixup
     //---------------------------------------------------------------------
 
     // Data type of key-value input iterator
-    typedef typename std::iterator_traits<PairsInputIteratorT>::value_type KeyValuePairT;
+    using KeyValuePairT = cub::detail::value_t<PairsInputIteratorT>;
 
     // Value type
-    typedef typename KeyValuePairT::Value ValueT;
+    using ValueT = typename KeyValuePairT::Value;
 
     // Tile status descriptor interface type
-    typedef ReduceByKeyScanTileState<ValueT, OffsetT> ScanTileStateT;
+    using ScanTileStateT = ReduceByKeyScanTileState<ValueT, OffsetT>;
 
     // Constants
     enum
     {
-        BLOCK_THREADS       = AgentSegmentFixupPolicyT::BLOCK_THREADS,
-        ITEMS_PER_THREAD    = AgentSegmentFixupPolicyT::ITEMS_PER_THREAD,
-        TILE_ITEMS          = BLOCK_THREADS * ITEMS_PER_THREAD,
+      BLOCK_THREADS    = AgentSegmentFixupPolicyT::BLOCK_THREADS,
+      ITEMS_PER_THREAD = AgentSegmentFixupPolicyT::ITEMS_PER_THREAD,
+      TILE_ITEMS       = BLOCK_THREADS * ITEMS_PER_THREAD,
 
-        // Whether or not do fixup using RLE + global atomics
-        USE_ATOMIC_FIXUP    = (CUB_PTX_ARCH >= 350) && 
-                                (Equals<ValueT, float>::VALUE || 
-                                 Equals<ValueT, int>::VALUE ||
-                                 Equals<ValueT, unsigned int>::VALUE ||
-                                 Equals<ValueT, unsigned long long>::VALUE),
+      // Whether or not do fixup using RLE + global atomics
+      USE_ATOMIC_FIXUP = (CUB_PTX_ARCH >= 350) &&
+                         (std::is_same<ValueT, float>::value ||
+                          std::is_same<ValueT, int>::value ||
+                          std::is_same<ValueT, unsigned int>::value ||
+                          std::is_same<ValueT, unsigned long long>::value),
 
-        // Whether or not the scan operation has a zero-valued identity value (true if we're performing addition on a primitive type)
-        HAS_IDENTITY_ZERO   = (Equals<ReductionOpT, cub::Sum>::VALUE) && (Traits<ValueT>::PRIMITIVE),
+      // Whether or not the scan operation has a zero-valued identity value
+      // (true if we're performing addition on a primitive type)
+      HAS_IDENTITY_ZERO = (std::is_same<ReductionOpT, cub::Sum>::value) &&
+                          (Traits<ValueT>::PRIMITIVE),
     };
 
     // Cache-modified Input iterator wrapper type (for applying cache modifier) for keys
-    typedef typename If<IsPointer<PairsInputIteratorT>::VALUE,
-            CacheModifiedInputIterator<AgentSegmentFixupPolicyT::LOAD_MODIFIER, KeyValuePairT, OffsetT>,    // Wrap the native input pointer with CacheModifiedValuesInputIterator
-            PairsInputIteratorT>::Type                                                                      // Directly use the supplied input iterator type
-        WrappedPairsInputIteratorT;
+    // Wrap the native input pointer with CacheModifiedValuesInputIterator
+    // or directly use the supplied input iterator type
+    using WrappedPairsInputIteratorT = cub::detail::conditional_t<
+      std::is_pointer<PairsInputIteratorT>::value,
+      CacheModifiedInputIterator<AgentSegmentFixupPolicyT::LOAD_MODIFIER,
+                                 KeyValuePairT,
+                                 OffsetT>,
+      PairsInputIteratorT>;
 
     // Cache-modified Input iterator wrapper type (for applying cache modifier) for fixup values
-    typedef typename If<IsPointer<AggregatesOutputIteratorT>::VALUE,
-            CacheModifiedInputIterator<AgentSegmentFixupPolicyT::LOAD_MODIFIER, ValueT, OffsetT>,    // Wrap the native input pointer with CacheModifiedValuesInputIterator
-            AggregatesOutputIteratorT>::Type                                                        // Directly use the supplied input iterator type
-        WrappedFixupInputIteratorT;
+    // Wrap the native input pointer with CacheModifiedValuesInputIterator
+    // or directly use the supplied input iterator type
+    using WrappedFixupInputIteratorT = cub::detail::conditional_t<
+      std::is_pointer<AggregatesOutputIteratorT>::value,
+      CacheModifiedInputIterator<AgentSegmentFixupPolicyT::LOAD_MODIFIER,
+                                 ValueT,
+                                 OffsetT>,
+      AggregatesOutputIteratorT>;
 
     // Reduce-value-by-segment scan operator
-    typedef ReduceByKeyOp<cub::Sum> ReduceBySegmentOpT;
+    using ReduceBySegmentOpT = ReduceByKeyOp<cub::Sum>;
 
     // Parameterized BlockLoad type for pairs
-    typedef BlockLoad<
-            KeyValuePairT,
-            BLOCK_THREADS,
-            ITEMS_PER_THREAD,
-            AgentSegmentFixupPolicyT::LOAD_ALGORITHM>
-        BlockLoadPairs;
+    using BlockLoadPairs = BlockLoad<KeyValuePairT,
+                                     BLOCK_THREADS,
+                                     ITEMS_PER_THREAD,
+                                     AgentSegmentFixupPolicyT::LOAD_ALGORITHM>;
 
     // Parameterized BlockScan type
-    typedef BlockScan<
-            KeyValuePairT,
-            BLOCK_THREADS,
-            AgentSegmentFixupPolicyT::SCAN_ALGORITHM>
-        BlockScanT;
+    using BlockScanT = BlockScan<KeyValuePairT,
+                                 BLOCK_THREADS,
+                                 AgentSegmentFixupPolicyT::SCAN_ALGORITHM>;
 
     // Callback type for obtaining tile prefix during block scan
-    typedef TilePrefixCallbackOp<
-            KeyValuePairT,
-            ReduceBySegmentOpT,
-            ScanTileStateT>
-        TilePrefixCallbackOpT;
+    using TilePrefixCallbackOpT =
+      TilePrefixCallbackOp<KeyValuePairT, ReduceBySegmentOpT, ScanTileStateT>;
 
     // Shared memory type for this thread block
     union _TempStorage

--- a/cub/agent/agent_segmented_radix_sort.cuh
+++ b/cub/agent/agent_segmented_radix_sort.cuh
@@ -70,7 +70,7 @@ struct AgentSegmentedRadixSort
   static constexpr int BLOCK_THREADS    = SegmentedPolicyT::BLOCK_THREADS;
   static constexpr int RADIX_BITS       = SegmentedPolicyT::RADIX_BITS;
   static constexpr int RADIX_DIGITS     = 1 << RADIX_BITS;
-  static constexpr int KEYS_ONLY        = Equals<ValueT, NullType>::VALUE;
+  static constexpr int KEYS_ONLY        = std::is_same<ValueT, NullType>::value;
 
   // Huge segment handlers
   using BlockUpsweepT = AgentRadixSortUpsweep<SegmentedPolicyT, KeyT, OffsetT>;

--- a/cub/agent/agent_select_if.cuh
+++ b/cub/agent/agent_select_if.cuh
@@ -105,18 +105,17 @@ struct AgentSelectIf
     //---------------------------------------------------------------------
 
     // The input value type
-    typedef typename std::iterator_traits<InputIteratorT>::value_type InputT;
+    using InputT = cub::detail::value_t<InputIteratorT>;
 
     // The output value type
-    typedef typename If<(Equals<typename std::iterator_traits<SelectedOutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-        typename std::iterator_traits<InputIteratorT>::value_type,                                                  // ... then the input iterator's value type,
-        typename std::iterator_traits<SelectedOutputIteratorT>::value_type>::Type OutputT;                          // ... else the output iterator's value type
+    using OutputT =
+      cub::detail::non_void_value_t<SelectedOutputIteratorT, InputT>;
 
     // The flag value type
-    typedef typename std::iterator_traits<FlagsInputIteratorT>::value_type FlagT;
+    using FlagT = cub::detail::value_t<FlagsInputIteratorT>;
 
     // Tile status descriptor interface type
-    typedef ScanTileState<OffsetT> ScanTileStateT;
+    using ScanTileStateT = ScanTileState<OffsetT>;
 
     // Constants
     enum
@@ -130,60 +129,54 @@ struct AgentSelectIf
         TILE_ITEMS              = BLOCK_THREADS * ITEMS_PER_THREAD,
         TWO_PHASE_SCATTER       = (ITEMS_PER_THREAD > 1),
 
-        SELECT_METHOD           = (!Equals<SelectOpT, NullType>::VALUE) ?
-                                    USE_SELECT_OP :
-                                    (!Equals<FlagT, NullType>::VALUE) ?
-                                        USE_SELECT_FLAGS :
-                                        USE_DISCONTINUITY
+      SELECT_METHOD =
+        (!std::is_same<SelectOpT, NullType>::value) ? USE_SELECT_OP
+        : (!std::is_same<FlagT, NullType>::value)   ? USE_SELECT_FLAGS
+                                                    : USE_DISCONTINUITY
     };
 
     // Cache-modified Input iterator wrapper type (for applying cache modifier) for items
-    typedef typename If<IsPointer<InputIteratorT>::VALUE,
-            CacheModifiedInputIterator<AgentSelectIfPolicyT::LOAD_MODIFIER, InputT, OffsetT>,        // Wrap the native input pointer with CacheModifiedValuesInputIterator
-            InputIteratorT>::Type                                                               // Directly use the supplied input iterator type
-        WrappedInputIteratorT;
+    // Wrap the native input pointer with CacheModifiedValuesInputIterator
+    // or directly use the supplied input iterator type
+    using WrappedInputIteratorT = cub::detail::conditional_t<
+      std::is_pointer<InputIteratorT>::value,
+      CacheModifiedInputIterator<AgentSelectIfPolicyT::LOAD_MODIFIER,
+                                 InputT,
+                                 OffsetT>,
+      InputIteratorT>;
 
     // Cache-modified Input iterator wrapper type (for applying cache modifier) for values
-    typedef typename If<IsPointer<FlagsInputIteratorT>::VALUE,
-            CacheModifiedInputIterator<AgentSelectIfPolicyT::LOAD_MODIFIER, FlagT, OffsetT>,    // Wrap the native input pointer with CacheModifiedValuesInputIterator
-            FlagsInputIteratorT>::Type                                                          // Directly use the supplied input iterator type
-        WrappedFlagsInputIteratorT;
+    // Wrap the native input pointer with CacheModifiedValuesInputIterator
+    // or directly use the supplied input iterator type
+    using WrappedFlagsInputIteratorT = cub::detail::conditional_t<
+      std::is_pointer<FlagsInputIteratorT>::value,
+      CacheModifiedInputIterator<AgentSelectIfPolicyT::LOAD_MODIFIER,
+                                 FlagT,
+                                 OffsetT>,
+      FlagsInputIteratorT>;
 
     // Parameterized BlockLoad type for input data
-    typedef BlockLoad<
-            OutputT,
-            BLOCK_THREADS,
-            ITEMS_PER_THREAD,
-            AgentSelectIfPolicyT::LOAD_ALGORITHM>
-        BlockLoadT;
+    using BlockLoadT = BlockLoad<OutputT,
+                                 BLOCK_THREADS,
+                                 ITEMS_PER_THREAD,
+                                 AgentSelectIfPolicyT::LOAD_ALGORITHM>;
 
     // Parameterized BlockLoad type for flags
-    typedef BlockLoad<
-            FlagT,
-            BLOCK_THREADS,
-            ITEMS_PER_THREAD,
-            AgentSelectIfPolicyT::LOAD_ALGORITHM>
-        BlockLoadFlags;
+    using BlockLoadFlags = BlockLoad<FlagT,
+                                     BLOCK_THREADS,
+                                     ITEMS_PER_THREAD,
+                                     AgentSelectIfPolicyT::LOAD_ALGORITHM>;
 
     // Parameterized BlockDiscontinuity type for items
-    typedef BlockDiscontinuity<
-            OutputT,
-            BLOCK_THREADS>
-        BlockDiscontinuityT;
+    using BlockDiscontinuityT = BlockDiscontinuity<OutputT, BLOCK_THREADS>;
 
     // Parameterized BlockScan type
-    typedef BlockScan<
-            OffsetT,
-            BLOCK_THREADS,
-            AgentSelectIfPolicyT::SCAN_ALGORITHM>
-        BlockScanT;
+    using BlockScanT =
+      BlockScan<OffsetT, BLOCK_THREADS, AgentSelectIfPolicyT::SCAN_ALGORITHM>;
 
     // Callback type for obtaining tile prefix during block scan
-    typedef TilePrefixCallbackOp<
-            OffsetT,
-            cub::Sum,
-            ScanTileStateT>
-        TilePrefixCallbackOpT;
+    using TilePrefixCallbackOpT =
+      TilePrefixCallbackOp<OffsetT, cub::Sum, ScanTileStateT>;
 
     // Item exchange type
     typedef OutputT ItemExchangeT[TILE_ITEMS];

--- a/cub/agent/agent_spmv_orig.cuh
+++ b/cub/agent/agent_spmv_orig.cuh
@@ -202,11 +202,14 @@ struct AgentSpmv
     /// Merge item type (either a non-zero value or a row-end offset)
     union MergeItem
     {
-        // Value type to pair with index type OffsetT (NullType if loading values directly during merge)
-        typedef typename If<AgentSpmvPolicyT::DIRECT_LOAD_NONZEROS, NullType, ValueT>::Type MergeValueT;
+      // Value type to pair with index type OffsetT
+      // (NullType if loading values directly during merge)
+      using MergeValueT =
+        cub::detail::conditional_t<
+          AgentSpmvPolicyT::DIRECT_LOAD_NONZEROS, NullType, ValueT>;
 
-        OffsetT     row_end_offset;
-        MergeValueT nonzero;
+      OffsetT row_end_offset;
+      MergeValueT nonzero;
     };
 
     /// Shared memory type required by this thread block

--- a/cub/agent/agent_three_way_partition.cuh
+++ b/cub/agent/agent_three_way_partition.cuh
@@ -86,7 +86,7 @@ struct AgentThreeWayPartition
   //---------------------------------------------------------------------
 
   // The input value type
-  using InputT = typename std::iterator_traits<InputIteratorT>::value_type;
+  using InputT = cub::detail::value_t<InputIteratorT>;
 
   // Tile status descriptor interface type
   using ScanTileStateT = cub::ScanTileState<OffsetT>;
@@ -96,10 +96,10 @@ struct AgentThreeWayPartition
   constexpr static int ITEMS_PER_THREAD = PolicyT::ITEMS_PER_THREAD;
   constexpr static int TILE_ITEMS = BLOCK_THREADS * ITEMS_PER_THREAD;
 
-  using WrappedInputIteratorT = typename std::conditional<
+  using WrappedInputIteratorT = cub::detail::conditional_t<
     std::is_pointer<InputIteratorT>::value,
     cub::CacheModifiedInputIterator<PolicyT::LOAD_MODIFIER, InputT, OffsetT>,
-    InputIteratorT>::type;
+    InputIteratorT>;
 
   // Parameterized BlockLoad type for input data
   using BlockLoadT = cub::BlockLoad<InputT,

--- a/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/agent/single_pass_scan_operators.cuh
@@ -124,24 +124,22 @@ template <typename T>
 struct ScanTileState<T, true>
 {
     // Status word type
-    typedef typename If<(sizeof(T) == 8),
-        long long,
-        typename If<(sizeof(T) == 4),
-            int,
-            typename If<(sizeof(T) == 2),
-                short,
-                char>::Type>::Type>::Type StatusWord;
-
+    using StatusWord = cub::detail::conditional_t<
+      sizeof(T) == 8,
+      long long,
+      cub::detail::conditional_t<
+        sizeof(T) == 4,
+        int,
+        cub::detail::conditional_t<sizeof(T) == 2, short, char>>>;
 
     // Unit word type
-    typedef typename If<(sizeof(T) == 8),
-        longlong2,
-        typename If<(sizeof(T) == 4),
-            int2,
-            typename If<(sizeof(T) == 2),
-                int,
-                uchar2>::Type>::Type>::Type TxnWord;
-
+    using TxnWord = cub::detail::conditional_t<
+      sizeof(T) == 8,
+      longlong2,
+      cub::detail::conditional_t<
+        sizeof(T) == 4,
+        int2,
+        cub::detail::conditional_t<sizeof(T) == 2, int, uchar2>>>;
 
     // Device word type
     struct TileDescriptor
@@ -485,20 +483,19 @@ struct ReduceByKeyScanTileState<ValueT, KeyT, true>
     };
 
     // Status word type
-    typedef typename If<(STATUS_WORD_SIZE == 8),
-        long long,
-        typename If<(STATUS_WORD_SIZE == 4),
-            int,
-            typename If<(STATUS_WORD_SIZE == 2),
-                short,
-                char>::Type>::Type>::Type StatusWord;
+    using StatusWord = cub::detail::conditional_t<
+      STATUS_WORD_SIZE == 8,
+      long long,
+      cub::detail::conditional_t<
+        STATUS_WORD_SIZE == 4,
+        int,
+        cub::detail::conditional_t<STATUS_WORD_SIZE == 2, short, char>>>;
 
     // Status word type
-    typedef typename If<(TXN_WORD_SIZE == 16),
-        longlong2,
-        typename If<(TXN_WORD_SIZE == 8),
-            long long,
-            int>::Type>::Type TxnWord;
+    using TxnWord = cub::detail::conditional_t<
+      TXN_WORD_SIZE == 16,
+      longlong2,
+      cub::detail::conditional_t<TXN_WORD_SIZE == 8, long long, int>>;
 
     // Device word type (for when sizeof(ValueT) == sizeof(KeyT))
     struct TileDescriptorBigStatus
@@ -517,12 +514,10 @@ struct ReduceByKeyScanTileState<ValueT, KeyT, true>
     };
 
     // Device word type
-    typedef typename If<
-            (sizeof(ValueT) == sizeof(KeyT)),
-            TileDescriptorBigStatus,
-            TileDescriptorLittleStatus>::Type
-        TileDescriptor;
-
+    using TileDescriptor =
+      cub::detail::conditional_t<sizeof(ValueT) == sizeof(KeyT),
+                                 TileDescriptorBigStatus,
+                                 TileDescriptorLittleStatus>;
 
     // Device storage
     TxnWord *d_tile_descriptors;

--- a/cub/block/block_histogram.cuh
+++ b/cub/block/block_histogram.cuh
@@ -188,9 +188,16 @@ private:
             ALGORITHM;
 
     /// Internal specialization.
-    typedef typename If<(SAFE_ALGORITHM == BLOCK_HISTO_SORT),
-        BlockHistogramSort<T, BLOCK_DIM_X, ITEMS_PER_THREAD, BINS, BLOCK_DIM_Y, BLOCK_DIM_Z, PTX_ARCH>,
-        BlockHistogramAtomic<BINS> >::Type InternalBlockHistogram;
+    using InternalBlockHistogram =
+      cub::detail::conditional_t<SAFE_ALGORITHM == BLOCK_HISTO_SORT,
+                                 BlockHistogramSort<T,
+                                                    BLOCK_DIM_X,
+                                                    ITEMS_PER_THREAD,
+                                                    BINS,
+                                                    BLOCK_DIM_Y,
+                                                    BLOCK_DIM_Z,
+                                                    PTX_ARCH>,
+                                 BlockHistogramAtomic<BINS>>;
 
     /// Shared memory storage layout type for BlockHistogram
     typedef typename InternalBlockHistogram::TempStorage _TempStorage;

--- a/cub/block/block_load.cuh
+++ b/cub/block/block_load.cuh
@@ -1292,7 +1292,7 @@ public:
 
 template <class Policy,
           class It,
-          class T = typename std::iterator_traits<It>::value_type>
+          class T = cub::detail::value_t<It>>
 struct BlockLoadType
 {
   using type = cub::BlockLoad<T,

--- a/cub/block/block_merge_sort.cuh
+++ b/cub/block/block_merge_sort.cuh
@@ -179,7 +179,7 @@ private:
   static constexpr int ITEMS_PER_TILE = ITEMS_PER_THREAD * NUM_THREADS;
 
   // Whether or not there are values to be trucked along with keys
-  static constexpr bool KEYS_ONLY = Equals<ValueT, NullType>::VALUE;
+  static constexpr bool KEYS_ONLY = std::is_same<ValueT, NullType>::value;
 
   /// Shared memory type required by this thread block
   union _TempStorage

--- a/cub/block/block_radix_rank.cuh
+++ b/cub/block/block_radix_rank.cuh
@@ -156,9 +156,10 @@ private:
     typedef unsigned short DigitCounter;
 
     // Integer type for packing DigitCounters into columns of shared memory banks
-    typedef typename If<(SMEM_CONFIG == cudaSharedMemBankSizeEightByte),
-        unsigned long long,
-        unsigned int>::Type PackedCounter;
+    using PackedCounter =
+      cub::detail::conditional_t<SMEM_CONFIG == cudaSharedMemBankSizeEightByte,
+                                 unsigned long long,
+                                 unsigned int>;
 
     enum
     {
@@ -746,7 +747,9 @@ public:
             temp_storage.aliasable.raking_grid[linear_tid][ITEM] = scan_counters[ITEM];
 
         CTA_SYNC();
-        if (!Equals<CountsCallback, BlockRadixRankEmptyCallback<BINS_TRACKED_PER_THREAD>>::VALUE)
+        if (!std::is_same<
+              CountsCallback,
+              BlockRadixRankEmptyCallback<BINS_TRACKED_PER_THREAD>>::value)
         {
             CallBack<KEYS_PER_THREAD>(callback);
         }

--- a/cub/block/block_radix_sort.cuh
+++ b/cub/block/block_radix_sort.cuh
@@ -185,7 +185,7 @@ private:
         BLOCK_THREADS               = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
 
         // Whether or not there are values to be trucked along with keys
-        KEYS_ONLY                   = Equals<ValueT, NullType>::VALUE,
+        KEYS_ONLY                   = std::is_same<ValueT, NullType>::value,
     };
 
     // KeyT traits and unsigned bits type

--- a/cub/block/block_reduce.cuh
+++ b/cub/block/block_reduce.cuh
@@ -239,11 +239,12 @@ private:
     typedef BlockReduceRaking<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z, PTX_ARCH>                   Raking;
 
     /// Internal specialization type
-    typedef typename If<(ALGORITHM == BLOCK_REDUCE_WARP_REDUCTIONS),
-        WarpReductions,
-        typename If<(ALGORITHM == BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY),
-            RakingCommutativeOnly,
-            Raking>::Type>::Type InternalBlockReduce;     // BlockReduceRaking
+    using InternalBlockReduce = cub::detail::conditional_t<
+      ALGORITHM == BLOCK_REDUCE_WARP_REDUCTIONS,
+      WarpReductions,
+      cub::detail::conditional_t<ALGORITHM == BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY,
+                                 RakingCommutativeOnly,
+                                 Raking>>; // BlockReduceRaking
 
     /// Shared memory storage layout type for BlockReduce
     typedef typename InternalBlockReduce::TempStorage _TempStorage;

--- a/cub/block/block_scan.cuh
+++ b/cub/block/block_scan.cuh
@@ -222,9 +222,9 @@ private:
     typedef BlockScanRaking<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z, (SAFE_ALGORITHM == BLOCK_SCAN_RAKING_MEMOIZE), PTX_ARCH> Raking;
 
     /// Define the delegate type for the desired algorithm
-    typedef typename If<(SAFE_ALGORITHM == BLOCK_SCAN_WARP_SCANS),
-        WarpScans,
-        Raking>::Type InternalBlockScan;
+    using InternalBlockScan =
+      cub::detail::conditional_t<
+        SAFE_ALGORITHM == BLOCK_SCAN_WARP_SCANS, WarpScans, Raking>;
 
     /// Shared memory storage layout type for BlockScan
     typedef typename InternalBlockScan::TempStorage _TempStorage;

--- a/cub/block/block_store.cuh
+++ b/cub/block/block_store.cuh
@@ -1057,7 +1057,7 @@ public:
 
 template <class Policy,
           class It,
-          class T = typename std::iterator_traits<It>::value_type>
+          class T = cub::detail::value_t<It>>
 struct BlockStoreType
 {
   using type = cub::BlockStore<T,

--- a/cub/device/device_histogram.cuh
+++ b/cub/device/device_histogram.cuh
@@ -130,7 +130,7 @@ struct DeviceHistogram
         bool                debug_synchronous       = false)            ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  May cause significant slowdown.  Default is \p false.
     {
         /// The sample value type of the input iterator
-        typedef typename std::iterator_traits<SampleIteratorT>::value_type SampleT;
+        using SampleT = cub::detail::value_t<SampleIteratorT>;
 
         CounterT*           d_histogram1[1]     = {d_histogram};
         int                 num_levels1[1]      = {num_levels};
@@ -331,7 +331,7 @@ struct DeviceHistogram
         bool                debug_synchronous       = false)            ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  May cause significant slowdown.  Default is \p false.
     {
         /// The sample value type of the input iterator
-        typedef typename std::iterator_traits<SampleIteratorT>::value_type SampleT;
+        using SampleT = cub::detail::value_t<SampleIteratorT>;
 
         return MultiHistogramEven<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
             d_temp_storage,
@@ -440,7 +440,7 @@ struct DeviceHistogram
         bool                debug_synchronous       = false)            ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  May cause significant slowdown.  Default is \p false.
     {
         /// The sample value type of the input iterator
-        typedef typename std::iterator_traits<SampleIteratorT>::value_type SampleT;
+        using SampleT = cub::detail::value_t<SampleIteratorT>;
         Int2Type<sizeof(SampleT) == 1> is_byte_sample;
 
         if ((sizeof(OffsetT) > sizeof(int)) &&
@@ -533,7 +533,7 @@ struct DeviceHistogram
         bool                debug_synchronous   = false)            ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  May cause significant slowdown.  Default is \p false.
     {
         /// The sample value type of the input iterator
-        typedef typename std::iterator_traits<SampleIteratorT>::value_type SampleT;
+        using SampleT = cub::detail::value_t<SampleIteratorT>;
 
         CounterT*           d_histogram1[1] = {d_histogram};
         int                 num_levels1[1]  = {num_levels};
@@ -727,7 +727,7 @@ struct DeviceHistogram
         bool                debug_synchronous   = false)            ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  May cause significant slowdown.  Default is \p false.
     {
         /// The sample value type of the input iterator
-        typedef typename std::iterator_traits<SampleIteratorT>::value_type SampleT;
+        using SampleT = cub::detail::value_t<SampleIteratorT>;
 
         return MultiHistogramRange<NUM_CHANNELS, NUM_ACTIVE_CHANNELS>(
             d_temp_storage,
@@ -832,7 +832,7 @@ struct DeviceHistogram
         bool                debug_synchronous   = false)            ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  May cause significant slowdown.  Default is \p false.
     {
         /// The sample value type of the input iterator
-        typedef typename std::iterator_traits<SampleIteratorT>::value_type SampleT;
+        using SampleT = cub::detail::value_t<SampleIteratorT>;
         Int2Type<sizeof(SampleT) == 1> is_byte_sample;
 
         if ((sizeof(OffsetT) > sizeof(int)) &&

--- a/cub/device/device_reduce.cuh
+++ b/cub/device/device_reduce.cuh
@@ -232,12 +232,12 @@ struct DeviceReduce
         bool                        debug_synchronous   = false)        ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
         // Signed integer type for global offsets
-        typedef int OffsetT;
+        using OffsetT = int;
 
         // The output value type
-        typedef typename If<(Equals<typename std::iterator_traits<OutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-            typename std::iterator_traits<InputIteratorT>::value_type,                                          // ... then the input iterator's value type,
-            typename std::iterator_traits<OutputIteratorT>::value_type>::Type OutputT;                          // ... else the output iterator's value type
+        using OutputT =
+          cub::detail::non_void_value_t<OutputIteratorT,
+                                        cub::detail::value_t<InputIteratorT>>;
 
         return DispatchReduce<InputIteratorT, OutputIteratorT, OffsetT, cub::Sum>::Dispatch(
             d_temp_storage,
@@ -309,10 +309,10 @@ struct DeviceReduce
         bool                        debug_synchronous   = false)        ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
         // Signed integer type for global offsets
-        typedef int OffsetT;
+        using OffsetT = int;
 
         // The input value type
-        typedef typename std::iterator_traits<InputIteratorT>::value_type InputT;
+        using InputT = cub::detail::value_t<InputIteratorT>;
 
         return DispatchReduce<InputIteratorT, OutputIteratorT, OffsetT, cub::Min>::Dispatch(
             d_temp_storage,
@@ -386,21 +386,23 @@ struct DeviceReduce
         bool                        debug_synchronous   = false)        ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
         // Signed integer type for global offsets
-        typedef int OffsetT;
+        using OffsetT = int;
 
         // The input type
-        typedef typename std::iterator_traits<InputIteratorT>::value_type InputValueT;
+        using InputValueT = cub::detail::value_t<InputIteratorT>;
 
         // The output tuple type
-        typedef typename If<(Equals<typename std::iterator_traits<OutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-            KeyValuePair<OffsetT, InputValueT>,                                                                 // ... then the key value pair OffsetT + InputValueT
-            typename std::iterator_traits<OutputIteratorT>::value_type>::Type OutputTupleT;                     // ... else the output iterator's value type
+        using OutputTupleT =
+          cub::detail::non_void_value_t<OutputIteratorT,
+                                        KeyValuePair<OffsetT, InputValueT>>;
 
         // The output value type
-        typedef typename OutputTupleT::Value OutputValueT;
+        using OutputValueT = typename OutputTupleT::Value;
 
         // Wrapped input iterator to produce index-value <OffsetT, InputT> tuples
-        typedef ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT> ArgIndexInputIteratorT;
+        using ArgIndexInputIteratorT =
+          ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
+
         ArgIndexInputIteratorT d_indexed_in(d_in);
 
         // Initial value
@@ -476,10 +478,10 @@ struct DeviceReduce
         bool                        debug_synchronous   = false)        ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
         // Signed integer type for global offsets
-        typedef int OffsetT;
+        using OffsetT = int;
 
         // The input value type
-        typedef typename std::iterator_traits<InputIteratorT>::value_type InputT;
+        using InputT = cub::detail::value_t<InputIteratorT>;
 
         return DispatchReduce<InputIteratorT, OutputIteratorT, OffsetT, cub::Max>::Dispatch(
             d_temp_storage,
@@ -553,21 +555,23 @@ struct DeviceReduce
         bool                        debug_synchronous   = false)        ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
         // Signed integer type for global offsets
-        typedef int OffsetT;
+        using OffsetT = int;
 
         // The input type
-        typedef typename std::iterator_traits<InputIteratorT>::value_type InputValueT;
+        using InputValueT = cub::detail::value_t<InputIteratorT>;
 
         // The output tuple type
-        typedef typename If<(Equals<typename std::iterator_traits<OutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-            KeyValuePair<OffsetT, InputValueT>,                                                                 // ... then the key value pair OffsetT + InputValueT
-            typename std::iterator_traits<OutputIteratorT>::value_type>::Type OutputTupleT;                     // ... else the output iterator's value type
+        using OutputTupleT =
+          cub::detail::non_void_value_t<OutputIteratorT,
+                                        KeyValuePair<OffsetT, InputValueT>>;
 
         // The output value type
-        typedef typename OutputTupleT::Value OutputValueT;
+        using OutputValueT = typename OutputTupleT::Value;
 
         // Wrapped input iterator to produce index-value <OffsetT, InputT> tuples
-        typedef ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT> ArgIndexInputIteratorT;
+        using ArgIndexInputIteratorT =
+          ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
+
         ArgIndexInputIteratorT d_indexed_in(d_in);
 
         // Initial value

--- a/cub/device/device_run_length_encode.cuh
+++ b/cub/device/device_run_length_encode.cuh
@@ -152,19 +152,18 @@ struct DeviceRunLengthEncode
         cudaStream_t                stream             = 0,         ///< [in] <b>[optional]</b> CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
         bool                        debug_synchronous  = false)     ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  May cause significant slowdown.  Default is \p false.
     {
-        typedef int         OffsetT;                    // Signed integer type for global offsets
-        typedef NullType*   FlagIterator;               // FlagT iterator type (not used)
-        typedef NullType    SelectOp;                   // Selection op (not used)
-        typedef Equality    EqualityOp;                 // Default == operator
-        typedef cub::Sum    ReductionOp;                // Value reduction operator
+        using OffsetT      = int;        // Signed integer type for global offsets
+        using FlagIterator = NullType*;  // FlagT iterator type (not used)
+        using SelectOp     = NullType;   // Selection op (not used)
+        using EqualityOp   = Equality;   // Default == operator
+        using ReductionOp  = cub::Sum;   // Value reduction operator
 
         // The lengths output value type
-        typedef typename If<(Equals<typename std::iterator_traits<LengthsOutputIteratorT>::value_type, void>::VALUE),   // LengthT =  (if output iterator's value type is void) ?
-            OffsetT,                                                                                                    // ... then the OffsetT type,
-            typename std::iterator_traits<LengthsOutputIteratorT>::value_type>::Type LengthT;                           // ... else the output iterator's value type
+        using LengthT =
+          cub::detail::non_void_value_t<LengthsOutputIteratorT, OffsetT>;
 
         // Generator type for providing 1s values for run-length reduction
-        typedef ConstantInputIterator<LengthT, OffsetT> LengthsInputIteratorT;
+        using LengthsInputIteratorT = ConstantInputIterator<LengthT, OffsetT>;
 
         return DispatchReduceByKey<InputIteratorT, UniqueOutputIteratorT, LengthsInputIteratorT, LengthsOutputIteratorT, NumRunsOutputIteratorT, EqualityOp, ReductionOp, OffsetT>::Dispatch(
             d_temp_storage,

--- a/cub/device/device_scan.cuh
+++ b/cub/device/device_scan.cuh
@@ -154,11 +154,11 @@ struct DeviceScan
         bool            debug_synchronous   = false)        ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  May cause significant slowdown.  Default is \p false.
     {
         // Signed integer type for global offsets
-        typedef int OffsetT;
+        using OffsetT = int;
 
         // The output value type -- used as the intermediate accumulator
         // Use the input value type per https://wg21.link/P0571
-        typedef typename std::iterator_traits<InputIteratorT>::value_type OutputT;
+        using OutputT = cub::detail::value_t<InputIteratorT>;
 
         // Initial value
         OutputT init_value = 0;
@@ -526,11 +526,11 @@ struct DeviceScan
         bool                  debug_synchronous=false)      ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  May cause significant slowdown.  Default is \p false.
     {
         // Signed integer type for global offsets
-        typedef int OffsetT;
+        using OffsetT = int;
 
         // The output value type -- used as the intermediate accumulator
         // Use the input value type per https://wg21.link/P0571
-        typedef typename std::iterator_traits<ValuesInputIteratorT>::value_type OutputT;
+        using OutputT = cub::detail::value_t<ValuesInputIteratorT>;
 
         // Initial value
         OutputT init_value = 0;

--- a/cub/device/device_segmented_reduce.cuh
+++ b/cub/device/device_segmented_reduce.cuh
@@ -232,9 +232,9 @@ struct DeviceSegmentedReduce
         typedef int OffsetT;
 
         // The output value type
-        typedef typename If<(Equals<typename std::iterator_traits<OutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-            typename std::iterator_traits<InputIteratorT>::value_type,                                          // ... then the input iterator's value type,
-            typename std::iterator_traits<OutputIteratorT>::value_type>::Type OutputT;                          // ... else the output iterator's value type
+        using OutputT =
+          cub::detail::non_void_value_t<OutputIteratorT,
+                                        cub::detail::value_t<InputIteratorT>>;
 
         return DispatchSegmentedReduce<InputIteratorT,  OutputIteratorT, BeginOffsetIteratorT, EndOffsetIteratorT, OffsetT, cub::Sum>::Dispatch(
             d_temp_storage,
@@ -316,10 +316,10 @@ struct DeviceSegmentedReduce
         bool                  debug_synchronous   = false)        ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
         // Signed integer type for global offsets
-        typedef int OffsetT;
+        using OffsetT = int;
 
         // The input value type
-        typedef typename std::iterator_traits<InputIteratorT>::value_type InputT;
+        using InputT = cub::detail::value_t<InputIteratorT>;
 
         return DispatchSegmentedReduce<InputIteratorT,  OutputIteratorT, BeginOffsetIteratorT, EndOffsetIteratorT, OffsetT, cub::Min>::Dispatch(
             d_temp_storage,
@@ -403,21 +403,23 @@ struct DeviceSegmentedReduce
         bool                 debug_synchronous   = false)        ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
         // Signed integer type for global offsets
-        typedef int OffsetT;
+        using OffsetT = int;
 
         // The input type
-        typedef typename std::iterator_traits<InputIteratorT>::value_type InputValueT;
+        using InputValueT = cub::detail::value_t<InputIteratorT>;
 
         // The output tuple type
-        typedef typename If<(Equals<typename std::iterator_traits<OutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-            KeyValuePair<OffsetT, InputValueT>,                                                                 // ... then the key value pair OffsetT + InputValueT
-            typename std::iterator_traits<OutputIteratorT>::value_type>::Type OutputTupleT;                     // ... else the output iterator's value type
+        using OutputTupleT =
+          cub::detail::non_void_value_t<OutputIteratorT,
+                                        KeyValuePair<OffsetT, InputValueT>>;
 
         // The output value type
-        typedef typename OutputTupleT::Value OutputValueT;
+        using OutputValueT = typename OutputTupleT::Value;
 
         // Wrapped input iterator to produce index-value <OffsetT, InputT> tuples
-        typedef ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT> ArgIndexInputIteratorT;
+        using ArgIndexInputIteratorT =
+          ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
+
         ArgIndexInputIteratorT d_indexed_in(d_in);
 
         // Initial value
@@ -503,10 +505,10 @@ struct DeviceSegmentedReduce
         bool                 debug_synchronous   = false)        ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
         // Signed integer type for global offsets
-        typedef int OffsetT;
+        using OffsetT = int;
 
         // The input value type
-        typedef typename std::iterator_traits<InputIteratorT>::value_type InputT;
+        using InputT = cub::detail::value_t<InputIteratorT>;
 
         return DispatchSegmentedReduce<InputIteratorT,  OutputIteratorT, BeginOffsetIteratorT, EndOffsetIteratorT, OffsetT, cub::Max>::Dispatch(
             d_temp_storage,
@@ -590,21 +592,23 @@ struct DeviceSegmentedReduce
         bool                 debug_synchronous   = false)        ///< [in] <b>[optional]</b> Whether or not to synchronize the stream after every kernel launch to check for errors.  Also causes launch configurations to be printed to the console.  Default is \p false.
     {
         // Signed integer type for global offsets
-        typedef int OffsetT;
+        using OffsetT = int;
 
         // The input type
-        typedef typename std::iterator_traits<InputIteratorT>::value_type InputValueT;
+        using InputValueT = cub::detail::value_t<InputIteratorT>;
 
         // The output tuple type
-        typedef typename If<(Equals<typename std::iterator_traits<OutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-            KeyValuePair<OffsetT, InputValueT>,                                                                 // ... then the key value pair OffsetT + InputValueT
-            typename std::iterator_traits<OutputIteratorT>::value_type>::Type OutputTupleT;                     // ... else the output iterator's value type
+        using OutputTupleT =
+          cub::detail::non_void_value_t<OutputIteratorT,
+                                        KeyValuePair<OffsetT, InputValueT>>;
 
         // The output value type
-        typedef typename OutputTupleT::Value OutputValueT;
+        using OutputValueT = typename OutputTupleT::Value;
 
         // Wrapped input iterator to produce index-value <OffsetT, InputT> tuples
-        typedef ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT> ArgIndexInputIteratorT;
+        using ArgIndexInputIteratorT =
+          ArgIndexInputIterator<InputIteratorT, OffsetT, OutputValueT>;
+
         ArgIndexInputIteratorT d_indexed_in(d_in);
 
         // Initial value

--- a/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/device/dispatch/dispatch_histogram.cuh
@@ -178,7 +178,7 @@ struct DispatchHistogram
     //---------------------------------------------------------------------
 
     /// The sample value type of the input iterator
-    typedef typename std::iterator_traits<SampleIteratorT>::value_type SampleT;
+    using SampleT = cub::detail::value_t<SampleIteratorT>;
 
     enum
     {
@@ -212,10 +212,12 @@ struct DispatchHistogram
         __host__ __device__ __forceinline__ void BinSelect(_SampleT sample, int &bin, bool valid)
         {
             /// Level iterator wrapper type
-            typedef typename If<IsPointer<LevelIteratorT>::VALUE,
-                    CacheModifiedInputIterator<LOAD_MODIFIER, LevelT, OffsetT>,     // Wrap the native input pointer with CacheModifiedInputIterator
-                    LevelIteratorT>::Type                                           // Directly use the supplied input iterator type
-                WrappedLevelIteratorT;
+            // Wrap the native input pointer with CacheModifiedInputIterator
+            // or Directly use the supplied input iterator type
+            using WrappedLevelIteratorT = cub::detail::conditional_t<
+              std::is_pointer<LevelIteratorT>::value,
+              CacheModifiedInputIterator<LOAD_MODIFIER, LevelT, OffsetT>,
+              LevelIteratorT>;
 
             WrappedLevelIteratorT wrapped_levels(d_levels);
 

--- a/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -190,7 +190,7 @@ DeviceMergeSortMergeKernel(bool ping,
 template <typename KeyIteratorT>
 struct DeviceMergeSortPolicy
 {
-  using KeyT = typename std::iterator_traits<KeyIteratorT>::value_type;
+  using KeyT = cub::detail::value_t<KeyIteratorT>;
 
   //----------------------------------------------------------------------------
   // Architecture-specific tuning policies
@@ -445,11 +445,11 @@ template <typename KeyInputIteratorT,
           typename SelectedPolicy = DeviceMergeSortPolicy<KeyIteratorT>>
 struct DispatchMergeSort : SelectedPolicy
 {
-  using KeyT   = typename std::iterator_traits<KeyIteratorT>::value_type;
-  using ValueT = typename std::iterator_traits<ValueIteratorT>::value_type;
+  using KeyT   = cub::detail::value_t<KeyIteratorT>;
+  using ValueT = cub::detail::value_t<ValueIteratorT>;
 
   /// Whether or not there are values to be trucked along with keys
-  static constexpr bool KEYS_ONLY = Equals<ValueT, NullType>::VALUE;
+  static constexpr bool KEYS_ONLY = std::is_same<ValueT, NullType>::value;
 
   // Problem state
 

--- a/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/device/dispatch/dispatch_reduce.cuh
@@ -72,18 +72,17 @@ __global__ void DeviceReduceKernel(
     ReductionOpT            reduction_op)               ///< [in] Binary reduction functor
 {
     // The output value type
-    typedef typename If<(Equals<typename std::iterator_traits<OutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-        typename std::iterator_traits<InputIteratorT>::value_type,                                          // ... then the input iterator's value type,
-        typename std::iterator_traits<OutputIteratorT>::value_type>::Type OutputT;                          // ... else the output iterator's value type
+    using OutputT =
+      cub::detail::non_void_value_t<OutputIteratorT,
+                                    cub::detail::value_t<InputIteratorT>>;
 
     // Thread block type for reducing input tiles
-    typedef AgentReduce<
-            typename ChainedPolicyT::ActivePolicy::ReducePolicy,
-            InputIteratorT,
-            OutputIteratorT,
-            OffsetT,
-            ReductionOpT>
-        AgentReduceT;
+    using AgentReduceT =
+      AgentReduce<typename ChainedPolicyT::ActivePolicy::ReducePolicy,
+                  InputIteratorT,
+                  OutputIteratorT,
+                  OffsetT,
+                  ReductionOpT>;
 
     // Shared memory storage
     __shared__ typename AgentReduceT::TempStorage temp_storage;
@@ -319,11 +318,11 @@ template <
     typename OffsetT,           ///< Signed integer type for global offsets
     typename ReductionOpT,      ///< Binary reduction functor type having member <tt>T operator()(const T &a, const T &b)</tt>
     typename OutputT =          ///< Data type of the output iterator
-        typename If<(Equals<typename std::iterator_traits<OutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-            typename std::iterator_traits<InputIteratorT>::value_type,                                  // ... then the input iterator's value type,
-            typename std::iterator_traits<OutputIteratorT>::value_type>::Type,                          // ... else the output iterator's value type
+        cub::detail::non_void_value_t<
+          OutputIteratorT,
+          cub::detail::value_t<InputIteratorT>>,
     typename SelectedPolicy = DeviceReducePolicy<
-        typename std::iterator_traits<InputIteratorT>::value_type,
+        cub::detail::value_t<InputIteratorT>,
         OutputT,
         OffsetT,
         ReductionOpT> >
@@ -643,11 +642,10 @@ template <
     typename OffsetT,              ///< Signed integer type for global offsets
     typename ReductionOpT,         ///< Binary reduction functor type having member <tt>T operator()(const T &a, const T &b)</tt>
     typename OutputT =             ///< Data type of the output iterator
-        typename If<(Equals<typename std::iterator_traits<OutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-            typename std::iterator_traits<InputIteratorT>::value_type,                                  // ... then the input iterator's value type,
-            typename std::iterator_traits<OutputIteratorT>::value_type>::Type,                          // ... else the output iterator's value type
+          cub::detail::non_void_value_t<OutputIteratorT,
+                                        cub::detail::value_t<InputIteratorT>>,
     typename SelectedPolicy = DeviceReducePolicy<
-        typename std::iterator_traits<InputIteratorT>::value_type,
+        cub::detail::value_t<InputIteratorT>,
         OutputT,
         OffsetT,
         ReductionOpT> >

--- a/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -129,20 +129,18 @@ struct DispatchReduceByKey
     //-------------------------------------------------------------------------
 
     // The input keys type
-    typedef typename std::iterator_traits<KeysInputIteratorT>::value_type KeyInputT;
+    using KeyInputT = cub::detail::value_t<KeysInputIteratorT>;
 
     // The output keys type
-    typedef typename If<(Equals<typename std::iterator_traits<UniqueOutputIteratorT>::value_type, void>::VALUE),    // KeyOutputT =  (if output iterator's value type is void) ?
-        typename std::iterator_traits<KeysInputIteratorT>::value_type,                                              // ... then the input iterator's value type,
-        typename std::iterator_traits<UniqueOutputIteratorT>::value_type>::Type KeyOutputT;                         // ... else the output iterator's value type
+    using KeyOutputT =
+      cub::detail::non_void_value_t<UniqueOutputIteratorT, KeyInputT>;
 
     // The input values type
-    typedef typename std::iterator_traits<ValuesInputIteratorT>::value_type ValueInputT;
+    using ValueInputT = cub::detail::value_t<ValuesInputIteratorT>;
 
     // The output values type
-    typedef typename If<(Equals<typename std::iterator_traits<AggregatesOutputIteratorT>::value_type, void>::VALUE),    // ValueOutputT =  (if output iterator's value type is void) ?
-        typename std::iterator_traits<ValuesInputIteratorT>::value_type,                                                // ... then the input iterator's value type,
-        typename std::iterator_traits<AggregatesOutputIteratorT>::value_type>::Type ValueOutputT;                       // ... else the output iterator's value type
+    using ValueOutputT =
+      cub::detail::non_void_value_t<AggregatesOutputIteratorT, ValueInputT>;
 
     enum
     {
@@ -152,8 +150,7 @@ struct DispatchReduceByKey
     };
 
     // Tile status descriptor interface type
-    typedef ReduceByKeyScanTileState<ValueOutputT, OffsetT> ScanTileStateT;
-
+    using ScanTileStateT = ReduceByKeyScanTileState<ValueOutputT, OffsetT>;
 
     //-------------------------------------------------------------------------
     // Tuning policies

--- a/cub/device/dispatch/dispatch_rle.cuh
+++ b/cub/device/dispatch/dispatch_rle.cuh
@@ -124,12 +124,11 @@ struct DeviceRleDispatch
      ******************************************************************************/
 
     // The input value type
-    typedef typename std::iterator_traits<InputIteratorT>::value_type T;
+    using T = cub::detail::value_t<InputIteratorT>;
 
     // The lengths output value type
-    typedef typename If<(Equals<typename std::iterator_traits<LengthsOutputIteratorT>::value_type, void>::VALUE),   // LengthT =  (if output iterator's value type is void) ?
-        OffsetT,                                                                                                    // ... then the OffsetT type,
-        typename std::iterator_traits<LengthsOutputIteratorT>::value_type>::Type LengthT;                           // ... else the output iterator's value type
+    using LengthT =
+      cub::detail::non_void_value_t<LengthsOutputIteratorT, OffsetT>;
 
     enum
     {
@@ -137,7 +136,7 @@ struct DeviceRleDispatch
     };
 
     // Tile status descriptor interface type
-    typedef ReduceByKeyScanTileState<LengthT, OffsetT> ScanTileStateT;
+    using ScanTileStateT = ReduceByKeyScanTileState<LengthT, OffsetT>;
 
 
     /******************************************************************************

--- a/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/device/dispatch/dispatch_scan.cuh
@@ -210,9 +210,9 @@ template <
     typename OffsetT,            ///< Signed integer type for global offsets
     typename SelectedPolicy = DeviceScanPolicy<
       // Accumulator type.
-      typename If<Equals<InitValueT, NullType>::VALUE,
-                  typename std::iterator_traits<InputIteratorT>::value_type,
-                  typename InitValueT::value_type>::Type>>
+      cub::detail::conditional_t<std::is_same<InitValueT, NullType>::value,
+                                 cub::detail::value_t<InputIteratorT>,
+                                 typename InitValueT::value_type>>>
 struct DispatchScan:
     SelectedPolicy
 {
@@ -226,13 +226,15 @@ struct DispatchScan:
     };
 
     // The input value type
-    using InputT = typename std::iterator_traits<InputIteratorT>::value_type;
+    using InputT = cub::detail::value_t<InputIteratorT>;
 
     // The output value type -- used as the intermediate accumulator
     // Per https://wg21.link/P0571, use InitValueT::value_type if provided, otherwise the
     // input iterator's value type.
     using OutputT =
-      typename If<Equals<InitValueT, NullType>::VALUE, InputT, typename InitValueT::value_type>::Type;
+      cub::detail::conditional_t<std::is_same<InitValueT, NullType>::value,
+                                 InputT,
+                                 typename InitValueT::value_type>;
 
     void*           d_temp_storage;         ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
     size_t&         temp_storage_bytes;     ///< [in,out] Reference to size in bytes of \p d_temp_storage allocation

--- a/cub/device/dispatch/dispatch_segmented_sort.cuh
+++ b/cub/device/dispatch/dispatch_segmented_sort.cuh
@@ -532,10 +532,7 @@ template <typename KeyT,
 struct DeviceSegmentedSortPolicy
 {
   using DominantT =
-    typename std::conditional<
-      (sizeof(ValueT) > sizeof(KeyT)),
-      ValueT,
-      KeyT>::type;
+    cub::detail::conditional_t<(sizeof(ValueT) > sizeof(KeyT)), ValueT, KeyT>;
 
   constexpr static int KEYS_ONLY = std::is_same<ValueT, cub::NullType>::value;
 
@@ -868,15 +865,15 @@ struct DeviceSegmentedSortPolicy
 };
 
 template <bool IS_DESCENDING,
-  typename KeyT,
-  typename ValueT,
-  typename OffsetT,
-  typename BeginOffsetIteratorT,
-  typename EndOffsetIteratorT,
-  typename SelectedPolicy = DeviceSegmentedSortPolicy<KeyT, ValueT>>
+          typename KeyT,
+          typename ValueT,
+          typename OffsetT,
+          typename BeginOffsetIteratorT,
+          typename EndOffsetIteratorT,
+          typename SelectedPolicy = DeviceSegmentedSortPolicy<KeyT, ValueT>>
 struct DispatchSegmentedSort : SelectedPolicy
 {
-  static constexpr int KEYS_ONLY = Equals<ValueT, NullType>::VALUE;
+  static constexpr int KEYS_ONLY = std::is_same<ValueT, NullType>::value;
 
   struct LargeSegmentsSelectorT
   {

--- a/cub/device/dispatch/dispatch_select_if.cuh
+++ b/cub/device/dispatch/dispatch_select_if.cuh
@@ -130,12 +130,12 @@ struct DispatchSelectIf
      ******************************************************************************/
 
     // The output value type
-    typedef typename If<(Equals<typename std::iterator_traits<SelectedOutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-        typename std::iterator_traits<InputIteratorT>::value_type,                                                  // ... then the input iterator's value type,
-        typename std::iterator_traits<SelectedOutputIteratorT>::value_type>::Type OutputT;                          // ... else the output iterator's value type
+    using OutputT =
+      cub::detail::non_void_value_t<SelectedOutputIteratorT,
+                                    cub::detail::value_t<InputIteratorT>>;
 
     // The flag value type
-    typedef typename std::iterator_traits<FlagsInputIteratorT>::value_type FlagT;
+    using FlagT = cub::detail::value_t<FlagsInputIteratorT>;
 
     enum
     {

--- a/cub/device/dispatch/dispatch_three_way_partition.cuh
+++ b/cub/device/dispatch/dispatch_three_way_partition.cuh
@@ -157,7 +157,7 @@ struct DispatchThreeWayPartitionIf
    * Types and constants
    ****************************************************************************/
 
-  using InputT = typename std::iterator_traits<InputIteratorT>::value_type;
+  using InputT = cub::detail::value_t<InputIteratorT>;
   using ScanTileStateT = cub::ScanTileState<OffsetT>;
 
   constexpr static int INIT_KERNEL_THREADS = 256;

--- a/cub/iterator/arg_index_input_iterator.cuh
+++ b/cub/iterator/arg_index_input_iterator.cuh
@@ -105,7 +105,7 @@ CUB_NAMESPACE_BEGIN
 template <
     typename    InputIteratorT,
     typename    OffsetT             = ptrdiff_t,
-    typename    OutputValueT        = typename std::iterator_traits<InputIteratorT>::value_type>
+    typename    OutputValueT        = cub::detail::value_t<InputIteratorT>>
 class ArgIndexInputIterator
 {
 public:

--- a/cub/iterator/cache_modified_input_iterator.cuh
+++ b/cub/iterator/cache_modified_input_iterator.cuh
@@ -134,7 +134,7 @@ public:
     __host__ __device__ __forceinline__ CacheModifiedInputIterator(
         QualifiedValueType* ptr)     ///< Native pointer to wrap
     :
-        ptr(const_cast<typename RemoveQualifiers<QualifiedValueType>::Type *>(ptr))
+        ptr(const_cast<typename std::remove_cv<QualifiedValueType>::type *>(ptr))
     {}
 
     /// Postfix increment

--- a/cub/iterator/cache_modified_output_iterator.cuh
+++ b/cub/iterator/cache_modified_output_iterator.cuh
@@ -154,7 +154,7 @@ public:
     __host__ __device__ __forceinline__ CacheModifiedOutputIterator(
         QualifiedValueType* ptr)     ///< Native pointer to wrap
     :
-        ptr(const_cast<typename RemoveQualifiers<QualifiedValueType>::Type *>(ptr))
+        ptr(const_cast<typename std::remove_cv<QualifiedValueType>::type *>(ptr))
     {}
 
     /// Postfix increment

--- a/cub/iterator/tex_obj_input_iterator.cuh
+++ b/cub/iterator/tex_obj_input_iterator.cuh
@@ -160,7 +160,7 @@ public:
         size_t          bytes,              ///< Number of bytes in the range
         size_t          tex_offset = 0)     ///< OffsetT (in items) from \p ptr denoting the position of the iterator
     {
-        this->ptr = const_cast<typename RemoveQualifiers<QualifiedT>::Type *>(ptr);
+        this->ptr = const_cast<typename std::remove_cv<QualifiedT>::type *>(ptr);
         this->tex_offset = static_cast<difference_type>(tex_offset);
 
         cudaChannelFormatDesc   channel_desc = cudaCreateChannelDesc<TextureWord>();

--- a/cub/iterator/tex_ref_input_iterator.cuh
+++ b/cub/iterator/tex_ref_input_iterator.cuh
@@ -292,7 +292,7 @@ public:
         size_t          bytes,                  ///< Number of bytes in the range
         size_t          tex_offset = 0)         ///< OffsetT (in items) from \p ptr denoting the position of the iterator
     {
-        this->ptr = const_cast<typename RemoveQualifiers<QualifiedT>::Type *>(ptr);
+        this->ptr = const_cast<typename std::remove_cv<QualifiedT>::type *>(ptr);
         size_t offset;
         cudaError_t retval = TexId::BindTexture(this->ptr + tex_offset, bytes, offset);
         this->tex_offset = (difference_type) (offset / sizeof(QualifiedT));

--- a/cub/thread/thread_load.cuh
+++ b/cub/thread/thread_load.cuh
@@ -98,11 +98,10 @@ enum CacheLoadModifier
  * \tparam MODIFIER             <b>[inferred]</b> CacheLoadModifier enumeration
  * \tparam InputIteratorT       <b>[inferred]</b> Input iterator type \iterator
  */
-template <
-    CacheLoadModifier MODIFIER,
-    typename InputIteratorT>
-__device__ __forceinline__ typename std::iterator_traits<InputIteratorT>::value_type ThreadLoad(InputIteratorT itr);
-
+template <CacheLoadModifier MODIFIER,
+          typename InputIteratorT>
+__device__ __forceinline__ cub::detail::value_t<InputIteratorT>
+ThreadLoad(InputIteratorT itr);
 
 //@}  end member group
 
@@ -303,10 +302,10 @@ struct IterateThreadLoad<MAX, MAX>
  * ThreadLoad definition for LOAD_DEFAULT modifier on iterator types
  */
 template <typename InputIteratorT>
-__device__ __forceinline__ typename std::iterator_traits<InputIteratorT>::value_type ThreadLoad(
-    InputIteratorT          itr,
-    Int2Type<LOAD_DEFAULT>  /*modifier*/,
-    Int2Type<false>         /*is_pointer*/)
+__device__ __forceinline__ cub::detail::value_t<InputIteratorT>
+ThreadLoad(InputIteratorT          itr,
+           Int2Type<LOAD_DEFAULT>  /*modifier*/,
+           Int2Type<false>         /*is_pointer*/)
 {
     return *itr;
 }
@@ -402,13 +401,14 @@ __device__ __forceinline__ T ThreadLoad(
 template <
     CacheLoadModifier MODIFIER,
     typename InputIteratorT>
-__device__ __forceinline__ typename std::iterator_traits<InputIteratorT>::value_type ThreadLoad(InputIteratorT itr)
+__device__ __forceinline__ cub::detail::value_t<InputIteratorT>
+ThreadLoad(InputIteratorT itr)
 {
     // Apply tags for partial-specialization
     return ThreadLoad(
         itr,
         Int2Type<MODIFIER>(),
-        Int2Type<IsPointer<InputIteratorT>::VALUE>());
+        Int2Type<std::is_pointer<InputIteratorT>::value>());
 }
 
 

--- a/cub/thread/thread_search.cuh
+++ b/cub/thread/thread_search.cuh
@@ -34,8 +34,9 @@
 #pragma once
 
 #include <iterator>
-#include "../util_namespace.cuh"
-#include "../config.cuh"
+#include <cub/util_namespace.cuh>
+#include <cub/util_type.cuh>
+#include <cub/config.cuh>
 
 CUB_NAMESPACE_BEGIN
 
@@ -57,7 +58,7 @@ __host__ __device__ __forceinline__ void MergePathSearch(
     CoordinateT&    path_coordinate)
 {
     /// The value type of the input iterator
-    typedef typename std::iterator_traits<AIteratorT>::value_type T;
+    using T = cub::detail::value_t<AIteratorT>;
 
     OffsetT split_min = CUB_MAX(diagonal - b_len, 0);
     OffsetT split_max = CUB_MIN(diagonal, a_len);

--- a/cub/thread/thread_sort.cuh
+++ b/cub/thread/thread_sort.cuh
@@ -81,7 +81,7 @@ StableOddEvenSort(KeyT (&keys)[ITEMS_PER_THREAD],
                   ValueT (&items)[ITEMS_PER_THREAD],
                   CompareOp compare_op)
 {
-  constexpr bool KEYS_ONLY = Equals<ValueT, NullType>::VALUE;
+  constexpr bool KEYS_ONLY = std::is_same<ValueT, NullType>::value;
 
   #pragma unroll
   for (int i = 0; i < ITEMS_PER_THREAD; ++i)

--- a/cub/thread/thread_store.cuh
+++ b/cub/thread/thread_store.cuh
@@ -401,7 +401,7 @@ __device__ __forceinline__ void ThreadStore(OutputIteratorT itr, T val)
         itr,
         val,
         Int2Type<MODIFIER>(),
-        Int2Type<IsPointer<OutputIteratorT>::VALUE>());
+        Int2Type<std::is_pointer<OutputIteratorT>::value>());
 }
 
 

--- a/cub/util_device.cuh
+++ b/cub/util_device.cuh
@@ -672,19 +672,22 @@ struct KernelConfig
 template <int PTX_VERSION, typename PolicyT, typename PrevPolicyT>
 struct ChainedPolicy
 {
-   /// The policy for the active compiler pass
-   typedef typename If<(CUB_PTX_ARCH < PTX_VERSION), typename PrevPolicyT::ActivePolicy, PolicyT>::Type ActivePolicy;
+  /// The policy for the active compiler pass
+  using ActivePolicy =
+    cub::detail::conditional_t<(CUB_PTX_ARCH < PTX_VERSION),
+                               typename PrevPolicyT::ActivePolicy,
+                               PolicyT>;
 
-   /// Specializes and dispatches op in accordance to the first policy in the chain of adequate PTX version
-   template <typename FunctorT>
-   CUB_RUNTIME_FUNCTION __forceinline__
-   static cudaError_t Invoke(int ptx_version, FunctorT& op)
-   {
-       if (ptx_version < PTX_VERSION) {
-           return PrevPolicyT::Invoke(ptx_version, op);
-       }
-       return op.template Invoke<PolicyT>();
-   }
+  /// Specializes and dispatches op in accordance to the first policy in the chain of adequate PTX version
+  template <typename FunctorT>
+  CUB_RUNTIME_FUNCTION __forceinline__
+  static cudaError_t Invoke(int ptx_version, FunctorT& op)
+  {
+      if (ptx_version < PTX_VERSION) {
+          return PrevPolicyT::Invoke(ptx_version, op);
+      }
+      return op.template Invoke<PolicyT>();
+  }
 };
 
 /// Helper for dispatching into a policy chain (end-of-chain specialization)

--- a/cub/util_type.cuh
+++ b/cub/util_type.cuh
@@ -33,9 +33,10 @@
 
 #pragma once
 
+#include <cfloat>
 #include <iostream>
 #include <limits>
-#include <cfloat>
+#include <type_traits>
 
 #if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !_NVHPC_CUDA
     #include <cuda_fp16.h>
@@ -44,10 +45,10 @@
     #include <cuda_bf16.h>
 #endif
 
-#include "util_macro.cuh"
-#include "util_arch.cuh"
-#include "util_namespace.cuh"
-
+#include <cub/util_arch.cuh>
+#include <cub/util_deprecated.cuh>
+#include <cub/util_macro.cuh>
+#include <cub/util_namespace.cuh>
 
 
 CUB_NAMESPACE_BEGIN
@@ -64,27 +65,55 @@ CUB_NAMESPACE_BEGIN
  * Conditional types
  ******************************************************************************/
 
+
+namespace detail
+{
+
+
+template <bool Test, class T1, class T2>
+using conditional_t = typename std::conditional<Test, T1, T2>::type;
+
+
+template <typename Iterator>
+using value_t = typename std::iterator_traits<Iterator>::value_type;
+
+
+/**
+ * The output value type
+ * type = (if IteratorT's value type is void) ?
+ * ... then the FallbackT,
+ * ... else the IteratorT's value type
+ */
+template <typename IteratorT, typename FallbackT>
+using non_void_value_t =
+  cub::detail::conditional_t<std::is_same<value_t<IteratorT>, void>::value,
+                             FallbackT,
+                             value_t<IteratorT>>;
+
+} // namespace detail
+
+
 /**
  * \brief Type selection (<tt>IF ? ThenType : ElseType</tt>)
+ *
+ * \deprecated [Since 1.16.0] The cub::If APIs are deprecated.
+ *             Use cub::detail::conditional_t instead.
  */
 template <bool IF, typename ThenType, typename ElseType>
-struct If
+struct CUB_DEPRECATED If
 {
-    /// Conditional type result
-    typedef ThenType Type;      // true
+  /// Conditional type result
+  typedef ThenType Type; // true
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
 
 template <typename ThenType, typename ElseType>
-struct If<false, ThenType, ElseType>
+struct CUB_DEPRECATED If<false, ThenType, ElseType>
 {
     typedef ElseType Type;      // false
 };
-
-#endif // DOXYGEN_SHOULD_SKIP_THIS
-
-
+#endif
 
 /******************************************************************************
  * Type equality
@@ -92,9 +121,12 @@ struct If<false, ThenType, ElseType>
 
 /**
  * \brief Type equality test
+ *
+ * \deprecated [Since 1.16.0] The cub::Equals APIs are deprecated.
+ *             Use std::is_same instead.
  */
 template <typename A, typename B>
-struct Equals
+struct CUB_DEPRECATED Equals
 {
     enum {
         VALUE = 0,
@@ -105,7 +137,7 @@ struct Equals
 #ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
 
 template <typename A>
-struct Equals <A, A>
+struct CUB_DEPRECATED Equals<A, A>
 {
     enum {
         VALUE = 1,
@@ -114,7 +146,6 @@ struct Equals <A, A>
 };
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
-
 
 /******************************************************************************
  * Static math
@@ -146,7 +177,6 @@ struct Log2<N, 0, COUNT>
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
-
 /**
  * \brief Statically determine if N is a power-of-two
  */
@@ -164,9 +194,12 @@ struct PowerOfTwo
 
 /**
  * \brief Pointer vs. iterator
+ *
+ * \deprecated [Since 1.16.0] The cub::IsPointer APIs are deprecated.
+ *             Use std::is_pointer instead.
  */
 template <typename Tp>
-struct IsPointer
+struct CUB_DEPRECATED IsPointer
 {
     enum { VALUE = 0 };
 };
@@ -181,17 +214,18 @@ struct IsPointer<Tp*>
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
-
-
 /******************************************************************************
  * Qualifier detection
  ******************************************************************************/
 
 /**
  * \brief Volatile modifier test
+ *
+ * \deprecated [Since 1.16.0] The cub::IsVolatile APIs are deprecated.
+ *             Use std::is_volatile instead.
  */
 template <typename Tp>
-struct IsVolatile
+struct CUB_DEPRECATED IsVolatile
 {
     enum { VALUE = 0 };
 };
@@ -199,13 +233,12 @@ struct IsVolatile
 #ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
 
 template <typename Tp>
-struct IsVolatile<Tp volatile>
+struct CUB_DEPRECATED IsVolatile<Tp volatile>
 {
     enum { VALUE = 1 };
 };
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
-
 
 /******************************************************************************
  * Qualifier removal
@@ -214,11 +247,14 @@ struct IsVolatile<Tp volatile>
 /**
  * \brief Removes \p const and \p volatile qualifiers from type \p Tp.
  *
+ * \deprecated [Since 1.16.0] The cub::RemoveQualifiers APIs are deprecated.
+ *             Use std::remove_cv instead.
+ *
  * For example:
  *     <tt>typename RemoveQualifiers<volatile int>::Type         // int;</tt>
  */
 template <typename Tp, typename Up = Tp>
-struct RemoveQualifiers
+struct CUB_DEPRECATED RemoveQualifiers
 {
     /// Type without \p const and \p volatile qualifiers
     typedef Up Type;
@@ -227,19 +263,19 @@ struct RemoveQualifiers
 #ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
 
 template <typename Tp, typename Up>
-struct RemoveQualifiers<Tp, volatile Up>
+struct CUB_DEPRECATED RemoveQualifiers<Tp, volatile Up>
 {
     typedef Up Type;
 };
 
 template <typename Tp, typename Up>
-struct RemoveQualifiers<Tp, const Up>
+struct CUB_DEPRECATED RemoveQualifiers<Tp, const Up>
 {
     typedef Up Type;
 };
 
 template <typename Tp, typename Up>
-struct RemoveQualifiers<Tp, const volatile Up>
+struct CUB_DEPRECATED RemoveQualifiers<Tp, const volatile Up>
 {
     typedef Up Type;
 };
@@ -415,10 +451,11 @@ __CUB_ALIGN_BYTES(longlong4, 16)
 __CUB_ALIGN_BYTES(ulonglong4, 16)
 __CUB_ALIGN_BYTES(double4, 16)
 
+// clang-format off
 template <typename T> struct AlignBytes<volatile T> : AlignBytes<T> {};
 template <typename T> struct AlignBytes<const T> : AlignBytes<T> {};
 template <typename T> struct AlignBytes<const volatile T> : AlignBytes<T> {};
-
+// clang-format on
 
 /// Unit-words of data movement
 template <typename T>
@@ -437,31 +474,36 @@ struct UnitWord
         };
     };
 
-    /// Biggest shuffle word that T is a whole multiple of and is not larger than the alignment of T
-    typedef typename If<IsMultiple<int>::IS_MULTIPLE,
-        unsigned int,
-        typename If<IsMultiple<short>::IS_MULTIPLE,
-            unsigned short,
-            unsigned char>::Type>::Type         ShuffleWord;
+    /// Biggest shuffle word that T is a whole multiple of and is not larger than
+    /// the alignment of T
+    using ShuffleWord = cub::detail::conditional_t<
+      IsMultiple<int>::IS_MULTIPLE,
+      unsigned int,
+      cub::detail::conditional_t<IsMultiple<short>::IS_MULTIPLE,
+                                 unsigned short,
+                                 unsigned char>>;
 
-    /// Biggest volatile word that T is a whole multiple of and is not larger than the alignment of T
-    typedef typename If<IsMultiple<long long>::IS_MULTIPLE,
-        unsigned long long,
-        ShuffleWord>::Type                      VolatileWord;
+    /// Biggest volatile word that T is a whole multiple of and is not larger than
+    /// the alignment of T
+    using VolatileWord =
+      cub::detail::conditional_t<IsMultiple<long long>::IS_MULTIPLE,
+                                 unsigned long long,
+                                 ShuffleWord>;
 
-    /// Biggest memory-access word that T is a whole multiple of and is not larger than the alignment of T
-    typedef typename If<IsMultiple<longlong2>::IS_MULTIPLE,
-        ulonglong2,
-        VolatileWord>::Type                     DeviceWord;
+    /// Biggest memory-access word that T is a whole multiple of and is not larger
+    /// than the alignment of T
+    using DeviceWord =
+      cub::detail::conditional_t<IsMultiple<longlong2>::IS_MULTIPLE,
+                                 ulonglong2,
+                                 VolatileWord>;
 
-    /// Biggest texture reference word that T is a whole multiple of and is not larger than the alignment of T
-    typedef typename If<IsMultiple<int4>::IS_MULTIPLE,
-        uint4,
-        typename If<IsMultiple<int2>::IS_MULTIPLE,
-            uint2,
-            ShuffleWord>::Type>::Type           TextureWord;
+    /// Biggest texture reference word that T is a whole multiple of and is not
+    /// larger than the alignment of T
+    using TextureWord = cub::detail::conditional_t<
+      IsMultiple<int4>::IS_MULTIPLE,
+      uint4,
+      cub::detail::conditional_t<IsMultiple<int2>::IS_MULTIPLE, uint2, ShuffleWord>>;
 };
-
 
 // float2 specialization workaround (for SM10-SM13)
 template <>
@@ -509,11 +551,11 @@ struct UnitWord <char2>
     typedef unsigned short      TextureWord;
 };
 
-
+// clang-format off
 template <typename T> struct UnitWord<volatile T> : UnitWord<T> {};
 template <typename T> struct UnitWord<const T> : UnitWord<T> {};
 template <typename T> struct UnitWord<const volatile T> : UnitWord<T> {};
-
+// clang-format on
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
@@ -676,6 +718,7 @@ struct CubVector<T, 4>
 
 
 // Expand CUDA vector types for built-in primitives
+// clang-format off
 CUB_DEFINE_VECTOR_TYPE(char,               char)
 CUB_DEFINE_VECTOR_TYPE(signed char,        char)
 CUB_DEFINE_VECTOR_TYPE(short,              short)
@@ -690,13 +733,12 @@ CUB_DEFINE_VECTOR_TYPE(unsigned long long, ulonglong)
 CUB_DEFINE_VECTOR_TYPE(float,              float)
 CUB_DEFINE_VECTOR_TYPE(double,             double)
 CUB_DEFINE_VECTOR_TYPE(bool,               uchar)
+// clang-format on
 
 // Undefine macros
 #undef CUB_DEFINE_VECTOR_TYPE
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
-
-
 
 /******************************************************************************
  * Wrapper types
@@ -930,9 +972,12 @@ struct DoubleBuffer
 
 /**
  * \brief Simple enable-if (similar to Boost)
+ *
+ * \deprecated [Since 1.16.0] The cub::If APIs are deprecated.
+ *             Use std::enable_if instead.
  */
 template <bool Condition, class T = void>
-struct EnableIf
+struct CUB_DEPRECATED EnableIf
 {
     /// Enable-if type for SFINAE dummy variables
     typedef T Type;
@@ -940,9 +985,7 @@ struct EnableIf
 
 
 template <class T>
-struct EnableIf<false, T> {};
-
-
+struct CUB_DEPRECATED EnableIf<false, T> {};
 
 /******************************************************************************
  * Typedef-detection
@@ -1142,7 +1185,6 @@ struct FpLimits<double>
     }
 };
 
-
 #if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !_NVHPC_CUDA
 template <>
 struct FpLimits<__half>
@@ -1219,6 +1261,7 @@ struct BaseTraits<FLOATING_POINT, true, false, _UnsignedBits, T>
 /**
  * \brief Numeric type traits
  */
+// clang-format off
 template <typename T> struct NumericTraits :            BaseTraits<NOT_A_NUMBER, false, false, T, T> {};
 
 template <> struct NumericTraits<NullType> :            BaseTraits<NOT_A_NUMBER, false, true, NullType, NullType> {};
@@ -1246,14 +1289,13 @@ template <> struct NumericTraits<double> :              BaseTraits<FLOATING_POIN
 #endif
 
 template <> struct NumericTraits<bool> :                BaseTraits<UNSIGNED_INTEGER, true, false, typename UnitWord<bool>::VolatileWord, bool> {};
-
-
+// clang-format on
 
 /**
  * \brief Type traits
  */
 template <typename T>
-struct Traits : NumericTraits<typename RemoveQualifiers<T>::Type> {};
+struct Traits : NumericTraits<typename std::remove_cv<T>::type> {};
 
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS

--- a/cub/util_type.cuh
+++ b/cub/util_type.cuh
@@ -102,18 +102,9 @@ using non_void_value_t =
 template <bool IF, typename ThenType, typename ElseType>
 struct CUB_DEPRECATED If
 {
-  /// Conditional type result
-  typedef ThenType Type; // true
+  using Type = cub::detail::conditional_t<IF, ThenType, ElseType>;
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
-
-template <typename ThenType, typename ElseType>
-struct CUB_DEPRECATED If<false, ThenType, ElseType>
-{
-    typedef ElseType Type;      // false
-};
-#endif
 
 /******************************************************************************
  * Type equality
@@ -128,24 +119,10 @@ struct CUB_DEPRECATED If<false, ThenType, ElseType>
 template <typename A, typename B>
 struct CUB_DEPRECATED Equals
 {
-    enum {
-        VALUE = 0,
-        NEGATE = 1
-    };
+  static constexpr int VALUE = std::is_same<A, B>::value ? 1 : 0;
+  static constexpr int NEGATE = VALUE ? 0 : 1;
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
-
-template <typename A>
-struct CUB_DEPRECATED Equals<A, A>
-{
-    enum {
-        VALUE = 1,
-        NEGATE = 0
-    };
-};
-
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /******************************************************************************
  * Static math
@@ -201,18 +178,9 @@ struct PowerOfTwo
 template <typename Tp>
 struct CUB_DEPRECATED IsPointer
 {
-    enum { VALUE = 0 };
+  static constexpr int VALUE = std::is_pointer<Tp>::value;
 };
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
-
-template <typename Tp>
-struct IsPointer<Tp*>
-{
-    enum { VALUE = 1 };
-};
-
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /******************************************************************************
  * Qualifier detection
@@ -227,18 +195,8 @@ struct IsPointer<Tp*>
 template <typename Tp>
 struct CUB_DEPRECATED IsVolatile
 {
-    enum { VALUE = 0 };
+  static constexpr int VALUE = std::is_volatile<Tp>::value;
 };
-
-#ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
-
-template <typename Tp>
-struct CUB_DEPRECATED IsVolatile<Tp volatile>
-{
-    enum { VALUE = 1 };
-};
-
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /******************************************************************************
  * Qualifier removal
@@ -256,28 +214,7 @@ struct CUB_DEPRECATED IsVolatile<Tp volatile>
 template <typename Tp, typename Up = Tp>
 struct CUB_DEPRECATED RemoveQualifiers
 {
-    /// Type without \p const and \p volatile qualifiers
-    typedef Up Type;
-};
-
-#ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
-
-template <typename Tp, typename Up>
-struct CUB_DEPRECATED RemoveQualifiers<Tp, volatile Up>
-{
-    typedef Up Type;
-};
-
-template <typename Tp, typename Up>
-struct CUB_DEPRECATED RemoveQualifiers<Tp, const Up>
-{
-    typedef Up Type;
-};
-
-template <typename Tp, typename Up>
-struct CUB_DEPRECATED RemoveQualifiers<Tp, const volatile Up>
-{
-    typedef Up Type;
+  using Type = typename std::remove_cv<Tp>::type;
 };
 
 
@@ -285,13 +222,14 @@ struct CUB_DEPRECATED RemoveQualifiers<Tp, const volatile Up>
  * Marker types
  ******************************************************************************/
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
+
 /**
  * \brief A simple "NULL" marker type
  */
 struct NullType
 {
     using value_type = NullType;
-#ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
 
     template <typename T>
     __host__ __device__ __forceinline__ NullType& operator =(const T&) { return *this; }
@@ -299,8 +237,6 @@ struct NullType
     __host__ __device__ __forceinline__ bool operator ==(const NullType&) { return true; }
 
     __host__ __device__ __forceinline__ bool operator !=(const NullType&) { return false; }
-
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 };
 
 
@@ -388,8 +324,6 @@ private:
 };
 
 } // namespace detail
-
-#ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
 
 
 /******************************************************************************
@@ -557,9 +491,6 @@ template <typename T> struct UnitWord<const T> : UnitWord<T> {};
 template <typename T> struct UnitWord<const volatile T> : UnitWord<T> {};
 // clang-format on
 
-#endif // DOXYGEN_SHOULD_SKIP_THIS
-
-
 
 /******************************************************************************
  * Vector type inference utilities.
@@ -570,7 +501,6 @@ template <typename T> struct UnitWord<const volatile T> : UnitWord<T> {};
  */
 template <typename T, int vec_elements> struct CubVector;
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
 
 enum
 {
@@ -738,7 +668,6 @@ CUB_DEFINE_VECTOR_TYPE(bool,               uchar)
 // Undefine macros
 #undef CUB_DEFINE_VECTOR_TYPE
 
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /******************************************************************************
  * Wrapper types
@@ -877,9 +806,6 @@ struct KeyValuePair<K, V, false, true>
 #endif // #if defined(_WIN32) && !defined(_WIN64)
 
 
-#ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
-
-
 /**
  * \brief A wrapper for passing simple static arrays as kernel parameters
  */
@@ -893,8 +819,6 @@ struct ArrayWrapper
     /// Constructor
     __host__ __device__ __forceinline__ ArrayWrapper() {}
 };
-
-#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 
 /**
@@ -979,13 +903,8 @@ struct DoubleBuffer
 template <bool Condition, class T = void>
 struct CUB_DEPRECATED EnableIf
 {
-    /// Enable-if type for SFINAE dummy variables
-    typedef T Type;
+  using Type = typename std::enable_if<Condition, T>::type;
 };
-
-
-template <class T>
-struct CUB_DEPRECATED EnableIf<false, T> {};
 
 /******************************************************************************
  * Typedef-detection

--- a/cub/warp/specializations/warp_scan_smem.cuh
+++ b/cub/warp/specializations/warp_scan_smem.cuh
@@ -70,7 +70,7 @@ struct WarpScanSmem
     };
 
     /// Storage cell type (workaround for SM1x compiler bugs with custom-ops like Max() on signed chars)
-    typedef typename If<((Equals<T, char>::VALUE || Equals<T, signed char>::VALUE) && (PTX_ARCH < 200)), int, T>::Type CellT;
+    using CellT = T;
 
     /// Shared memory storage layout type (1.5 warps-worth of elements for each warp)
     typedef CellT _TempStorage[WARP_SMEM_ELEMENTS];

--- a/cub/warp/warp_merge_sort.cuh
+++ b/cub/warp/warp_merge_sort.cuh
@@ -128,7 +128,7 @@ class WarpMergeSort
 {
 private:
   constexpr static bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(PTX_ARCH);
-  constexpr static bool KEYS_ONLY = cub::Equals<ValueT, NullType>::VALUE;
+  constexpr static bool KEYS_ONLY = std::is_same<ValueT, NullType>::value;
   constexpr static int TILE_SIZE = ITEMS_PER_THREAD * LOGICAL_WARP_THREADS;
 
   using BlockMergeSortStrategyT = BlockMergeSortStrategy<KeyT,

--- a/cub/warp/warp_reduce.cuh
+++ b/cub/warp/warp_reduce.cuh
@@ -154,12 +154,14 @@ public:
 
     #ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
 
-    /// Internal specialization.  Use SHFL-based reduction if (architecture is >= SM30) and (LOGICAL_WARP_THREADS is a power-of-two)
-    typedef typename If<(PTX_ARCH >= 300) && (IS_POW_OF_TWO),
-        WarpReduceShfl<T, LOGICAL_WARP_THREADS, PTX_ARCH>,
-        WarpReduceSmem<T, LOGICAL_WARP_THREADS, PTX_ARCH> >::Type InternalWarpReduce;
+    /// Internal specialization.
+    /// Use SHFL-based reduction if LOGICAL_WARP_THREADS is a power-of-two
+    using InternalWarpReduce = cub::detail::conditional_t<
+      IS_POW_OF_TWO,
+      WarpReduceShfl<T, LOGICAL_WARP_THREADS, PTX_ARCH>,
+      WarpReduceSmem<T, LOGICAL_WARP_THREADS, PTX_ARCH>>;
 
-    #endif // DOXYGEN_SHOULD_SKIP_THIS
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 
 private:

--- a/cub/warp/warp_scan.cuh
+++ b/cub/warp/warp_scan.cuh
@@ -158,10 +158,12 @@ private:
         IS_INTEGER = ((Traits<T>::CATEGORY == SIGNED_INTEGER) || (Traits<T>::CATEGORY == UNSIGNED_INTEGER))
     };
 
-    /// Internal specialization.  Use SHFL-based scan if (architecture is >= SM30) and (LOGICAL_WARP_THREADS is a power-of-two)
-    typedef typename If<(PTX_ARCH >= 300) && (IS_POW_OF_TWO),
-        WarpScanShfl<T, LOGICAL_WARP_THREADS, PTX_ARCH>,
-        WarpScanSmem<T, LOGICAL_WARP_THREADS, PTX_ARCH> >::Type InternalWarpScan;
+    /// Internal specialization.
+    /// Use SHFL-based scan if LOGICAL_WARP_THREADS is a power-of-two
+    using InternalWarpScan = cub::detail::conditional_t<
+      IS_POW_OF_TWO,
+      WarpScanShfl<T, LOGICAL_WARP_THREADS, PTX_ARCH>,
+      WarpScanSmem<T, LOGICAL_WARP_THREADS, PTX_ARCH>>;
 
     /// Shared memory storage layout type for WarpScan
     typedef typename InternalWarpScan::TempStorage _TempStorage;

--- a/experimental/defunct/example_coo_spmv.cu
+++ b/experimental/defunct/example_coo_spmv.cu
@@ -72,7 +72,9 @@ template <typename Value>
 struct TexVector
 {
     // Texture type to actually use (e.g., because CUDA doesn't load doubles as texture items)
-    typedef typename If<(Equals<Value, double>::VALUE), uint2, Value>::Type CastType;
+    using CastType =
+      cub::detail::conditional_t<
+        std::is_same<Value, double>::value, uint2, Value>;
 
     // Texture reference type
     typedef texture<CastType, cudaTextureType1D, cudaReadModeElementType> TexRef;

--- a/experimental/histogram/histogram_cub.h
+++ b/experimental/histogram/histogram_cub.h
@@ -29,11 +29,10 @@
 
 using namespace cub;
 
-template <
-    int         NUM_CHANNELS,
-    int         ACTIVE_CHANNELS,
-    int         NUM_BINS,
-    typename    PixelType>
+template <int NUM_CHANNELS,
+          int ACTIVE_CHANNELS,
+          int NUM_BINS,
+          typename PixelType>
 double run_cub_histogram(
     PixelType *d_image,
     int width,
@@ -41,12 +40,10 @@ double run_cub_histogram(
     unsigned int *d_hist, 
     bool is_warmup)
 {
-    enum {
-        is_float = Equals<PixelType, float4>::VALUE,
-    };
+    constexpr bool is_float = std::is_same<PixelType, float4>::value;
 
-    typedef typename If<is_float, float, unsigned char>::Type    SampleT;    // Sample type
-    typedef typename If<is_float, float, unsigned int>::Type     LevelT;     // Level type (uint32 for uchar)
+    using SampleT = cub::detail::conditional_t<is_float, float, unsigned char>;   // Sample type
+    using LevelT = cub::detail::conditional_t<is_float, float, unsigned int>;     // Level type (uint32 for uchar)
 
     // Setup data structures
     unsigned int*       d_histogram[ACTIVE_CHANNELS];

--- a/test/test_block_load_store.cu
+++ b/test/test_block_load_store.cu
@@ -83,16 +83,17 @@ __global__ void Kernel(
     };
 
     // The input value type
-    typedef typename std::iterator_traits<InputIteratorT>::value_type InputT;
+    using InputT = cub::detail::value_t<InputIteratorT>;
 
     // The output value type
-    typedef typename If<(Equals<typename std::iterator_traits<OutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-        typename std::iterator_traits<InputIteratorT>::value_type,                                          // ... then the input iterator's value type,
-        typename std::iterator_traits<OutputIteratorT>::value_type>::Type OutputT;                          // ... else the output iterator's value type
+    using OutputT = cub::detail::non_void_value_t<OutputIteratorT, InputT>;
 
     // Threadblock load/store abstraction types
-    typedef BlockLoad<InputT, BLOCK_THREADS, ITEMS_PER_THREAD, LOAD_ALGORITHM> BlockLoad;
-    typedef BlockStore<OutputT, BLOCK_THREADS, ITEMS_PER_THREAD, STORE_ALGORITHM> BlockStore;
+    using BlockLoad =
+      BlockLoad<InputT, BLOCK_THREADS, ITEMS_PER_THREAD, LOAD_ALGORITHM>;
+
+    using BlockStore =
+      BlockStore<OutputT, BLOCK_THREADS, ITEMS_PER_THREAD, STORE_ALGORITHM>;
 
     // Shared memory type for this thread block
     union TempStorage

--- a/test/test_block_radix_sort.cu
+++ b/test/test_block_radix_sort.cu
@@ -300,7 +300,7 @@ void TestDriver(
     enum
     {
         TILE_SIZE = BLOCK_THREADS * ITEMS_PER_THREAD,
-        KEYS_ONLY = Equals<Value, NullType>::VALUE,
+        KEYS_ONLY = std::is_same<Value, NullType>::value,
     };
 
     // Allocate host arrays

--- a/test/test_block_reduce.cu
+++ b/test/test_block_reduce.cu
@@ -338,7 +338,7 @@ void TestFullTile(
 
     // Test multi-tile (unguarded)
     printf("TestFullTile %s, %s, gen-mode %d, num_items(%d), BLOCK_THREADS(%d) (%d,%d,%d), ITEMS_PER_THREAD(%d), tiles(%d), %s (%d bytes) elements:\n",
-        Equals<ReductionOp, Sum>::VALUE ? "Sum" : "Max",
+        std::is_same<ReductionOp, Sum>::value ? "Sum" : "Max",
         (ALGORITHM == BLOCK_REDUCE_RAKING) ? "BLOCK_REDUCE_RAKING" : (ALGORITHM == BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY) ? "BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY" : "BLOCK_REDUCE_WARP_REDUCTIONS",
         gen_mode,
         num_items,

--- a/test/test_block_run_length_decode.cu
+++ b/test/test_block_run_length_decode.cu
@@ -78,22 +78,48 @@ public:
   constexpr static bool TEST_RELATIVE_OFFSETS = TEST_RELATIVE_OFFSETS_;
 
 private:
-  using RunItemT   = typename std::iterator_traits<ItemItT>::value_type;
-  using RunLengthT = typename std::iterator_traits<RunLengthsItT>::value_type;
+  using RunItemT   = cub::detail::value_t<ItemItT>;
+  using RunLengthT = cub::detail::value_t<RunLengthsItT>;
 
-  using BlockRunOffsetScanT = cub::BlockScan<RunLengthT, BLOCK_DIM_X, BLOCK_SCAN_RAKING, BLOCK_DIM_Y, BLOCK_DIM_Z>;
+  using BlockRunOffsetScanT = cub::BlockScan<RunLengthT,
+                                             BLOCK_DIM_X,
+                                             BLOCK_SCAN_RAKING,
+                                             BLOCK_DIM_Y,
+                                             BLOCK_DIM_Z>;
 
   using BlockRunLengthDecodeT =
-    cub::BlockRunLengthDecode<RunItemT, BLOCK_DIM_X, RUNS_PER_THREAD, DECODED_ITEMS_PER_THREAD>;
-  using BlockLoadRunItemT =
-    cub::BlockLoad<RunItemT, BLOCK_DIM_X, RUNS_PER_THREAD, BLOCK_LOAD_WARP_TRANSPOSE, BLOCK_DIM_Y, BLOCK_DIM_Z>;
-  using BlockLoadRunLengthsT =
-    cub::BlockLoad<RunLengthT, BLOCK_DIM_X, RUNS_PER_THREAD, BLOCK_LOAD_WARP_TRANSPOSE, BLOCK_DIM_Y, BLOCK_DIM_Z>;
-  using BlockStoreDecodedItemT = cub::
-    BlockStore<RunItemT, BLOCK_DIM_X, DECODED_ITEMS_PER_THREAD, BLOCK_STORE_WARP_TRANSPOSE, BLOCK_DIM_Y, BLOCK_DIM_Z>;
+    cub::BlockRunLengthDecode<RunItemT,
+                              BLOCK_DIM_X,
+                              RUNS_PER_THREAD,
+                              DECODED_ITEMS_PER_THREAD>;
 
-  using BlockStoreRelativeOffsetT = cub::
-    BlockStore<RunLengthT, BLOCK_DIM_X, DECODED_ITEMS_PER_THREAD, BLOCK_STORE_WARP_TRANSPOSE, BLOCK_DIM_Y, BLOCK_DIM_Z>;
+  using BlockLoadRunItemT = cub::BlockLoad<RunItemT,
+                                           BLOCK_DIM_X,
+                                           RUNS_PER_THREAD,
+                                           BLOCK_LOAD_WARP_TRANSPOSE,
+                                           BLOCK_DIM_Y,
+                                           BLOCK_DIM_Z>;
+
+  using BlockLoadRunLengthsT = cub::BlockLoad<RunLengthT,
+                                              BLOCK_DIM_X,
+                                              RUNS_PER_THREAD,
+                                              BLOCK_LOAD_WARP_TRANSPOSE,
+                                              BLOCK_DIM_Y,
+                                              BLOCK_DIM_Z>;
+
+  using BlockStoreDecodedItemT = cub::BlockStore<RunItemT,
+                                                 BLOCK_DIM_X,
+                                                 DECODED_ITEMS_PER_THREAD,
+                                                 BLOCK_STORE_WARP_TRANSPOSE,
+                                                 BLOCK_DIM_Y,
+                                                 BLOCK_DIM_Z>;
+
+  using BlockStoreRelativeOffsetT = cub::BlockStore<RunLengthT,
+                                                    BLOCK_DIM_X,
+                                                    DECODED_ITEMS_PER_THREAD,
+                                                    BLOCK_STORE_WARP_TRANSPOSE,
+                                                    BLOCK_DIM_Y,
+                                                    BLOCK_DIM_Z>;
 
   __device__ __forceinline__ BlockRunLengthDecodeT InitBlockRunLengthDecode(RunItemT (&unique_items)[RUNS_PER_THREAD],
                                                                             RunLengthT (&run_lengths)[RUNS_PER_THREAD],
@@ -153,7 +179,9 @@ public:
   {
     typename BlockLoadRunItemT::TempStorage load_uniques_storage;
     typename BlockLoadRunLengthsT::TempStorage load_run_lengths_storage;
-    typename std::conditional<TEST_RUN_OFFSETS_, typename BlockRunOffsetScanT::TempStorage, cub::NullType>::type
+    cub::detail::conditional_t<TEST_RUN_OFFSETS_,
+                               typename BlockRunOffsetScanT::TempStorage,
+                               cub::NullType>
       run_offsets_scan_storage;
     struct
     {

--- a/test/test_device_histogram.cu
+++ b/test/test_device_histogram.cu
@@ -142,7 +142,7 @@ struct Dispatch<NUM_ACTIVE_CHANNELS, NUM_CHANNELS, CUB>
         cudaStream_t        stream,
         bool                debug_synchronous)
     {
-        typedef typename std::iterator_traits<SampleIteratorT>::value_type SampleT;
+        using SampleT = cub::detail::value_t<SampleIteratorT>;
 
         cudaError_t error = cudaSuccess;
         for (int i = 0; i < timing_timing_iterations; ++i)
@@ -501,7 +501,7 @@ void InitializeBins(
     OffsetT         num_rows,                               ///< [in] The number of rows in the region of interest
     OffsetT         row_stride_bytes)                       ///< [in] The number of bytes between starts of consecutive rows in the region of interest
 {
-    typedef typename std::iterator_traits<SampleIteratorT>::value_type SampleT;
+    using SampleT = cub::detail::value_t<SampleIteratorT>;
 
     // Init bins
     for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
@@ -570,7 +570,7 @@ void TestEven(
     printf("\n----------------------------\n");
     printf("%s cub::DeviceHistogramEven (%s) %d pixels (%d height, %d width, %d-byte row stride), %d %d-byte %s samples (entropy reduction %d), %s counters, %d/%d channels, max sample ",
         (BACKEND == CDP) ? "CDP CUB" : "CUB",
-        (IsPointer<SampleIteratorT>::VALUE) ? "pointer" : "iterator",
+        (std::is_pointer<SampleIteratorT>::value) ? "pointer" : "iterator",
         (int) (num_row_pixels * num_rows),
         (int) num_rows,
         (int) num_row_pixels,

--- a/test/test_device_radix_sort.cu
+++ b/test/test_device_radix_sort.cu
@@ -591,14 +591,14 @@ void InitializeKeysSorted(
         // twiddled_key < max_bits at this point.
         UnsignedBits inc = static_cast<UnsignedBits>(std::min(1 + inc_bits % max_inc, max_bits - twiddled_key));
         twiddled_key += inc;
-        
+
         // Generate random run length (ensure there are enough values to fill the rest).
         std::size_t run_bits = 0;
         RandomBits(run_bits);
         std::size_t run_length = std::min(1 + run_bits % max_run, num_items - i);
         if (twiddled_key == max_bits) run_length = num_items - i;
         std::size_t run_end = i + run_length;
-        
+
         // Fill the array.
         UnsignedBits key = TraitsT::TwiddleOut(twiddled_key);
         // Avoid -0.0 for floating-point keys.
@@ -689,7 +689,7 @@ void InitializeSolution(
             cur_key = key;
             summary.push_back(Element{cur_key, 1, i});
         }
-        
+
         // Generate a random permutation from the summary. Such a complicated
         // approach is used to permute the array and compute ranks in a
         // cache-friendly way and in a short time.
@@ -839,7 +839,7 @@ void Test(
     // Key alias type
     using KeyAliasT = typename UnwrapHalfAndBfloat16<KeyT>::Type;
 
-    const bool KEYS_ONLY = Equals<ValueT, NullType>::VALUE;
+    const bool KEYS_ONLY = std::is_same<ValueT, NullType>::value;
 
     printf("%s %s cub::DeviceRadixSort %zd items, %d segments, "
            "%d-byte keys (%s) %d-byte values (%s), descending %d, "
@@ -991,7 +991,9 @@ template <typename KeyT, typename ValueT>
 bool HasEnoughMemory(std::size_t num_items)
 {
     std::size_t total_mem = TotalGlobalMem();
-    std::size_t value_size = Equals<ValueT, NullType>::VALUE ? 0 : sizeof(ValueT);
+    std::size_t value_size = std::is_same<ValueT, NullType>::value
+                           ? 0
+                           : sizeof(ValueT);
     // A conservative estimate of the amount of memory required.
     std::size_t test_mem = 4 * num_items * (sizeof(KeyT) + value_size);
     return test_mem < total_mem;
@@ -1012,7 +1014,7 @@ void TestBackend(
     KeyT                 *h_reference_keys,
     std::size_t          *h_reference_ranks)
 {
-    const bool KEYS_ONLY = Equals<ValueT, NullType>::VALUE;
+    const bool KEYS_ONLY = std::is_same<ValueT, NullType>::value;
 
     ValueT *h_values             = NULL;
     ValueT *h_reference_values   = NULL;
@@ -1141,7 +1143,8 @@ void TestBits(
     EndOffsetIteratorT   d_segment_end_offsets)
 {
     // Don't test partial-word sorting for boolean, fp, or signed types (the bit-flipping techniques get in the way) or pre-sorted keys
-    if ((Traits<KeyT>::CATEGORY == UNSIGNED_INTEGER) && (!Equals<KeyT, bool>::VALUE)
+    if ((Traits<KeyT>::CATEGORY == UNSIGNED_INTEGER)
+        && (!std::is_same<KeyT, bool>::value)
         && !pre_sorted)
     {
         // Partial bits
@@ -1315,7 +1318,7 @@ void TestGen(
     InitializeKeyBits(INTEGER_SEED, h_keys.get(), max_items, 0);
     TestSizes(h_keys.get(), max_items, max_segments, false);
 
-    if (!cub::Equals<KeyT, bool>::VALUE)
+    if (!std::is_same<KeyT, bool>::value)
     {
         // Presorting is only used for testing large input arrays.
         // Increase above 2^32 once 64-bit indexing is enabled.
@@ -1352,7 +1355,7 @@ void Test(
     int         begin_bit,
     int         end_bit)
 {
-    const bool KEYS_ONLY = Equals<ValueT, NullType>::VALUE;
+    const bool KEYS_ONLY = std::is_same<ValueT, NullType>::value;
 
     KeyT         *h_keys             = new KeyT[num_items];
     std::size_t  *h_reference_ranks  = NULL;

--- a/test/test_device_reduce.cu
+++ b/test/test_device_reduce.cu
@@ -40,6 +40,7 @@
 #include <cub/iterator/constant_input_iterator.cuh>
 #include <cub/iterator/discard_output_iterator.cuh>
 #include <cub/iterator/transform_input_iterator.cuh>
+#include <cub/util_type.cuh>
 
 #include "test_util.h"
 
@@ -112,12 +113,10 @@ cudaError_t Dispatch(
     cudaStream_t        stream,
     bool                debug_synchronous)
 {
-    typedef typename std::iterator_traits<InputIteratorT>::value_type InputT;
+    using InputT = cub::detail::value_t<InputIteratorT>;
 
     // The output value type
-    typedef typename If<(Equals<typename std::iterator_traits<OutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-        typename std::iterator_traits<InputIteratorT>::value_type,                                          // ... then the input iterator's value type,
-        typename std::iterator_traits<OutputIteratorT>::value_type>::Type OutputT;                          // ... else the output iterator's value type
+    using OutputT = cub::detail::non_void_value_t<OutputIteratorT, InputT>;
 
     // Max-identity
     OutputT identity = Traits<InputT>::Lowest(); // replace with std::numeric_limits<OutputT>::lowest() when C++ support is more prevalent
@@ -328,12 +327,10 @@ cudaError_t Dispatch(
     bool                debug_synchronous)
 {
     // The input value type
-    typedef typename std::iterator_traits<InputIteratorT>::value_type InputT;
+    using InputT = cub::detail::value_t<InputIteratorT>;
 
     // The output value type
-    typedef typename If<(Equals<typename std::iterator_traits<OutputIteratorT>::value_type, void>::VALUE),  // OutputT =  (if output iterator's value type is void) ?
-        typename std::iterator_traits<InputIteratorT>::value_type,                                          // ... then the input iterator's value type,
-        typename std::iterator_traits<OutputIteratorT>::value_type>::Type OutputT;                          // ... else the output iterator's value type
+    using OutputT = cub::detail::non_void_value_t<OutputIteratorT, InputT>;
 
     // Max-identity
     OutputT identity = Traits<InputT>::Lowest(); // replace with std::numeric_limits<OutputT>::lowest() when C++ support is more prevalent
@@ -771,7 +768,7 @@ void Test(
     HostReferenceIteratorT  h_reference)
 {
     // Input data types
-    typedef typename std::iterator_traits<DeviceInputIteratorT>::value_type InputT;
+    using InputT = cub::detail::value_t<DeviceInputIteratorT>;
 
     // Allocate CUB_CDP device arrays for temp storage size and error
     size_t          *d_temp_storage_bytes = NULL;
@@ -857,9 +854,9 @@ void SolveAndTest(
     EndOffsetIteratorT      d_segment_end_offsets,
     ReductionOpT            reduction_op)
 {
-    typedef typename std::iterator_traits<DeviceInputIteratorT>::value_type     InputValueT;
-    typedef Solution<ReductionOpT, InputValueT, OutputValueT>                   SolutionT;
-    typedef typename SolutionT::OutputT                                         OutputT;
+    using InputValueT = cub::detail::value_t<DeviceInputIteratorT>;
+    using SolutionT = Solution<ReductionOpT, InputValueT, OutputValueT>;
+    using OutputT = typename SolutionT::OutputT;
 
     printf("\n\n%s cub::DeviceReduce<%s> %d items (%s), %d segments\n",
         (BACKEND == CUB_CDP) ? "CUB_CDP" : (BACKEND == CUB_SEGMENTED) ? "CUB_SEGMENTED" : "CUB",

--- a/test/test_device_reduce_by_key.cu
+++ b/test/test_device_reduce_by_key.cu
@@ -450,7 +450,7 @@ void TestPointer(
 
     printf("\nPointer %s cub::DeviceReduce::ReduceByKey %s reduction of %d items, %d segments (avg run length %.3f), {%s,%s} key value pairs, max_segment %d, entropy_reduction %d\n",
         (BACKEND == CDP) ? "CDP CUB" : "CUB",
-        (Equals<ReductionOpT, Sum>::VALUE) ? "Sum" : "Max",
+        (std::is_same<ReductionOpT, Sum>::value) ? "Sum" : "Max",
         num_items, num_segments, float(num_items) / num_segments,
         typeid(KeyT).name(), typeid(ValueT).name(),
         max_segment, entropy_reduction);
@@ -509,7 +509,7 @@ void TestIterator(
 
     printf("\nIterator %s cub::DeviceReduce::ReduceByKey %s reduction of %d items, %d segments (avg run length %.3f), {%s,%s} key value pairs, max_segment %d, entropy_reduction %d\n",
         (BACKEND == CDP) ? "CDP CUB" : "CUB",
-        (Equals<ReductionOpT, Sum>::VALUE) ? "Sum" : "Max",
+        (std::is_same<ReductionOpT, Sum>::value) ? "Sum" : "Max",
         num_items, num_segments, float(num_items) / num_segments,
         typeid(KeyT).name(), typeid(ValueT).name(),
         max_segment, entropy_reduction);

--- a/test/test_device_scan.cu
+++ b/test/test_device_scan.cu
@@ -36,10 +36,11 @@
 #include <stdio.h>
 #include <typeinfo>
 
-#include <cub/util_allocator.cuh>
+#include <cub/device/device_scan.cuh>
 #include <cub/iterator/constant_input_iterator.cuh>
 #include <cub/iterator/discard_output_iterator.cuh>
-#include <cub/device/device_scan.cuh>
+#include <cub/util_allocator.cuh>
+#include <cub/util_type.cuh>
 
 #include "test_util.h"
 
@@ -390,7 +391,7 @@ void Solve(
 {
     // When no initial value type is supplied, use InputT for accumulation
     // per P0571
-    using AccumT = typename std::iterator_traits<InputIteratorT>::value_type;
+    using AccumT = cub::detail::value_t<InputIteratorT>;
 
     if (num_items > 0)
     {
@@ -437,7 +438,7 @@ void Test(
     ScanOpT                 scan_op,
     InitialValueT           initial_value)
 {
-    typedef typename std::iterator_traits<DeviceInputIteratorT>::value_type InputT;
+    using InputT = cub::detail::value_t<DeviceInputIteratorT>;
 
     // Allocate device output array
     OutputT *d_out = NULL;
@@ -674,8 +675,8 @@ void TestPointer(
 {
     printf("\nPointer %s %s cub::DeviceScan::%s %d items, %s->%s (%d->%d bytes) , gen-mode %s\n",
         (BACKEND == CDP) ? "CDP CUB" : "CUB",
-        (Equals<InitialValueT, NullType>::VALUE) ? "Inclusive" : "Exclusive",
-        (Equals<ScanOpT, Sum>::VALUE) ? "Sum" : "Scan",
+        (std::is_same<InitialValueT, NullType>::value) ? "Inclusive" : "Exclusive",
+        (std::is_same<ScanOpT, Sum>::value) ? "Sum" : "Scan",
         num_items,
         typeid(InputT).name(), typeid(OutputT).name(), (int) sizeof(InputT), (int) sizeof(OutputT),
         (gen_mode == RANDOM) ? "RANDOM" : (gen_mode == INTEGER_SEED) ? "SEQUENTIAL" : "HOMOGENOUS");
@@ -694,8 +695,8 @@ void TestPointer(
     // type.
     // Do the same thing here:
     if (Traits<OutputT>::PRIMITIVE &&
-        Equals<ScanOpT, cub::Sum>::VALUE &&
-        !Equals<InitialValueT, NullType>::VALUE)
+        std::is_same<ScanOpT, cub::Sum>::value &&
+        !std::is_same<InitialValueT, NullType>::value)
     {
       Solve(h_in, h_reference, num_items, cub::Sum{}, InputT{});
     }
@@ -739,8 +740,8 @@ void TestIterator(
 {
     printf("\nIterator %s %s cub::DeviceScan::%s %d items, %s->%s (%d->%d bytes)\n",
         (BACKEND == CDP) ? "CDP CUB" : "CUB",
-        (Equals<InitialValueT, NullType>::VALUE) ? "Inclusive" : "Exclusive",
-        (Equals<ScanOpT, Sum>::VALUE) ? "Sum" : "Scan",
+        (std::is_same<InitialValueT, NullType>::value) ? "Inclusive" : "Exclusive",
+        (std::is_same<ScanOpT, Sum>::value) ? "Sum" : "Scan",
         num_items,
         typeid(InputT).name(), typeid(OutputT).name(), (int) sizeof(InputT), (int) sizeof(OutputT));
     fflush(stdout);

--- a/test/test_device_scan_by_key.cu
+++ b/test/test_device_scan_by_key.cu
@@ -444,7 +444,7 @@ void Solve(
 {
     // When no initial value type is supplied, use InputT for accumulation
     // per P0571
-    using AccumT = typename std::iterator_traits<ValuesInputIteratorT>::value_type;
+    using AccumT = cub::detail::value_t<ValuesInputIteratorT>;
 
     if (num_items > 0)
     {
@@ -499,8 +499,8 @@ void Test(
     InitialValueT           initial_value,
     EqualityOpT             equality_op)
 {
-    typedef typename std::iterator_traits<KeysInputIteratorT>::value_type KeyT;
-    typedef typename std::iterator_traits<ValuesInputIteratorT>::value_type InputT;
+    using KeyT = cub::detail::value_t<KeysInputIteratorT>;
+    using InputT = cub::detail::value_t<ValuesInputIteratorT>;
 
     // Allocate device output array
     OutputT *d_values_out = NULL;
@@ -668,8 +668,8 @@ void TestPointer(
 {
     printf("\nPointer %s %s cub::DeviceScan::%s %d items, %s->%s (%d->%d bytes) , gen-mode %s\n",
         (BACKEND == CDP) ? "CDP CUB" : "CUB",
-        (Equals<InitialValueT, NullType>::VALUE) ? "Inclusive" : "Exclusive",
-        (Equals<ScanOpT, Sum>::VALUE) ? "Sum" : "Scan",
+        (std::is_same<InitialValueT, NullType>::value) ? "Inclusive" : "Exclusive",
+        (std::is_same<ScanOpT, Sum>::value) ? "Sum" : "Scan",
         num_items,
         typeid(InputT).name(), typeid(OutputT).name(), (int) sizeof(InputT), (int) sizeof(OutputT),
         (gen_mode == RANDOM) ? "RANDOM" : (gen_mode == INTEGER_SEED) ? "SEQUENTIAL" : "HOMOGENOUS");
@@ -690,8 +690,8 @@ void TestPointer(
     // type.
     // Do the same thing here:
     if (Traits<OutputT>::PRIMITIVE &&
-        Equals<ScanOpT, cub::Sum>::VALUE &&
-        !Equals<InitialValueT, NullType>::VALUE)
+        std::is_same<ScanOpT, cub::Sum>::value &&
+        !std::is_same<InitialValueT, NullType>::value)
     {
       Solve(h_keys_in, h_values_in, h_reference, num_items, cub::Sum{}, InputT{}, equality_op);
     }
@@ -742,8 +742,8 @@ void TestIterator(
 {
     printf("\nIterator %s %s cub::DeviceScan::%s %d items, %s->%s (%d->%d bytes)\n",
         (BACKEND == CDP) ? "CDP CUB" : "CUB",
-        (Equals<InitialValueT, NullType>::VALUE) ? "Inclusive" : "Exclusive",
-        (Equals<ScanOpT, Sum>::VALUE) ? "Sum" : "Scan",
+        (std::is_same<InitialValueT, NullType>::value) ? "Inclusive" : "Exclusive",
+        (std::is_same<ScanOpT, Sum>::value) ? "Sum" : "Scan",
         num_items,
         typeid(InputT).name(), typeid(OutputT).name(), (int) sizeof(InputT), (int) sizeof(OutputT));
     fflush(stdout);

--- a/test/test_device_segmented_sort.cu
+++ b/test/test_device_segmented_sort.cu
@@ -217,8 +217,8 @@ class Input
   thrust::device_vector<int> d_offsets;
   thrust::host_vector<int> h_offsets;
 
-  using MaskedValueT = typename std::
-    conditional<std::is_same<ValueT, cub::NullType>::value, KeyT, ValueT>::type;
+  using MaskedValueT = cub::detail::conditional_t<
+    std::is_same<ValueT, cub::NullType>::value, KeyT, ValueT>;
 
   bool reverse {};
   int num_items {};

--- a/test/test_device_spmv.cu
+++ b/test/test_device_spmv.cu
@@ -179,10 +179,9 @@ struct csr_matrix
 
 private:
   template <typename VecValueT>
-  using vector_t =
-    typename std::conditional<HostStorage,
-                              thrust::host_vector<VecValueT>,
-                              thrust::device_vector<VecValueT>>::type;
+  using vector_t = cub::detail::conditional_t<HostStorage,
+                                              thrust::host_vector<VecValueT>,
+                                              thrust::device_vector<VecValueT>>;
 
   vector_t<ValueT> m_values;
   vector_t<int> m_row_offsets;

--- a/test/test_util.h
+++ b/test/test_util.h
@@ -1868,7 +1868,7 @@ template <int LogicalWarpThreads,
           typename IteratorT>
 void FillStriped(IteratorT it)
 {
-  using T = typename std::iterator_traits<IteratorT>::value_type;
+  using T = CUB_NS_QUALIFIER::detail::value_t<IteratorT>;
 
   const int warps_in_block = BlockThreads / LogicalWarpThreads;
   const int items_per_warp = LogicalWarpThreads * ItemsPerThread;

--- a/test/test_warp_load.cu
+++ b/test/test_warp_load.cu
@@ -55,7 +55,7 @@ template <int                 BlockThreads,
 __global__ void kernel(InputIteratorT input,
                        int *err)
 {
-  using InputT = typename std::iterator_traits<InputIteratorT>::value_type;
+  using InputT = cub::detail::value_t<InputIteratorT>;
 
   using WarpLoadT = WarpLoad<InputT,
                              ItemsPerThread,
@@ -103,12 +103,10 @@ __global__ void kernel(int valid_items,
                        InputIteratorT input,
                        int *err)
 {
-  using InputT = typename std::iterator_traits<InputIteratorT>::value_type;
+  using InputT = cub::detail::value_t<InputIteratorT>;
 
-  using WarpLoadT = WarpLoad<InputT,
-    ItemsPerThread,
-    LoadAlgorithm,
-    WarpThreads>;
+  using WarpLoadT =
+    WarpLoad<InputT, ItemsPerThread, LoadAlgorithm, WarpThreads>;
 
   constexpr int warps_in_block = BlockThreads / WarpThreads;
   constexpr int tile_size = ItemsPerThread * WarpThreads;

--- a/test/test_warp_scan.cu
+++ b/test/test_warp_scan.cu
@@ -451,7 +451,7 @@ void Test(
     printf("Test-mode %d (%s), gen-mode %d (%s), %s warpscan, %d warp threads, %s (%d bytes) elements:\n",
         TEST_MODE, typeid(TEST_MODE).name(),
         gen_mode, typeid(gen_mode).name(),
-        (Equals<InitialValueT, NullType>::VALUE) ? "Inclusive" : "Exclusive",
+        (std::is_same<InitialValueT, NullType>::value) ? "Inclusive" : "Exclusive",
         LOGICAL_WARP_THREADS,
         typeid(T).name(),
         (int) sizeof(T));


### PR DESCRIPTION
This PR is related to [the issue](https://github.com/NVIDIA/cub/issues/341) and deprecates:

- `If` (replaced with `std::conditional`)
- `Equals` (replaced with `std::is_same`)
- `IsPointer` (replaced with `std::is_pointer`)
- `IsVolatile` (replaced with `std::is_volatile`)
- `RemoveQualifiers` (replaced with `std::remove_cv`)
- `EnableIf` (replaced with `std::enable_if`)

Some tests seem to take about 6% less time to compile with these changes.  