### PR TITLE
Initialize padding member to silence warning.

### DIFF
--- a/cub/iterator/discard_output_iterator.cuh
+++ b/cub/iterator/discard_output_iterator.cuh
@@ -87,7 +87,7 @@ private:
 
 #if defined(_WIN32) || !defined(_WIN64)
     // Workaround for win32 parameter-passing bug (ulonglong2 argmin DeviceReduce)
-    OffsetT pad[CUB_MAX(1, (16 / sizeof(OffsetT) - 1))];
+    OffsetT pad[CUB_MAX(1, (16 / sizeof(OffsetT) - 1))] = {};
 #endif
 
 public:


### PR DESCRIPTION
Fixes #419 and gpuCI gcc10 builds.