### PR TITLE
Add missing <iterator> headers.

### DIFF
--- a/cub/device/dispatch/dispatch_adjacent_difference.cuh
+++ b/cub/device/dispatch/dispatch_adjacent_difference.cuh
@@ -27,15 +27,16 @@
 
 #pragma once
 
-#include "../../config.cuh"
-#include "../../util_math.cuh"
-#include "../../util_device.cuh"
-#include "../../util_namespace.cuh"
-#include "../../detail/type_traits.cuh"
-#include "../../agent/agent_adjacent_difference.cuh"
+#include <cub/agent/agent_adjacent_difference.cuh>
+#include <cub/config.cuh>
+#include <cub/detail/type_traits.cuh>
+#include <cub/util_device.cuh>
+#include <cub/util_math.cuh>
+#include <cub/util_namespace.cuh>
 
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 
+#include <iterator>
 
 CUB_NAMESPACE_BEGIN
 

--- a/cub/device/dispatch/dispatch_unique_by_key.cuh
+++ b/cub/device/dispatch/dispatch_unique_by_key.cuh
@@ -31,11 +31,12 @@
  * cub::DeviceSelect::UniqueByKey provides device-wide, parallel operations for selecting unique items by key from sequences of data items residing within device-accessible memory.
  */
 
-#include "../../agent/agent_unique_by_key.cuh"
-#include "../../util_math.cuh"
-#include "../../util_macro.cuh"
+#include <cub/agent/agent_unique_by_key.cuh>
+#include <cub/device/dispatch/dispatch_scan.cuh>
+#include <cub/util_macro.cuh>
+#include <cub/util_math.cuh>
 
-#include "dispatch_scan.cuh"
+#include <iterator>
 
 CUB_NAMESPACE_BEGIN
 

--- a/cub/util_type.cuh
+++ b/cub/util_type.cuh
@@ -35,6 +35,7 @@
 
 #include <cfloat>
 #include <iostream>
+#include <iterator>
 #include <limits>
 #include <type_traits>
 


### PR DESCRIPTION
Fixes #435.

Will backport to 1.16.X and tag a new RC once merged.