### PR TITLE
Fix alignment in dyn_smem example

### DIFF
--- a/examples/block/example_block_reduce_dyn_smem.cu
+++ b/examples/block/example_block_reduce_dyn_smem.cu
@@ -98,8 +98,14 @@ __global__ void BlockReduceKernel(
     using BlockReduceT = cub::BlockReduce<int, BLOCK_THREADS>;
     using TempStorageT = typename BlockReduceT::TempStorage;
 
+    union ShmemLayout
+    {
+      TempStorageT reduce;
+      int aggregate;
+    };
+
     // shared memory byte-array
-    extern __shared__ char smem[];
+    extern __shared__ __align__(alignof(ShmemLayout)) char smem[];
     
     // cast to lvalue reference of expected type
     auto& temp_storage = reinterpret_cast<TempStorageT&>(smem);


### PR DESCRIPTION
[The following PR](https://github.com/NVIDIA/cub/pull/348) introduces an example with unaligned memory accesses. This PR fixes this issue. 