### PR TITLE
Avoid include cycles with nvc++ -stdpar

### DIFF
--- a/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -33,7 +33,6 @@
 #pragma once
 
 #include <iterator>
-#include <algorithm>
 
 #include "../../agent/agent_scan_by_key.cuh"
 #include "../../thread/thread_operators.cuh"


### PR DESCRIPTION
An `#include <algorithm>` in cub/device/dispatch/dispatch_scan_by_key.cuh
was causing compilation failures due to an include cycle when using
`nvc++ -stdpar`.  It doesn't look like `<algorithm>` is needed at all in
this file, so I am simply removing it.