### PR TITLE
Add missing thrust headers after fixing header leak.

### DIFF
--- a/test/test_device_merge_sort.cu
+++ b/test/test_device_merge_sort.cu
@@ -32,24 +32,25 @@
 // Ensure printing of CUDA runtime errors to console
 #define CUB_STDERR
 
-#include <stdio.h>
-#include <limits>
-#include <typeinfo>
-#include <memory>
-
-#include <cub/util_allocator.cuh>
 #include <cub/cub.cuh>
+#include <cub/util_allocator.cuh>
 
-#include <thrust/iterator/reverse_iterator.h>
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
-#include <thrust/transform.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/iterator/reverse_iterator.h>
 #include <thrust/random.h>
 #include <thrust/sequence.h>
 #include <thrust/shuffle.h>
 #include <thrust/sort.h>
+#include <thrust/transform.h>
 
 #include "test_util.h"
+
+#include <cstdio>
+#include <limits>
+#include <memory>
+#include <typeinfo>
 
 using namespace cub;
 

--- a/test/test_device_segmented_sort.cu
+++ b/test/test_device_segmented_sort.cu
@@ -28,16 +28,19 @@
 // Ensure printing of CUDA runtime errors to console
 #define CUB_STDERR
 
-#include <fstream>
-
 #include <cub/device/device_segmented_sort.cuh>
 #include <test_util.h>
 
+#include <thrust/count.h>
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
-#include <thrust/shuffle.h>
 #include <thrust/random.h>
 #include <thrust/reduce.h>
+#include <thrust/sequence.h>
+#include <thrust/shuffle.h>
+#include <thrust/sort.h>
+
+#include <fstream>
 
 #define TEST_HALF_T \
   (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !__NVCOMPILER_CUDA__

--- a/test/test_device_three_way_partition.cu
+++ b/test/test_device_three_way_partition.cu
@@ -33,9 +33,11 @@
 
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
-#include <thrust/shuffle.h>
+#include <thrust/partition.h>
 #include <thrust/random.h>
 #include <thrust/reduce.h>
+#include <thrust/shuffle.h>
+#include <thrust/tabulate.h>
 
 using namespace cub;
 

--- a/test/test_thread_sort.cu
+++ b/test/test_thread_sort.cu
@@ -30,7 +30,9 @@
 
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
+#include <thrust/sequence.h>
 #include <thrust/shuffle.h>
+#include <thrust/sort.h>
 #include <thrust/random.h>
 
 

--- a/test/test_warp_exchange.cu
+++ b/test/test_warp_exchange.cu
@@ -30,6 +30,8 @@
 
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
+#include <thrust/reverse.h>
+#include <thrust/sequence.h>
 
 template <typename InputT,
           typename OutputT,


### PR DESCRIPTION
This PR is part of the if-target split, and adds some missing includes uncovered by NVIDIA/thrust#1572.

Also organized the includes and ran them through clang-format to sort/dedup them.