### PR TITLE
fix bugs for logical warp size is not a power of 2

### DIFF
--- a/cub/warp/specializations/warp_reduce_smem.cuh
+++ b/cub/warp/specializations/warp_reduce_smem.cuh
@@ -113,7 +113,6 @@ struct WarpReduceSmem
 
         lane_id(IS_ARCH_WARP ?
             LaneId() :
-            threadIdx.x % LOGICAL_WARP_THREADS),
             (LaneId()+WARP_THREADS*WarpId()) % LOGICAL_WARP_THREADS),
             
 

--- a/cub/warp/specializations/warp_reduce_smem.cuh
+++ b/cub/warp/specializations/warp_reduce_smem.cuh
@@ -56,6 +56,7 @@ struct WarpReduceSmem
 
     enum
     {
+        WARP_THREADS = CUB_WARP_THREADS(PTX_ARCH),
         /// Whether the logical warp size and the PTX warp size coincide
         IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(PTX_ARCH)),
 
@@ -113,6 +114,8 @@ struct WarpReduceSmem
         lane_id(IS_ARCH_WARP ?
             LaneId() :
             threadIdx.x % LOGICAL_WARP_THREADS),
+            (LaneId()+WARP_THREADS*WarpId()) % LOGICAL_WARP_THREADS),
+            
 
         member_mask((0xffffffff >> (32 - LOGICAL_WARP_THREADS)) << ((IS_ARCH_WARP || !IS_POW_OF_TWO ) ?
             0 : // arch-width and non-power-of-two subwarps cannot be tiled with the arch-warp

--- a/cub/warp/specializations/warp_scan_smem.cuh
+++ b/cub/warp/specializations/warp_scan_smem.cuh
@@ -56,6 +56,7 @@ struct WarpScanSmem
 
     enum
     {
+        WARP_THREADS = CUB_WARP_THREADS(PTX_ARCH),
         /// Whether the logical warp size and the PTX warp size coincide
         IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(PTX_ARCH)),
 
@@ -103,7 +104,7 @@ struct WarpScanSmem
 
         lane_id(IS_ARCH_WARP ?
             LaneId() :
-            threadIdx.x % LOGICAL_WARP_THREADS),
+            (LaneId()+WARP_THREADS*WarpId()) % LOGICAL_WARP_THREADS),
 
         member_mask((0xffffffff >> (32 - LOGICAL_WARP_THREADS)) << ((IS_ARCH_WARP || !IS_POW_OF_TWO ) ?
             0 : // arch-width and non-power-of-two subwarps cannot be tiled with the arch-warp

--- a/cub/warp/specializations/warp_scan_smem.cuh
+++ b/cub/warp/specializations/warp_scan_smem.cuh
@@ -103,7 +103,7 @@ struct WarpScanSmem
 
         lane_id(IS_ARCH_WARP ?
             LaneId() :
-            LaneId() % LOGICAL_WARP_THREADS),
+            threadIdx.x % LOGICAL_WARP_THREADS),
 
         member_mask((0xffffffff >> (32 - LOGICAL_WARP_THREADS)) << ((IS_ARCH_WARP || !IS_POW_OF_TWO ) ?
             0 : // arch-width and non-power-of-two subwarps cannot be tiled with the arch-warp


### PR DESCRIPTION
just as issue #179 said,when warp size is not a power of 2,it will give a incorrect anwer. It is because `laneId` computation is not correct when a logical warp is locatd in both physical warps when using shared memory reduction. For example, the logical warp size is 7,and there are 5 warps per block. In the fifth warp,it's thread id is 28 to 34,so it's lane id should be 0 to 6 accordingly , but former code will give a wrong laneId: 0,1,2,3,0,1,2,the correct is: 0,1,2,3,4,5,6.  Warp scan may also has the same problem