### PR TITLE
Fix CachingDeviceAllocator with debug=true

### DIFF
--- a/cub/util_allocator.cuh
+++ b/cub/util_allocator.cuh
@@ -678,12 +678,12 @@ struct CachingDeviceAllocator
             if (CubDebug(error = cudaEventDestroy(begin->ready_event))) break;
 
             // Reduce balance and erase entry
-            cached_bytes[current_device].free -= begin->bytes;
-
+            const size_t block_bytes = begin->bytes;
+            cached_bytes[current_device].free -= block_bytes;
             cached_blocks.erase(begin);
 
             if (debug) _CubLog("\tDevice %d freed %lld bytes.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
-                current_device, (long long) begin->bytes, (long long) cached_blocks.size(), (long long) cached_bytes[current_device].free, (long long) live_blocks.size(), (long long) cached_bytes[current_device].live);
+                current_device, (long long) block_bytes, (long long) cached_blocks.size(), (long long) cached_bytes[current_device].free, (long long) live_blocks.size(), (long long) cached_bytes[current_device].live);
 
         }
 


### PR DESCRIPTION
`CachingDeviceAllocator::FreeAllCached` accesses freed memory after this [commit](https://github.com/NVIDIA/cub/commit/455d317b7af23a5df3782c47d3e39550c3acc55d):

```cuda
CachedBlocks::iterator begin = cached_blocks.begin();
cached_blocks.erase(begin);
if (debug) 
{ 
  print(begin); 
}
```

This leads to an exception on windows in `test/test_allocator.cu`. This PR contains a fix for this issue. 