### PR TITLE
Fix segfault in device radix sort tests

### DIFF
--- a/test/test_device_radix_sort.cu
+++ b/test/test_device_radix_sort.cu
@@ -1242,9 +1242,19 @@ void TestSegments(
     }
 
     // Test single segment
-    if (num_items < 128 * 1000 || pre_sorted) {
-        // Right now we assign a single thread block to each segment, so lets keep it to under 128K items per segment
-        TestSegmentIterators(h_keys, num_items, 1, pre_sorted, h_segment_offsets, d_segment_offsets);
+    if (num_items > 0)
+    {
+      if (num_items < 128 * 1000 || pre_sorted)
+      {
+        // Right now we assign a single thread block to each segment, so lets
+        // keep it to under 128K items per segment
+        TestSegmentIterators(h_keys,
+                             num_items,
+                             1,
+                             pre_sorted,
+                             h_segment_offsets,
+                             d_segment_offsets);
+      }
     }
 
     if (h_segment_offsets) delete[] h_segment_offsets;


### PR DESCRIPTION
There was a case where we were testing `num_items = 0 && num_segments = 1`. The radix sort tests don't support this, which leads to out of bounds accesses in multiple places. Somehow this issue doesn't show itself on Linux. All tests of device radix sort were failing on Windows in a racy way. 