### PR TITLE
s/__NVCOMPILER_CUDA__/_NVHPC_CUDA/g

### DIFF
--- a/cub/device/dispatch/dispatch_merge_sort.cuh
+++ b/cub/device/dispatch/dispatch_merge_sort.cuh
@@ -207,7 +207,7 @@ struct DeviceMergeSortPolicy
   };
 
 // NVBug 3384810
-#if defined(__NVCOMPILER_CUDA__)
+#if defined(_NVHPC_CUDA)
   using Policy520 = Policy350;
 #else
   struct Policy520 : ChainedPolicy<520, Policy520, Policy350>

--- a/cub/util_arch.cuh
+++ b/cub/util_arch.cuh
@@ -41,7 +41,7 @@ CUB_NAMESPACE_BEGIN
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
 
-#if ((__CUDACC_VER_MAJOR__ >= 9) || defined(__NVCOMPILER_CUDA__) ||            \
+#if ((__CUDACC_VER_MAJOR__ >= 9) || defined(_NVHPC_CUDA) ||            \
      CUDA_VERSION >= 9000) &&                                                  \
   !defined(CUB_USE_COOPERATIVE_GROUPS)
 #define CUB_USE_COOPERATIVE_GROUPS
@@ -50,7 +50,7 @@ CUB_NAMESPACE_BEGIN
 /// In device code, CUB_PTX_ARCH expands to the PTX version for which we are
 /// compiling. In host code, CUB_PTX_ARCH's value is implementation defined.
 #ifndef CUB_PTX_ARCH
-    #if defined(__NVCOMPILER_CUDA__)
+    #if defined(_NVHPC_CUDA)
         // __NVCOMPILER_CUDA_ARCH__ is the target PTX version, and is defined
         // when compiling both host code and device code. Currently, only one
         // PTX version can be targeted.
@@ -63,7 +63,7 @@ CUB_NAMESPACE_BEGIN
 #endif
 
 #ifndef CUB_IS_DEVICE_CODE
-    #if defined(__NVCOMPILER_CUDA__)
+    #if defined(_NVHPC_CUDA)
         #define CUB_IS_DEVICE_CODE __builtin_is_device_code()
         #define CUB_IS_HOST_CODE (!__builtin_is_device_code())
         #define CUB_INCLUDE_DEVICE_CODE 1

--- a/cub/util_compiler.cuh
+++ b/cub/util_compiler.cuh
@@ -63,7 +63,7 @@
 #endif // CUB_HOST_COMPILER
 
 // figure out which device compiler we're using
-#if defined(__CUDACC__) || defined(__NVCOMPILER_CUDA__)
+#if defined(__CUDACC__) || defined(_NVHPC_CUDA)
 #  define CUB_DEVICE_COMPILER CUB_DEVICE_COMPILER_NVCC
 #elif CUB_HOST_COMPILER == CUB_HOST_COMPILER_MSVC
 #  define CUB_DEVICE_COMPILER CUB_DEVICE_COMPILER_MSVC

--- a/cub/util_debug.cuh
+++ b/cub/util_debug.cuh
@@ -114,7 +114,7 @@ __host__ __device__ __forceinline__ cudaError_t Debug(
  * \brief Log macro for printf statements.
  */
 #if !defined(_CubLog)
-    #if defined(__NVCOMPILER_CUDA__)
+    #if defined(_NVHPC_CUDA)
         #define _CubLog(format, ...) (__builtin_is_device_code() \
             ? printf("[block (%d,%d,%d), thread (%d,%d,%d)]: " format, \
                      blockIdx.z, blockIdx.y, blockIdx.x, \

--- a/cub/util_type.cuh
+++ b/cub/util_type.cuh
@@ -37,10 +37,10 @@
 #include <limits>
 #include <cfloat>
 
-#if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !__NVCOMPILER_CUDA__
+#if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !_NVHPC_CUDA
     #include <cuda_fp16.h>
 #endif
-#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !__NVCOMPILER_CUDA__
+#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !_NVHPC_CUDA
     #include <cuda_bf16.h>
 #endif
 
@@ -1143,7 +1143,7 @@ struct FpLimits<double>
 };
 
 
-#if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !__NVCOMPILER_CUDA__
+#if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !_NVHPC_CUDA
 template <>
 struct FpLimits<__half>
 {
@@ -1159,7 +1159,7 @@ struct FpLimits<__half>
 };
 #endif
 
-#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !__NVCOMPILER_CUDA__
+#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !_NVHPC_CUDA
 template <>
 struct FpLimits<__nv_bfloat16>
 {
@@ -1238,10 +1238,10 @@ template <> struct NumericTraits<unsigned long long> :  BaseTraits<UNSIGNED_INTE
 
 template <> struct NumericTraits<float> :               BaseTraits<FLOATING_POINT, true, false, unsigned int, float> {};
 template <> struct NumericTraits<double> :              BaseTraits<FLOATING_POINT, true, false, unsigned long long, double> {};
-#if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !__NVCOMPILER_CUDA__
+#if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !_NVHPC_CUDA
     template <> struct NumericTraits<__half> :          BaseTraits<FLOATING_POINT, true, false, unsigned short, __half> {};
 #endif
-#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !__NVCOMPILER_CUDA__
+#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !_NVHPC_CUDA
     template <> struct NumericTraits<__nv_bfloat16> :   BaseTraits<FLOATING_POINT, true, false, unsigned short, __nv_bfloat16> {};
 #endif
 

--- a/test/test_device_radix_sort.cu
+++ b/test/test_device_radix_sort.cu
@@ -39,11 +39,11 @@
 #include <typeinfo>
 #include <vector>
 
-#if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !__NVCOMPILER_CUDA__
+#if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !_NVHPC_CUDA
     #include <cuda_fp16.h>
 #endif
 
-#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !__NVCOMPILER_CUDA__
+#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !_NVHPC_CUDA
     #include <cuda_bf16.h>
 #endif
 
@@ -880,14 +880,14 @@ struct UnwrapHalfAndBfloat16 {
     using Type = T;
 };
 
-#if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !__NVCOMPILER_CUDA__
+#if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !_NVHPC_CUDA
 template <>
 struct UnwrapHalfAndBfloat16<half_t> {
     using Type = __half;
 };
 #endif
 
-#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !__NVCOMPILER_CUDA__
+#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !_NVHPC_CUDA
 template <>
 struct UnwrapHalfAndBfloat16<bfloat16_t> {
     using Type = __nv_bfloat16;
@@ -1528,10 +1528,11 @@ int main(int argc, char** argv)
 
     printf("\n-------------------------------\n");
 
-#if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !__NVCOMPILER_CUDA__
+#if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !_NVHPC_CUDA
     Test<CUB,           half_t,             NullType, IS_DESCENDING>(num_items, 1, RANDOM, entropy_reduction, 0, bits);
 #endif
-#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !__NVCOMPILER_CUDA__
+
+#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !_NVHPC_CUDA
 #if !defined(__ICC)
     // Fails with `-0 != 0` with ICC for unknown reasons. See #333.
     Test<CUB,           bfloat16_t,         NullType, IS_DESCENDING>(num_items, 1, RANDOM, entropy_reduction, 0, bits);
@@ -1593,10 +1594,11 @@ int main(int argc, char** argv)
         TestGen<long long>            (num_items, num_segments);
         TestGen<unsigned long long>   (num_items, num_segments);
 
-#if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !__NVCOMPILER_CUDA__
+#if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !_NVHPC_CUDA
         TestGen<half_t>               (num_items, num_segments);
 #endif
-#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !__NVCOMPILER_CUDA__
+
+#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !_NVHPC_CUDA
 #if !defined(__ICC)
         // Fails with `-0 != 0` with ICC for unknown reasons. See #333.
         TestGen<bfloat16_t>           (num_items, num_segments);

--- a/test/test_device_segmented_sort.cu
+++ b/test/test_device_segmented_sort.cu
@@ -40,10 +40,10 @@
 #include <thrust/reduce.h>
 
 #define TEST_HALF_T \
-  (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !__NVCOMPILER_CUDA__
+  (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !_NVHPC_CUDA
 
 #define TEST_BF_T \
-  (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !__NVCOMPILER_CUDA__
+  (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !_NVHPC_CUDA
 
 #if TEST_HALF_T
 #include <cuda_fp16.h>


### PR DESCRIPTION
This is the preferred macro to check for nvc++.