### PR TITLE
Increase floating point tolerance when validating results.

### DIFF
--- a/test/test_util.h
+++ b/test/test_util.h
@@ -1428,7 +1428,7 @@ int CompareResults(float* computed, float* reference, OffsetT len, bool verbose 
             float difference = std::abs(computed[i]-reference[i]);
             float fraction = difference / std::abs(reference[i]);
 
-            if (fraction > 0.0001)
+            if (fraction > 0.00015)
             {
                 if (verbose) std::cout << "INCORRECT: [" << i << "]: "
                     << "(computed) " << CoutCast(computed[i]) << " != "
@@ -1463,7 +1463,7 @@ int CompareResults(double* computed, double* reference, OffsetT len, bool verbos
             double difference = std::abs(computed[i]-reference[i]);
             double fraction = difference / std::abs(reference[i]);
 
-            if (fraction > 0.0001)
+            if (fraction > 0.00015)
             {
                 if (verbose) std::cout << "INCORRECT: [" << i << "]: "
                     << CoutCast(computed[i]) << " != "


### PR DESCRIPTION
#295 reported that the `device_reduce` and `device_scan` tests were
failing due to the accumulated fp error exceeding the current threshold
of 0.01%. They observed a relative error of slightly more, 0.0100725%.

This appears to be happening on nvc++, though I've not been able to repro
the failure on NV HPC 21.7.

They suggest an alternate method of computing the summation that provides
more accuracy, but unfortunately this approach is not suitable for testing
cases where `scan_op` is not `cub::Sum`.

Instead, let's just bump up the error threshold to 0.015%.