### PR TITLE
Add libcu++ dependency; initial round of `NV_IF_TARGET` ports.

### DIFF
--- a/cub/agent/agent_histogram.cuh
+++ b/cub/agent/agent_histogram.cuh
@@ -562,15 +562,10 @@ struct AgentHistogram
             is_valid[PIXEL] = IS_FULL_TILE || (((threadIdx.x * PIXELS_PER_THREAD + PIXEL) * NUM_CHANNELS) < valid_samples);
 
         // Accumulate samples
-#if CUB_PTX_ARCH >= 120
         if (prefer_smem)
             AccumulateSmemPixels(samples, is_valid);
         else
             AccumulateGmemPixels(samples, is_valid);
-#else
-        AccumulateGmemPixels(samples, is_valid);
-#endif
-
     }
 
 

--- a/cub/agent/agent_histogram.cuh
+++ b/cub/agent/agent_histogram.cuh
@@ -103,7 +103,7 @@ template <
     typename    PrivatizedDecodeOpT,            ///< The transform operator type for determining privatized counter indices from samples, one for each channel
     typename    OutputDecodeOpT,                ///< The transform operator type for determining output bin-ids from privatized counter indices, one for each channel
     typename    OffsetT,                        ///< Signed integer type for global offsets
-    int         PTX_ARCH = CUB_PTX_ARCH>        ///< PTX compute capability
+    int         LEGACY_PTX_ARCH = 0>            ///< PTX compute capability (unused)
 struct AgentHistogram
 {
     //---------------------------------------------------------------------

--- a/cub/agent/agent_rle.cuh
+++ b/cub/agent/agent_rle.cuh
@@ -117,7 +117,7 @@ struct AgentRle
     // Constants
     enum
     {
-        WARP_THREADS            = CUB_WARP_THREADS(PTX_ARCH),
+        WARP_THREADS            = CUB_WARP_THREADS(0),
         BLOCK_THREADS           = AgentRlePolicyT::BLOCK_THREADS,
         ITEMS_PER_THREAD        = AgentRlePolicyT::ITEMS_PER_THREAD,
         WARP_ITEMS              = WARP_THREADS * ITEMS_PER_THREAD,

--- a/cub/agent/agent_segment_fixup.cuh
+++ b/cub/agent/agent_segment_fixup.cuh
@@ -111,8 +111,7 @@ struct AgentSegmentFixup
       TILE_ITEMS       = BLOCK_THREADS * ITEMS_PER_THREAD,
 
       // Whether or not do fixup using RLE + global atomics
-      USE_ATOMIC_FIXUP = (CUB_PTX_ARCH >= 350) &&
-                         (std::is_same<ValueT, float>::value ||
+      USE_ATOMIC_FIXUP = (std::is_same<ValueT, float>::value ||
                           std::is_same<ValueT, int>::value ||
                           std::is_same<ValueT, unsigned int>::value ||
                           std::is_same<ValueT, unsigned long long>::value),

--- a/cub/agent/agent_spmv_orig.cuh
+++ b/cub/agent/agent_spmv_orig.cuh
@@ -115,7 +115,7 @@ template <
     typename    OffsetT,                    ///< Signed integer type for sequence offsets
     bool        HAS_ALPHA,                  ///< Whether the input parameter \p alpha is 1
     bool        HAS_BETA,                   ///< Whether the input parameter \p beta is 0
-    int         PTX_ARCH = CUB_PTX_ARCH>    ///< PTX compute capability
+    int         LEGACY_PTX_ARCH = 0>        ///< PTX compute capability (unused)
 struct AgentSpmv
 {
     //---------------------------------------------------------------------

--- a/cub/agent/agent_sub_warp_merge_sort.cuh
+++ b/cub/agent/agent_sub_warp_merge_sort.cuh
@@ -33,6 +33,8 @@
 #include <cub/warp/warp_merge_sort.cuh>
 #include <cub/warp/warp_store.cuh>
 
+#include <nv/target>
+
 #include <thrust/system/cuda/detail/core/util.h>
 
 
@@ -109,6 +111,23 @@ class AgentSubWarpSort
     template <typename T>
     __device__ bool operator()(T lhs, T rhs)
     {
+      return this->impl(lhs, rhs);
+    }
+
+#if defined(__CUDA_FP16_TYPES_EXIST__)
+    __device__ bool operator()(__half lhs, __half rhs)
+    {
+      // Need to explicitly cast to float for SM <= 52.
+      NV_IF_TARGET(NV_PROVIDES_SM_53,
+                   (return this->impl(lhs, rhs);),
+                   (return this->impl(__half2float(lhs), __half2float(rhs));));
+    }
+#endif
+
+  private:
+    template <typename T>
+    __device__ bool impl(T lhs, T rhs)
+    {
       if (IS_DESCENDING)
       {
         return lhs > rhs;
@@ -118,19 +137,15 @@ class AgentSubWarpSort
         return lhs < rhs;
       }
     }
-
-#if defined(__CUDA_FP16_TYPES_EXIST__) && (CUB_PTX_ARCH < 530)
-    __device__ bool operator()(__half lhs, __half rhs)
-    {
-      return (*this)(__half2float(lhs), __half2float(rhs));
-    }
-#endif
   };
 
-#if defined(__CUDA_FP16_TYPES_EXIST__) && (CUB_PTX_ARCH < 530)
+#if defined(__CUDA_FP16_TYPES_EXIST__)
   __device__ static bool equal(__half lhs, __half rhs)
   {
-    return __half2float(lhs) == __half2float(rhs);
+    // Need to explicitly cast to float for SM <= 52.
+    NV_IF_TARGET(NV_PROVIDES_SM_53,
+                 (return lhs == rhs;),
+                 (return __half2float(lhs) == __half2float(rhs);));
   }
 #endif
 

--- a/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/agent/single_pass_scan_operators.cuh
@@ -666,11 +666,11 @@ template <
     typename    T,
     typename    ScanOpT,
     typename    ScanTileStateT,
-    int         PTX_ARCH = CUB_PTX_ARCH>
+    int         LEGACY_PTX_ARCH = 0>
 struct TilePrefixCallbackOp
 {
     // Parameterized warp reduce
-    typedef WarpReduce<T, CUB_PTX_WARP_THREADS, PTX_ARCH> WarpReduceT;
+    typedef WarpReduce<T, CUB_PTX_WARP_THREADS> WarpReduceT;
 
     // Temporary storage type
     struct _TempStorage

--- a/cub/block/block_adjacent_difference.cuh
+++ b/cub/block/block_adjacent_difference.cuh
@@ -41,7 +41,6 @@
 
 CUB_NAMESPACE_BEGIN
 
-
 /**
  * @brief BlockAdjacentDifference provides
  *        [<em>collective</em>](index.html#sec0) methods for computing the
@@ -125,9 +124,9 @@ CUB_NAMESPACE_BEGIN
  */
 template <typename T,
           int BLOCK_DIM_X,
-          int BLOCK_DIM_Y = 1,
-          int BLOCK_DIM_Z = 1,
-          int PTX_ARCH    = CUB_PTX_ARCH>
+          int BLOCK_DIM_Y     = 1,
+          int BLOCK_DIM_Z     = 1,
+          int LEGACY_PTX_ARCH = 0>
 class BlockAdjacentDifference
 {
 private:

--- a/cub/block/block_discontinuity.cuh
+++ b/cub/block/block_discontinuity.cuh
@@ -47,7 +47,7 @@ CUB_NAMESPACE_BEGIN
  * \tparam BLOCK_DIM_X      The thread block length in threads along the X dimension
  * \tparam BLOCK_DIM_Y      <b>[optional]</b> The thread block length in threads along the Y dimension (default: 1)
  * \tparam BLOCK_DIM_Z      <b>[optional]</b> The thread block length in threads along the Z dimension (default: 1)
- * \tparam PTX_ARCH         <b>[optional]</b> \ptxversion
+ * \tparam LEGACY_PTX_ARCH  <b>[optional]</b> Unused.
  *
  * \par Overview
  * - A set of "head flags" (or "tail flags") is often used to indicate corresponding items
@@ -107,7 +107,7 @@ template <
     int         BLOCK_DIM_X,
     int         BLOCK_DIM_Y     = 1,
     int         BLOCK_DIM_Z     = 1,
-    int         PTX_ARCH        = CUB_PTX_ARCH>
+    int         LEGACY_PTX_ARCH = 0>
 class BlockDiscontinuity
 {
 private:

--- a/cub/block/block_exchange.cuh
+++ b/cub/block/block_exchange.cuh
@@ -50,7 +50,7 @@ CUB_NAMESPACE_BEGIN
  * \tparam WARP_TIME_SLICING    <b>[optional]</b> When \p true, only use enough shared memory for a single warp's worth of tile data, time-slicing the block-wide exchange over multiple synchronized rounds.  Yields a smaller memory footprint at the expense of decreased parallelism.  (Default: false)
  * \tparam BLOCK_DIM_Y          <b>[optional]</b> The thread block length in threads along the Y dimension (default: 1)
  * \tparam BLOCK_DIM_Z          <b>[optional]</b> The thread block length in threads along the Z dimension (default: 1)
- * \tparam PTX_ARCH             <b>[optional]</b> \ptxversion
+ * \tparam LEGACY_PTX_ARCH      <b>[optional]</b> Unused.
  *
  * \par Overview
  * - It is commonplace for blocks of threads to rearrange data items between
@@ -114,7 +114,7 @@ template <
     bool        WARP_TIME_SLICING   = false,
     int         BLOCK_DIM_Y         = 1,
     int         BLOCK_DIM_Z         = 1,
-    int         PTX_ARCH            = CUB_PTX_ARCH>
+    int         LEGACY_PTX_ARCH     = 0>
 class BlockExchange
 {
 private:
@@ -129,11 +129,11 @@ private:
         /// The thread block size in threads
         BLOCK_THREADS               = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
 
-        LOG_WARP_THREADS            = CUB_LOG_WARP_THREADS(PTX_ARCH),
+        LOG_WARP_THREADS            = CUB_LOG_WARP_THREADS(0),
         WARP_THREADS                = 1 << LOG_WARP_THREADS,
         WARPS                       = (BLOCK_THREADS + WARP_THREADS - 1) / WARP_THREADS,
 
-        LOG_SMEM_BANKS              = CUB_LOG_SMEM_BANKS(PTX_ARCH),
+        LOG_SMEM_BANKS              = CUB_LOG_SMEM_BANKS(0),
         SMEM_BANKS                  = 1 << LOG_SMEM_BANKS,
 
         TILE_ITEMS                  = BLOCK_THREADS * ITEMS_PER_THREAD,
@@ -1126,4 +1126,3 @@ public:
 
 
 CUB_NAMESPACE_END
-

--- a/cub/block/block_histogram.cuh
+++ b/cub/block/block_histogram.cuh
@@ -176,20 +176,9 @@ private:
         BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
     };
 
-    /**
-     * Ensure the template parameterization meets the requirements of the
-     * targeted device architecture.  BLOCK_HISTO_ATOMIC can only be used
-     * on version SM120 or later.  Otherwise BLOCK_HISTO_SORT is used
-     * regardless.
-     */
-    static const BlockHistogramAlgorithm SAFE_ALGORITHM =
-        ((ALGORITHM == BLOCK_HISTO_ATOMIC) && (PTX_ARCH < 120)) ?
-            BLOCK_HISTO_SORT :
-            ALGORITHM;
-
     /// Internal specialization.
     using InternalBlockHistogram =
-      cub::detail::conditional_t<SAFE_ALGORITHM == BLOCK_HISTO_SORT,
+      cub::detail::conditional_t<ALGORITHM == BLOCK_HISTO_SORT,
                                  BlockHistogramSort<T,
                                                     BLOCK_DIM_X,
                                                     ITEMS_PER_THREAD,

--- a/cub/block/block_histogram.cuh
+++ b/cub/block/block_histogram.cuh
@@ -94,7 +94,7 @@ enum BlockHistogramAlgorithm
  * \tparam ALGORITHM            <b>[optional]</b> cub::BlockHistogramAlgorithm enumerator specifying the underlying algorithm to use (default: cub::BLOCK_HISTO_SORT)
  * \tparam BLOCK_DIM_Y          <b>[optional]</b> The thread block length in threads along the Y dimension (default: 1)
  * \tparam BLOCK_DIM_Z          <b>[optional]</b> The thread block length in threads along the Z dimension (default: 1)
- * \tparam PTX_ARCH             <b>[optional]</b> \ptxversion
+ * \tparam LEGACY_PTX_ARCH      <b>[optional]</b> Unused.
  *
  * \par Overview
  * - A <a href="http://en.wikipedia.org/wiki/Histogram"><em>histogram</em></a>
@@ -160,7 +160,7 @@ template <
     BlockHistogramAlgorithm ALGORITHM           = BLOCK_HISTO_SORT,
     int                     BLOCK_DIM_Y         = 1,
     int                     BLOCK_DIM_Z         = 1,
-    int                     PTX_ARCH            = CUB_PTX_ARCH>
+    int                     LEGACY_PTX_ARCH     = 0>
 class BlockHistogram
 {
 private:
@@ -184,8 +184,7 @@ private:
                                                     ITEMS_PER_THREAD,
                                                     BINS,
                                                     BLOCK_DIM_Y,
-                                                    BLOCK_DIM_Z,
-                                                    PTX_ARCH>,
+                                                    BLOCK_DIM_Z>,
                                  BlockHistogramAtomic<BINS>>;
 
     /// Shared memory storage layout type for BlockHistogram

--- a/cub/block/block_load.cuh
+++ b/cub/block/block_load.cuh
@@ -568,7 +568,7 @@ enum BlockLoadAlgorithm
  * \tparam WARP_TIME_SLICING    <b>[optional]</b> Whether or not only one warp's worth of shared memory should be allocated and time-sliced among block-warps during any load-related data transpositions (versus each warp having its own storage). (default: false)
  * \tparam BLOCK_DIM_Y          <b>[optional]</b> The thread block length in threads along the Y dimension (default: 1)
  * \tparam BLOCK_DIM_Z          <b>[optional]</b> The thread block length in threads along the Z dimension (default: 1)
- * \tparam PTX_ARCH             <b>[optional]</b> \ptxversion
+ * \tparam LEGACY_PTX_ARCH      <b>[optional]</b> Unused.
  *
  * \par Overview
  * - The BlockLoad class provides a single data movement abstraction that can be specialized
@@ -638,7 +638,7 @@ template <
     BlockLoadAlgorithm  ALGORITHM           = BLOCK_LOAD_DIRECT,
     int                 BLOCK_DIM_Y         = 1,
     int                 BLOCK_DIM_Z         = 1,
-    int                 PTX_ARCH            = CUB_PTX_ARCH>
+    int                 LEGACY_PTX_ARCH     = 0>
 class BlockLoad
 {
 private:
@@ -860,7 +860,7 @@ private:
     struct LoadInternal<BLOCK_LOAD_TRANSPOSE, DUMMY>
     {
         // BlockExchange utility type for keys
-        typedef BlockExchange<InputT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z, PTX_ARCH> BlockExchange;
+        typedef BlockExchange<InputT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchange;
 
         /// Shared memory storage layout type
         struct _TempStorage : BlockExchange::TempStorage
@@ -928,14 +928,14 @@ private:
     {
         enum
         {
-            WARP_THREADS = CUB_WARP_THREADS(PTX_ARCH)
+            WARP_THREADS = CUB_WARP_THREADS(0)
         };
 
         // Assert BLOCK_THREADS must be a multiple of WARP_THREADS
         CUB_STATIC_ASSERT((int(BLOCK_THREADS) % int(WARP_THREADS) == 0), "BLOCK_THREADS must be a multiple of WARP_THREADS");
 
         // BlockExchange utility type for keys
-        typedef BlockExchange<InputT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z, PTX_ARCH> BlockExchange;
+        typedef BlockExchange<InputT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchange;
 
         /// Shared memory storage layout type
         struct _TempStorage : BlockExchange::TempStorage
@@ -1003,14 +1003,14 @@ private:
     {
         enum
         {
-            WARP_THREADS = CUB_WARP_THREADS(PTX_ARCH)
+            WARP_THREADS = CUB_WARP_THREADS(0)
         };
 
         // Assert BLOCK_THREADS must be a multiple of WARP_THREADS
         CUB_STATIC_ASSERT((int(BLOCK_THREADS) % int(WARP_THREADS) == 0), "BLOCK_THREADS must be a multiple of WARP_THREADS");
 
         // BlockExchange utility type for keys
-        typedef BlockExchange<InputT, BLOCK_DIM_X, ITEMS_PER_THREAD, true, BLOCK_DIM_Y, BLOCK_DIM_Z, PTX_ARCH> BlockExchange;
+        typedef BlockExchange<InputT, BLOCK_DIM_X, ITEMS_PER_THREAD, true, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchange;
 
         /// Shared memory storage layout type
         struct _TempStorage : BlockExchange::TempStorage

--- a/cub/block/block_radix_rank.cuh
+++ b/cub/block/block_radix_rank.cuh
@@ -138,7 +138,7 @@ template <
     int                     BLOCK_DIM_X,
     int                     RADIX_BITS,
     bool                    IS_DESCENDING,
-    bool                    MEMOIZE_OUTER_SCAN      = (CUB_PTX_ARCH >= 350) ? true : false,
+    bool                    MEMOIZE_OUTER_SCAN      = true,
     BlockScanAlgorithm      INNER_SCAN_ALGORITHM    = BLOCK_SCAN_WARP_SCANS,
     cudaSharedMemConfig     SMEM_CONFIG             = cudaSharedMemBankSizeFourByte,
     int                     BLOCK_DIM_Y             = 1,

--- a/cub/block/block_radix_rank.cuh
+++ b/cub/block/block_radix_rank.cuh
@@ -104,7 +104,7 @@ struct BlockRadixRankEmptyCallback
  * \tparam SMEM_CONFIG          <b>[optional]</b> Shared memory bank mode (default: \p cudaSharedMemBankSizeFourByte)
  * \tparam BLOCK_DIM_Y          <b>[optional]</b> The thread block length in threads along the Y dimension (default: 1)
  * \tparam BLOCK_DIM_Z          <b>[optional]</b> The thread block length in threads along the Z dimension (default: 1)
- * \tparam PTX_ARCH             <b>[optional]</b> \ptxversion
+ * \tparam LEGACY_PTX_ARCH      <b>[optional]</b> Unused.
  *
  * \par Overview
  * Blah...
@@ -143,7 +143,7 @@ template <
     cudaSharedMemConfig     SMEM_CONFIG             = cudaSharedMemBankSizeFourByte,
     int                     BLOCK_DIM_Y             = 1,
     int                     BLOCK_DIM_Z             = 1,
-    int                     PTX_ARCH                = CUB_PTX_ARCH>
+    int                     LEGACY_PTX_ARCH         = 0>
 class BlockRadixRank
 {
 private:
@@ -168,7 +168,7 @@ private:
 
         RADIX_DIGITS                = 1 << RADIX_BITS,
 
-        LOG_WARP_THREADS            = CUB_LOG_WARP_THREADS(PTX_ARCH),
+        LOG_WARP_THREADS            = CUB_LOG_WARP_THREADS(0),
         WARP_THREADS                = 1 << LOG_WARP_THREADS,
         WARPS                       = (BLOCK_THREADS + WARP_THREADS - 1) / WARP_THREADS,
 
@@ -203,8 +203,7 @@ private:
             BLOCK_DIM_X,
             INNER_SCAN_ALGORITHM,
             BLOCK_DIM_Y,
-            BLOCK_DIM_Z,
-            PTX_ARCH>
+            BLOCK_DIM_Z>
         BlockScan;
 
 
@@ -508,7 +507,7 @@ template <
     BlockScanAlgorithm      INNER_SCAN_ALGORITHM    = BLOCK_SCAN_WARP_SCANS,
     int                     BLOCK_DIM_Y             = 1,
     int                     BLOCK_DIM_Z             = 1,
-    int                     PTX_ARCH                = CUB_PTX_ARCH>
+    int                     LEGACY_PTX_ARCH         = 0>
 class BlockRadixRankMatch
 {
 private:
@@ -527,7 +526,7 @@ private:
 
         RADIX_DIGITS                = 1 << RADIX_BITS,
 
-        LOG_WARP_THREADS            = CUB_LOG_WARP_THREADS(PTX_ARCH),
+        LOG_WARP_THREADS            = CUB_LOG_WARP_THREADS(0),
         WARP_THREADS                = 1 << LOG_WARP_THREADS,
         WARPS                       = (BLOCK_THREADS + WARP_THREADS - 1) / WARP_THREADS,
 
@@ -558,8 +557,7 @@ private:
             BLOCK_THREADS,
             INNER_SCAN_ALGORITHM,
             BLOCK_DIM_Y,
-            BLOCK_DIM_Z,
-            PTX_ARCH>
+            BLOCK_DIM_Z>
         BlockScanT;
 
 

--- a/cub/block/block_radix_sort.cuh
+++ b/cub/block/block_radix_sort.cuh
@@ -57,7 +57,7 @@ CUB_NAMESPACE_BEGIN
  * \tparam SMEM_CONFIG          <b>[optional]</b> Shared memory bank mode (default: \p cudaSharedMemBankSizeFourByte)
  * \tparam BLOCK_DIM_Y          <b>[optional]</b> The thread block length in threads along the Y dimension (default: 1)
  * \tparam BLOCK_DIM_Z          <b>[optional]</b> The thread block length in threads along the Z dimension (default: 1)
- * \tparam PTX_ARCH             <b>[optional]</b> \ptxversion
+ * \tparam LEGACY_PTX_ARCH      <b>[optional]</b> Unused.
  *
  * \par Overview
  * The [<em>radix sorting method</em>](http://en.wikipedia.org/wiki/Radix_sort) arranges
@@ -170,7 +170,7 @@ template <
     cudaSharedMemConfig     SMEM_CONFIG             = cudaSharedMemBankSizeFourByte,
     int                     BLOCK_DIM_Y             = 1,
     int                     BLOCK_DIM_Z             = 1,
-    int                     PTX_ARCH                = CUB_PTX_ARCH>
+    int                     LEGACY_PTX_ARCH         = 0>
 class BlockRadixSort
 {
 private:
@@ -201,8 +201,7 @@ private:
             INNER_SCAN_ALGORITHM,
             SMEM_CONFIG,
             BLOCK_DIM_Y,
-            BLOCK_DIM_Z,
-            PTX_ARCH>
+            BLOCK_DIM_Z>
         AscendingBlockRadixRank;
 
     /// Descending BlockRadixRank utility type
@@ -214,18 +213,17 @@ private:
             INNER_SCAN_ALGORITHM,
             SMEM_CONFIG,
             BLOCK_DIM_Y,
-            BLOCK_DIM_Z,
-            PTX_ARCH>
+            BLOCK_DIM_Z>
         DescendingBlockRadixRank;
 
     /// Digit extractor type
     typedef BFEDigitExtractor<KeyT> DigitExtractorT;
 
     /// BlockExchange utility type for keys
-    typedef BlockExchange<KeyT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z, PTX_ARCH> BlockExchangeKeys;
+    typedef BlockExchange<KeyT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchangeKeys;
 
     /// BlockExchange utility type for values
-    typedef BlockExchange<ValueT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z, PTX_ARCH> BlockExchangeValues;
+    typedef BlockExchange<ValueT, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchangeValues;
 
     /// Shared memory storage layout type
     union _TempStorage

--- a/cub/block/block_radix_sort.cuh
+++ b/cub/block/block_radix_sort.cuh
@@ -165,7 +165,7 @@ template <
     int                     ITEMS_PER_THREAD,
     typename                ValueT                   = NullType,
     int                     RADIX_BITS              = 4,
-    bool                    MEMOIZE_OUTER_SCAN      = (CUB_PTX_ARCH >= 350) ? true : false,
+    bool                    MEMOIZE_OUTER_SCAN      = true,
     BlockScanAlgorithm      INNER_SCAN_ALGORITHM    = BLOCK_SCAN_WARP_SCANS,
     cudaSharedMemConfig     SMEM_CONFIG             = cudaSharedMemBankSizeFourByte,
     int                     BLOCK_DIM_Y             = 1,

--- a/cub/block/block_raking_layout.cuh
+++ b/cub/block/block_raking_layout.cuh
@@ -52,12 +52,12 @@ CUB_NAMESPACE_BEGIN
  *
  * \tparam T                        The data type to be exchanged.
  * \tparam BLOCK_THREADS            The thread block size in threads.
- * \tparam PTX_ARCH                 <b>[optional]</b> \ptxversion
+ * \tparam LEGACY_PTX_ARCH          <b>[optional]</b> Unused.
  */
 template <
     typename    T,
     int         BLOCK_THREADS,
-    int         PTX_ARCH = CUB_PTX_ARCH>
+    int         LEGACY_PTX_ARCH = 0>
 struct BlockRakingLayout
 {
     //---------------------------------------------------------------------
@@ -70,7 +70,7 @@ struct BlockRakingLayout
         SHARED_ELEMENTS = BLOCK_THREADS,
 
         /// Maximum number of warp-synchronous raking threads
-        MAX_RAKING_THREADS = CUB_MIN(BLOCK_THREADS, CUB_WARP_THREADS(PTX_ARCH)),
+        MAX_RAKING_THREADS = CUB_MIN(BLOCK_THREADS, CUB_WARP_THREADS(0)),
 
         /// Number of raking elements per warp-synchronous raking thread (rounded up)
         SEGMENT_LENGTH = (SHARED_ELEMENTS + MAX_RAKING_THREADS - 1) / MAX_RAKING_THREADS,
@@ -79,11 +79,11 @@ struct BlockRakingLayout
         RAKING_THREADS = (SHARED_ELEMENTS + SEGMENT_LENGTH - 1) / SEGMENT_LENGTH,
 
         /// Whether we will have bank conflicts (technically we should find out if the GCD is > 1)
-        HAS_CONFLICTS = (CUB_SMEM_BANKS(PTX_ARCH) % SEGMENT_LENGTH == 0),
+        HAS_CONFLICTS = (CUB_SMEM_BANKS(0) % SEGMENT_LENGTH == 0),
 
         /// Degree of bank conflicts (e.g., 4-way)
         CONFLICT_DEGREE = (HAS_CONFLICTS) ?
-            (MAX_RAKING_THREADS * SEGMENT_LENGTH) / CUB_SMEM_BANKS(PTX_ARCH) :
+            (MAX_RAKING_THREADS * SEGMENT_LENGTH) / CUB_SMEM_BANKS(0) :
             1,
 
         /// Pad each segment length with one element if segment length is not relatively prime to warp size and can't be optimized as a vector load

--- a/cub/block/block_reduce.cuh
+++ b/cub/block/block_reduce.cuh
@@ -158,7 +158,7 @@ enum BlockReduceAlgorithm
  * \tparam ALGORITHM        <b>[optional]</b> cub::BlockReduceAlgorithm enumerator specifying the underlying algorithm to use (default: cub::BLOCK_REDUCE_WARP_REDUCTIONS)
  * \tparam BLOCK_DIM_Y      <b>[optional]</b> The thread block length in threads along the Y dimension (default: 1)
  * \tparam BLOCK_DIM_Z      <b>[optional]</b> The thread block length in threads along the Z dimension (default: 1)
- * \tparam PTX_ARCH         <b>[optional]</b> \ptxversion
+ * \tparam LEGACY_PTX_ARCH  <b>[optional]</b> Unused.
  *
  * \par Overview
  * - A <a href="http://en.wikipedia.org/wiki/Reduce_(higher-order_function)"><em>reduction</em></a> (or <em>fold</em>)
@@ -218,7 +218,7 @@ template <
     BlockReduceAlgorithm    ALGORITHM       = BLOCK_REDUCE_WARP_REDUCTIONS,
     int                     BLOCK_DIM_Y     = 1,
     int                     BLOCK_DIM_Z     = 1,
-    int                     PTX_ARCH        = CUB_PTX_ARCH>
+    int                     LEGACY_PTX_ARCH = 0>
 class BlockReduce
 {
 private:
@@ -234,9 +234,9 @@ private:
         BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
     };
 
-    typedef BlockReduceWarpReductions<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z, PTX_ARCH>           WarpReductions;
-    typedef BlockReduceRakingCommutativeOnly<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z, PTX_ARCH>    RakingCommutativeOnly;
-    typedef BlockReduceRaking<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z, PTX_ARCH>                   Raking;
+    typedef BlockReduceWarpReductions<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z>           WarpReductions;
+    typedef BlockReduceRakingCommutativeOnly<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z>    RakingCommutativeOnly;
+    typedef BlockReduceRaking<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z>                   Raking;
 
     /// Internal specialization type
     using InternalBlockReduce = cub::detail::conditional_t<

--- a/cub/block/block_scan.cuh
+++ b/cub/block/block_scan.cuh
@@ -117,7 +117,7 @@ enum BlockScanAlgorithm
  * \tparam ALGORITHM        <b>[optional]</b> cub::BlockScanAlgorithm enumerator specifying the underlying algorithm to use (default: cub::BLOCK_SCAN_RAKING)
  * \tparam BLOCK_DIM_Y      <b>[optional]</b> The thread block length in threads along the Y dimension (default: 1)
  * \tparam BLOCK_DIM_Z      <b>[optional]</b> The thread block length in threads along the Z dimension (default: 1)
- * \tparam PTX_ARCH         <b>[optional]</b> \ptxversion
+ * \tparam LEGACY_PTX_ARCH  <b>[optional]</b> Unused.
  *
  * \par Overview
  * - Given a list of input elements and a binary reduction operator, a [<em>prefix scan</em>](http://en.wikipedia.org/wiki/Prefix_sum)
@@ -191,7 +191,7 @@ template <
     BlockScanAlgorithm  ALGORITHM       = BLOCK_SCAN_RAKING,
     int                 BLOCK_DIM_Y     = 1,
     int                 BLOCK_DIM_Z     = 1,
-    int                 PTX_ARCH        = CUB_PTX_ARCH>
+    int                 LEGACY_PTX_ARCH = 0>
 class BlockScan
 {
 private:
@@ -214,12 +214,12 @@ private:
      * architectural warp size.
      */
     static const BlockScanAlgorithm SAFE_ALGORITHM =
-        ((ALGORITHM == BLOCK_SCAN_WARP_SCANS) && (BLOCK_THREADS % CUB_WARP_THREADS(PTX_ARCH) != 0)) ?
+        ((ALGORITHM == BLOCK_SCAN_WARP_SCANS) && (BLOCK_THREADS % CUB_WARP_THREADS(0) != 0)) ?
             BLOCK_SCAN_RAKING :
             ALGORITHM;
 
-    typedef BlockScanWarpScans<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z, PTX_ARCH> WarpScans;
-    typedef BlockScanRaking<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z, (SAFE_ALGORITHM == BLOCK_SCAN_RAKING_MEMOIZE), PTX_ARCH> Raking;
+    typedef BlockScanWarpScans<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z> WarpScans;
+    typedef BlockScanRaking<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z, (SAFE_ALGORITHM == BLOCK_SCAN_RAKING_MEMOIZE)> Raking;
 
     /// Define the delegate type for the desired algorithm
     using InternalBlockScan =

--- a/cub/block/block_shuffle.cuh
+++ b/cub/block/block_shuffle.cuh
@@ -47,7 +47,7 @@ CUB_NAMESPACE_BEGIN
  * \tparam BLOCK_DIM_X          The thread block length in threads along the X dimension
  * \tparam BLOCK_DIM_Y          <b>[optional]</b> The thread block length in threads along the Y dimension (default: 1)
  * \tparam BLOCK_DIM_Z          <b>[optional]</b> The thread block length in threads along the Z dimension (default: 1)
- * \tparam PTX_ARCH             <b>[optional]</b> \ptxversion
+ * \tparam LEGACY_PTX_ARCH      <b>[optional]</b> Unused.
  *
  * \par Overview
  * It is commonplace for blocks of threads to rearrange data items between
@@ -60,7 +60,7 @@ template <
     int                 BLOCK_DIM_X,
     int                 BLOCK_DIM_Y         = 1,
     int                 BLOCK_DIM_Z         = 1,
-    int                 PTX_ARCH            = CUB_PTX_ARCH>
+    int                 LEGACY_PTX_ARCH     = 0>
 class BlockShuffle
 {
 private:
@@ -73,7 +73,7 @@ private:
     {
         BLOCK_THREADS               = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
 
-        LOG_WARP_THREADS            = CUB_LOG_WARP_THREADS(PTX_ARCH),
+        LOG_WARP_THREADS            = CUB_LOG_WARP_THREADS(0),
         WARP_THREADS                = 1 << LOG_WARP_THREADS,
         WARPS                       = (BLOCK_THREADS + WARP_THREADS - 1) / WARP_THREADS,
     };

--- a/cub/block/block_store.cuh
+++ b/cub/block/block_store.cuh
@@ -454,7 +454,7 @@ enum BlockStoreAlgorithm
  * \tparam ALGORITHM            <b>[optional]</b> cub::BlockStoreAlgorithm tuning policy enumeration.  default: cub::BLOCK_STORE_DIRECT.
  * \tparam BLOCK_DIM_Y          <b>[optional]</b> The thread block length in threads along the Y dimension (default: 1)
  * \tparam BLOCK_DIM_Z          <b>[optional]</b> The thread block length in threads along the Z dimension (default: 1)
- * \tparam PTX_ARCH             <b>[optional]</b> \ptxversion
+ * \tparam LEGACY_PTX_ARCH      <b>[optional]</b> Unused.
  *
  * \par Overview
  * - The BlockStore class provides a single data movement abstraction that can be specialized
@@ -528,7 +528,7 @@ template <
     BlockStoreAlgorithm     ALGORITHM           = BLOCK_STORE_DIRECT,
     int                     BLOCK_DIM_Y         = 1,
     int                     BLOCK_DIM_Z         = 1,
-    int                     PTX_ARCH            = CUB_PTX_ARCH>
+    int                     LEGACY_PTX_ARCH     = 0>
 class BlockStore
 {
 private:
@@ -691,7 +691,7 @@ private:
     struct StoreInternal<BLOCK_STORE_TRANSPOSE, DUMMY>
     {
         // BlockExchange utility type for keys
-        typedef BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z, PTX_ARCH> BlockExchange;
+        typedef BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchange;
 
         /// Shared memory storage layout type
         struct _TempStorage : BlockExchange::TempStorage
@@ -752,14 +752,14 @@ private:
     {
         enum
         {
-            WARP_THREADS = CUB_WARP_THREADS(PTX_ARCH)
+            WARP_THREADS = CUB_WARP_THREADS(0)
         };
 
         // Assert BLOCK_THREADS must be a multiple of WARP_THREADS
         CUB_STATIC_ASSERT((int(BLOCK_THREADS) % int(WARP_THREADS) == 0), "BLOCK_THREADS must be a multiple of WARP_THREADS");
 
         // BlockExchange utility type for keys
-        typedef BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z, PTX_ARCH> BlockExchange;
+        typedef BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD, false, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchange;
 
         /// Shared memory storage layout type
         struct _TempStorage : BlockExchange::TempStorage
@@ -820,14 +820,14 @@ private:
     {
         enum
         {
-            WARP_THREADS = CUB_WARP_THREADS(PTX_ARCH)
+            WARP_THREADS = CUB_WARP_THREADS(0)
         };
 
         // Assert BLOCK_THREADS must be a multiple of WARP_THREADS
         CUB_STATIC_ASSERT((int(BLOCK_THREADS) % int(WARP_THREADS) == 0), "BLOCK_THREADS must be a multiple of WARP_THREADS");
 
         // BlockExchange utility type for keys
-        typedef BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD, true, BLOCK_DIM_Y, BLOCK_DIM_Z, PTX_ARCH> BlockExchange;
+        typedef BlockExchange<T, BLOCK_DIM_X, ITEMS_PER_THREAD, true, BLOCK_DIM_Y, BLOCK_DIM_Z> BlockExchange;
 
         /// Shared memory storage layout type
         struct _TempStorage : BlockExchange::TempStorage

--- a/cub/block/specializations/block_histogram_sort.cuh
+++ b/cub/block/specializations/block_histogram_sort.cuh
@@ -73,8 +73,7 @@ struct BlockHistogramSort
             BLOCK_SCAN_WARP_SCANS,
             cudaSharedMemBankSizeFourByte,
             BLOCK_DIM_Y,
-            BLOCK_DIM_Z,
-            PTX_ARCH>
+            BLOCK_DIM_Z>
         BlockRadixSortT;
 
     // Parameterize BlockDiscontinuity type for our thread block
@@ -82,8 +81,7 @@ struct BlockHistogramSort
             T,
             BLOCK_DIM_X,
             BLOCK_DIM_Y,
-            BLOCK_DIM_Z,
-            PTX_ARCH>
+            BLOCK_DIM_Z>
         BlockDiscontinuityT;
 
     /// Shared memory

--- a/cub/block/specializations/block_histogram_sort.cuh
+++ b/cub/block/specializations/block_histogram_sort.cuh
@@ -52,7 +52,7 @@ template <
     int         BINS,               ///< The number of bins into which histogram samples may fall
     int         BLOCK_DIM_Y,        ///< The thread block length in threads along the Y dimension
     int         BLOCK_DIM_Z,        ///< The thread block length in threads along the Z dimension
-    int         PTX_ARCH>           ///< The PTX compute capability for which to to specialize this collective
+    int         LEGACY_PTX_ARCH = 0> ///< The PTX compute capability for which to to specialize this collective (unused)
 struct BlockHistogramSort
 {
     /// Constants
@@ -69,7 +69,7 @@ struct BlockHistogramSort
             ITEMS_PER_THREAD,
             NullType,
             4,
-            (PTX_ARCH >= 350) ? true : false,
+            true,
             BLOCK_SCAN_WARP_SCANS,
             cudaSharedMemBankSizeFourByte,
             BLOCK_DIM_Y,

--- a/cub/block/specializations/block_reduce_raking.cuh
+++ b/cub/block/specializations/block_reduce_raking.cuh
@@ -60,7 +60,7 @@ template <
     int         BLOCK_DIM_X,    ///< The thread block length in threads along the X dimension
     int         BLOCK_DIM_Y,    ///< The thread block length in threads along the Y dimension
     int         BLOCK_DIM_Z,    ///< The thread block length in threads along the Z dimension
-    int         PTX_ARCH>       ///< The PTX compute capability for which to to specialize this collective
+    int         LEGACY_PTX_ARCH = 0> ///< The PTX compute capability for which to to specialize this collective
 struct BlockReduceRaking
 {
     /// Constants
@@ -71,10 +71,10 @@ struct BlockReduceRaking
     };
 
     /// Layout type for padded thread block raking grid
-    typedef BlockRakingLayout<T, BLOCK_THREADS, PTX_ARCH> BlockRakingLayout;
+    typedef BlockRakingLayout<T, BLOCK_THREADS> BlockRakingLayout;
 
     ///  WarpReduce utility type
-    typedef typename WarpReduce<T, BlockRakingLayout::RAKING_THREADS, PTX_ARCH>::InternalWarpReduce WarpReduce;
+    typedef typename WarpReduce<T, BlockRakingLayout::RAKING_THREADS>::InternalWarpReduce WarpReduce;
 
     /// Constants
     enum

--- a/cub/block/specializations/block_reduce_raking_commutative_only.cuh
+++ b/cub/block/specializations/block_reduce_raking_commutative_only.cuh
@@ -50,7 +50,7 @@ template <
     int         BLOCK_DIM_X,    ///< The thread block length in threads along the X dimension
     int         BLOCK_DIM_Y,    ///< The thread block length in threads along the Y dimension
     int         BLOCK_DIM_Z,    ///< The thread block length in threads along the Z dimension
-    int         PTX_ARCH>       ///< The PTX compute capability for which to to specialize this collective
+    int         LEGACY_PTX_ARCH = 0> ///< The PTX compute capability for which to to specialize this collective
 struct BlockReduceRakingCommutativeOnly
 {
     /// Constants
@@ -61,13 +61,13 @@ struct BlockReduceRakingCommutativeOnly
     };
 
     // The fall-back implementation to use when BLOCK_THREADS is not a multiple of the warp size or not all threads have valid values
-    typedef BlockReduceRaking<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z, PTX_ARCH> FallBack;
+    typedef BlockReduceRaking<T, BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z> FallBack;
 
     /// Constants
     enum
     {
         /// Number of warp threads
-        WARP_THREADS = CUB_WARP_THREADS(PTX_ARCH),
+        WARP_THREADS = CUB_WARP_THREADS(0),
 
         /// Whether or not to use fall-back
         USE_FALLBACK = ((BLOCK_THREADS % WARP_THREADS != 0) || (BLOCK_THREADS <= WARP_THREADS)),
@@ -83,10 +83,10 @@ struct BlockReduceRakingCommutativeOnly
     };
 
     ///  WarpReduce utility type
-    typedef WarpReduce<T, RAKING_THREADS, PTX_ARCH> WarpReduce;
+    typedef WarpReduce<T, RAKING_THREADS> WarpReduce;
 
     /// Layout type for padded thread block raking grid
-    typedef BlockRakingLayout<T, SHARING_THREADS, PTX_ARCH> BlockRakingLayout;
+    typedef BlockRakingLayout<T, SHARING_THREADS> BlockRakingLayout;
 
     /// Shared memory storage layout type
     union _TempStorage

--- a/cub/block/specializations/block_reduce_warp_reductions.cuh
+++ b/cub/block/specializations/block_reduce_warp_reductions.cuh
@@ -48,7 +48,7 @@ template <
     int         BLOCK_DIM_X,    ///< The thread block length in threads along the X dimension
     int         BLOCK_DIM_Y,    ///< The thread block length in threads along the Y dimension
     int         BLOCK_DIM_Z,    ///< The thread block length in threads along the Z dimension
-    int         PTX_ARCH>       ///< The PTX compute capability for which to to specialize this collective
+    int         LEGACY_PTX_ARCH = 0> ///< The PTX compute capability for which to to specialize this collective
 struct BlockReduceWarpReductions
 {
     /// Constants
@@ -58,7 +58,7 @@ struct BlockReduceWarpReductions
         BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
 
         /// Number of warp threads
-        WARP_THREADS = CUB_WARP_THREADS(PTX_ARCH),
+        WARP_THREADS = CUB_WARP_THREADS(0),
 
         /// Number of active warps
         WARPS = (BLOCK_THREADS + WARP_THREADS - 1) / WARP_THREADS,
@@ -72,7 +72,7 @@ struct BlockReduceWarpReductions
 
 
     ///  WarpReduce utility type
-    typedef typename WarpReduce<T, LOGICAL_WARP_SIZE, PTX_ARCH>::InternalWarpReduce WarpReduce;
+    typedef typename WarpReduce<T, LOGICAL_WARP_SIZE>::InternalWarpReduce WarpReduce;
 
 
     /// Shared memory storage layout type

--- a/cub/block/specializations/block_scan_raking.cuh
+++ b/cub/block/specializations/block_scan_raking.cuh
@@ -53,7 +53,7 @@ template <
     int         BLOCK_DIM_Y,    ///< The thread block length in threads along the Y dimension
     int         BLOCK_DIM_Z,    ///< The thread block length in threads along the Z dimension
     bool        MEMOIZE,        ///< Whether or not to buffer outer raking scan partials to incur fewer shared memory reads at the expense of higher register pressure
-    int         PTX_ARCH>       ///< The PTX compute capability for which to to specialize this collective
+    int         LEGACY_PTX_ARCH = 0> ///< The PTX compute capability for which to to specialize this collective
 struct BlockScanRaking
 {
     //---------------------------------------------------------------------
@@ -68,7 +68,7 @@ struct BlockScanRaking
     };
 
     /// Layout type for padded thread block raking grid
-    typedef BlockRakingLayout<T, BLOCK_THREADS, PTX_ARCH> BlockRakingLayout;
+    typedef BlockRakingLayout<T, BLOCK_THREADS> BlockRakingLayout;
 
     /// Constants
     enum
@@ -84,7 +84,7 @@ struct BlockScanRaking
     };
 
     ///  WarpScan utility type
-    typedef WarpScan<T, RAKING_THREADS, PTX_ARCH> WarpScan;
+    typedef WarpScan<T, RAKING_THREADS> WarpScan;
 
     /// Shared memory storage layout type
     struct _TempStorage

--- a/cub/block/specializations/block_scan_warp_scans.cuh
+++ b/cub/block/specializations/block_scan_warp_scans.cuh
@@ -47,7 +47,7 @@ template <
     int         BLOCK_DIM_X,    ///< The thread block length in threads along the X dimension
     int         BLOCK_DIM_Y,    ///< The thread block length in threads along the Y dimension
     int         BLOCK_DIM_Z,    ///< The thread block length in threads along the Z dimension
-    int         PTX_ARCH>       ///< The PTX compute capability for which to to specialize this collective
+    int         LEGACY_PTX_ARCH = 0> ///< The PTX compute capability for which to to specialize this collective
 struct BlockScanWarpScans
 {
     //---------------------------------------------------------------------
@@ -58,7 +58,7 @@ struct BlockScanWarpScans
     enum
     {
         /// Number of warp threads
-        WARP_THREADS = CUB_WARP_THREADS(PTX_ARCH),
+        WARP_THREADS = CUB_WARP_THREADS(0),
 
         /// The thread block size in threads
         BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
@@ -68,10 +68,10 @@ struct BlockScanWarpScans
     };
 
     ///  WarpScan utility type
-    typedef WarpScan<T, WARP_THREADS, PTX_ARCH> WarpScanT;
+    typedef WarpScan<T, WARP_THREADS> WarpScanT;
 
     ///  WarpScan utility type
-    typedef WarpScan<T, WARPS, PTX_ARCH> WarpAggregateScan;
+    typedef WarpScan<T, WARPS> WarpAggregateScan;
 
     /// Shared memory storage layout type
 

--- a/cub/block/specializations/block_scan_warp_scans2.cuh
+++ b/cub/block/specializations/block_scan_warp_scans2.cuh
@@ -47,7 +47,7 @@ template <
     int         BLOCK_DIM_X,    ///< The thread block length in threads along the X dimension
     int         BLOCK_DIM_Y,    ///< The thread block length in threads along the Y dimension
     int         BLOCK_DIM_Z,    ///< The thread block length in threads along the Z dimension
-    int         PTX_ARCH>       ///< The PTX compute capability for which to to specialize this collective
+    int         LEGACY_PTX_ARCH = 0> ///< The PTX compute capability for which to to specialize this collective
 struct BlockScanWarpScans
 {
     //---------------------------------------------------------------------
@@ -58,7 +58,7 @@ struct BlockScanWarpScans
     enum
     {
         /// Number of warp threads
-        WARP_THREADS = CUB_WARP_THREADS(PTX_ARCH),
+        WARP_THREADS = CUB_WARP_THREADS(0),
 
         /// The thread block size in threads
         BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
@@ -68,10 +68,10 @@ struct BlockScanWarpScans
     };
 
     ///  WarpScan utility type
-    typedef WarpScan<T, WARP_THREADS, PTX_ARCH> WarpScanT;
+    typedef WarpScan<T, WARP_THREADS> WarpScanT;
 
     ///  WarpScan utility type
-    typedef WarpScan<T, WARPS, PTX_ARCH> WarpAggregateScanT;
+    typedef WarpScan<T, WARPS> WarpAggregateScanT;
 
     /// Shared memory storage layout type
     struct _TempStorage

--- a/cub/block/specializations/block_scan_warp_scans3.cuh
+++ b/cub/block/specializations/block_scan_warp_scans3.cuh
@@ -47,7 +47,7 @@ template <
     int         BLOCK_DIM_X,    ///< The thread block length in threads along the X dimension
     int         BLOCK_DIM_Y,    ///< The thread block length in threads along the Y dimension
     int         BLOCK_DIM_Z,    ///< The thread block length in threads along the Z dimension
-    int         PTX_ARCH>       ///< The PTX compute capability for which to to specialize this collective
+    int         LEGACY_PTX_ARCH = 0> ///< The PTX compute capability for which to to specialize this collective
 struct BlockScanWarpScans
 {
     //---------------------------------------------------------------------
@@ -61,7 +61,7 @@ struct BlockScanWarpScans
         BLOCK_THREADS = BLOCK_DIM_X * BLOCK_DIM_Y * BLOCK_DIM_Z,
 
         /// Number of warp threads
-        INNER_WARP_THREADS = CUB_WARP_THREADS(PTX_ARCH),
+        INNER_WARP_THREADS = CUB_WARP_THREADS(0),
         OUTER_WARP_THREADS = BLOCK_THREADS / INNER_WARP_THREADS,
 
         /// Number of outer scan warps
@@ -69,10 +69,10 @@ struct BlockScanWarpScans
     };
 
     ///  Outer WarpScan utility type
-    typedef WarpScan<T, OUTER_WARP_THREADS, PTX_ARCH> OuterWarpScanT;
+    typedef WarpScan<T, OUTER_WARP_THREADS> OuterWarpScanT;
 
     ///  Inner WarpScan utility type
-    typedef WarpScan<T, INNER_WARP_THREADS, PTX_ARCH> InnerWarpScanT;
+    typedef WarpScan<T, INNER_WARP_THREADS> InnerWarpScanT;
 
     typedef typename OuterWarpScanT::TempStorage OuterScanArray[OUTER_WARPS];
 

--- a/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/device/dispatch/dispatch_histogram.cuh
@@ -34,19 +34,21 @@
 
 #pragma once
 
-#include <stdio.h>
-#include <iterator>
-#include <limits>
-
-#include "../../agent/agent_histogram.cuh"
-#include "../../util_debug.cuh"
-#include "../../util_device.cuh"
-#include "../../util_math.cuh"
-#include "../../thread/thread_search.cuh"
-#include "../../grid/grid_queue.cuh"
-#include "../../config.cuh"
+#include <cub/agent/agent_histogram.cuh>
+#include <cub/util_debug.cuh>
+#include <cub/util_device.cuh>
+#include <cub/util_math.cuh>
+#include <cub/thread/thread_search.cuh>
+#include <cub/grid/grid_queue.cuh>
+#include <cub/config.cuh>
 
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
+
+#include <nv/target>
+
+#include <cstdio>
+#include <iterator>
+#include <limits>
 
 CUB_NAMESPACE_BEGIN
 
@@ -401,31 +403,30 @@ struct DispatchHistogram
         int             ptx_version,
         KernelConfig    &histogram_sweep_config)
     {
-        cudaError_t result = cudaErrorNotSupported;
-        if (CUB_IS_DEVICE_CODE)
-        {
-            #if CUB_INCLUDE_DEVICE_CODE
-                // We're on the device, so initialize the kernel dispatch configurations with the current PTX policy
-                result = histogram_sweep_config.template Init<PtxHistogramSweepPolicy>();
-            #endif
-        }
-        else
-        {
-            #if CUB_INCLUDE_HOST_CODE
-                // We're on the host, so lookup and initialize the kernel dispatch configurations with the policies that match the device's PTX version
-                if (ptx_version >= 500)
-                {
-                    result = histogram_sweep_config.template Init<typename Policy500::HistogramSweepPolicy>();
-                }
-                else
-                {
-                    result = histogram_sweep_config.template Init<typename Policy350::HistogramSweepPolicy>();
-                }
-            #endif
-        }
-        return result;
-    }
+      cudaError_t result = cudaErrorNotSupported;
+      NV_IF_TARGET(
+        NV_IS_DEVICE,
+        (
+          // We're on the device, so initialize the kernel dispatch
+          // configurations with the current PTX policy
+          result = histogram_sweep_config.template Init<PtxHistogramSweepPolicy>();
+        ),
+        ( // NV_IS_HOST:
+          // We're on the host, so lookup and initialize the kernel dispatch
+          // configurations with the policies that match the device's PTX
+          // version
+          if (ptx_version >= 500)
+          {
+            result = histogram_sweep_config.template Init<typename Policy500::HistogramSweepPolicy>();
+          }
+          else
+          {
+            result = histogram_sweep_config.template Init<typename Policy350::HistogramSweepPolicy>();
+          }
+        ));
 
+      return result;
+    }
 
     /**
      * Kernel kernel dispatch configuration

--- a/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -1227,7 +1227,7 @@ struct DispatchRadixSort :
             UpsweepKernelT      upsweep_kernel,
             ScanKernelT         scan_kernel,
             DownsweepKernelT    downsweep_kernel,
-            int                 ptx_version,
+            int                 /*ptx_version*/,
             int                 sm_count,
             OffsetT             num_items)
         {
@@ -1244,7 +1244,7 @@ struct DispatchRadixSort :
                 if (CubDebug(error = scan_config.Init<ScanPolicyT>(scan_kernel))) break;
                 if (CubDebug(error = downsweep_config.Init<DownsweepPolicyT>(downsweep_kernel))) break;
 
-                max_downsweep_grid_size = (downsweep_config.sm_occupancy * sm_count) * CUB_SUBSCRIPTION_FACTOR(ptx_version);
+                max_downsweep_grid_size = (downsweep_config.sm_occupancy * sm_count) * CUB_SUBSCRIPTION_FACTOR(0);
 
                 even_share.DispatchInit(
                     num_items,

--- a/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -1332,9 +1332,15 @@ struct DispatchRadixSort :
                 MaxPolicyT, IS_DESCENDING, KeyT, OffsetT>;
             if (CubDebug(error = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
                 &histo_blocks_per_sm, histogram_kernel, HISTO_BLOCK_THREADS, 0))) break;
-            histogram_kernel<<<histo_blocks_per_sm * num_sms, HISTO_BLOCK_THREADS, 0, stream>>>
-                (d_bins, d_keys.Current(), num_items, begin_bit, end_bit);
-            if (CubDebug(error = cudaPeekAtLastError())) break;
+
+            error = THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(
+              histo_blocks_per_sm * num_sms, HISTO_BLOCK_THREADS, 0, stream
+            ).doit(histogram_kernel,
+                   d_bins, d_keys.Current(), num_items, begin_bit, end_bit);
+            if (CubDebug(error))
+            {
+                break;
+            }
 
             // exclusive sums to determine starts
             const int SCAN_BLOCK_THREADS = ActivePolicyT::ExclusiveSumPolicy::BLOCK_THREADS;
@@ -1368,17 +1374,22 @@ struct DispatchRadixSort :
                            stream))) break;
                     auto onesweep_kernel = DeviceRadixSortOnesweepKernel<
                         MaxPolicyT, IS_DESCENDING, KeyT, ValueT, OffsetT, PortionOffsetT>;
-                    onesweep_kernel<<<num_blocks, ONESWEEP_BLOCK_THREADS, 0, stream>>>
-                        (d_lookback, d_ctrs + portion * num_passes + pass,
-                         portion < num_portions - 1 ?
+                    errror = THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(
+                      num_blocks, ONESWEEP_BLOCK_THREADS, 0, stream
+                    ).doit(onesweep_kernel,
+                           d_lookback, d_ctrs + portion * num_passes + pass,
+                           portion < num_portions - 1 ?
                              d_bins + ((portion + 1) * num_passes + pass) * RADIX_DIGITS : NULL,
-                         d_bins + (portion * num_passes + pass) * RADIX_DIGITS,
-                         d_keys.Alternate(),
-                         d_keys.Current() + portion * PORTION_SIZE,
-                         d_values.Alternate(),
-                         d_values.Current() + portion * PORTION_SIZE,
-                         portion_num_items, current_bit, num_bits);
-                    if (CubDebug(error = cudaPeekAtLastError())) break;
+                           d_bins + (portion * num_passes + pass) * RADIX_DIGITS,
+                           d_keys.Alternate(),
+                           d_keys.Current() + portion * PORTION_SIZE,
+                           d_values.Alternate(),
+                           d_values.Current() + portion * PORTION_SIZE,
+                           portion_num_items, current_bit, num_bits);
+                    if (CubDebug(error))
+                    {
+                      break;
+                    }
                 }
                 
                 // use the temporary buffers if no overwrite is allowed

--- a/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/device/dispatch/dispatch_reduce.cuh
@@ -472,7 +472,7 @@ struct DispatchReduce :
             int reduce_device_occupancy = reduce_config.sm_occupancy * sm_count;
 
             // Even-share work distribution
-            int max_blocks = reduce_device_occupancy * CUB_SUBSCRIPTION_FACTOR(ptx_version);
+            int max_blocks = reduce_device_occupancy * CUB_SUBSCRIPTION_FACTOR(0);
             GridEvenShare<OffsetT> even_share;
             even_share.DispatchInit(num_items, max_blocks, reduce_config.tile_size);
 

--- a/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -1,4 +1,3 @@
-
 /******************************************************************************
  * Copyright (c) 2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
@@ -34,18 +33,20 @@
 
 #pragma once
 
-#include <stdio.h>
-#include <iterator>
+#include <cub/agent/agent_reduce_by_key.cuh>
+#include <cub/config.cuh>
+#include <cub/device/dispatch/dispatch_scan.cuh>
+#include <cub/grid/grid_queue.cuh>
+#include <cub/thread/thread_operators.cuh>
+#include <cub/util_device.cuh>
+#include <cub/util_math.cuh>
 
-#include "dispatch_scan.cuh"
-#include "../../config.cuh"
-#include "../../agent/agent_reduce_by_key.cuh"
-#include "../../thread/thread_operators.cuh"
-#include "../../grid/grid_queue.cuh"
-#include "../../util_device.cuh"
-#include "../../util_math.cuh"
+#include <nv/target>
 
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
+
+#include <cstdio>
+#include <iterator>
 
 CUB_NAMESPACE_BEGIN
 
@@ -193,27 +194,19 @@ struct DispatchReduceByKey
     template <typename KernelConfig>
     CUB_RUNTIME_FUNCTION __forceinline__
     static void InitConfigs(
-        int             ptx_version,
+        int             /*ptx_version*/,
         KernelConfig    &reduce_by_key_config)
     {
-        if (CUB_IS_DEVICE_CODE)
-        {
-            #if CUB_INCLUDE_DEVICE_CODE
-                (void)ptx_version;
-                // We're on the device, so initialize the kernel dispatch configurations with the current PTX policy
-                reduce_by_key_config.template Init<PtxReduceByKeyPolicy>();
-            #endif
-        }
-        else
-        {
-            #if CUB_INCLUDE_HOST_CODE
-                // We're on the host, so lookup and initialize the kernel dispatch configurations with the policies that match the device's PTX version
+        NV_IF_TARGET(NV_IS_DEVICE,
+        (
+            // We're on the device, so initialize the kernel dispatch configurations with the current PTX policy
+            reduce_by_key_config.template Init<PtxReduceByKeyPolicy>();
+        ), (
+            // We're on the host, so lookup and initialize the kernel dispatch configurations with the policies that match the device's PTX version
 
-                // (There's only one policy right now)
-                (void)ptx_version;
-                reduce_by_key_config.template Init<typename Policy350::ReduceByKeyPolicyT>();
-            #endif
-        }
+            // (There's only one policy right now)
+            reduce_by_key_config.template Init<typename Policy350::ReduceByKeyPolicyT>();
+        ));
     }
 
 

--- a/cub/device/dispatch/dispatch_select_if.cuh
+++ b/cub/device/dispatch/dispatch_select_if.cuh
@@ -1,4 +1,3 @@
-
 /******************************************************************************
  * Copyright (c) 2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
@@ -34,18 +33,20 @@
 
 #pragma once
 
-#include <stdio.h>
-#include <iterator>
-
-#include "dispatch_scan.cuh"
-#include "../../config.cuh"
-#include "../../agent/agent_select_if.cuh"
-#include "../../thread/thread_operators.cuh"
-#include "../../grid/grid_queue.cuh"
-#include "../../util_device.cuh"
-#include "../../util_math.cuh"
+#include <cub/agent/agent_select_if.cuh>
+#include <cub/config.cuh>
+#include <cub/device/dispatch/dispatch_scan.cuh>
+#include <cub/thread/thread_operators.cuh>
+#include <cub/grid/grid_queue.cuh>
+#include <cub/util_device.cuh>
+#include <cub/util_math.cuh>
 
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
+
+#include <nv/target>
+
+#include <cstdio>
+#include <iterator>
 
 CUB_NAMESPACE_BEGIN
 
@@ -188,23 +189,18 @@ struct DispatchSelectIf
         int             ptx_version,
         KernelConfig    &select_if_config)
     {
-        if (CUB_IS_DEVICE_CODE) {
-            #if CUB_INCLUDE_DEVICE_CODE
-                (void)ptx_version;
-                // We're on the device, so initialize the kernel dispatch configurations with the current PTX policy
-                select_if_config.template Init<PtxSelectIfPolicyT>();
-            #endif
-        }
-        else
-        {
-            #if CUB_INCLUDE_HOST_CODE
-                // We're on the host, so lookup and initialize the kernel dispatch configurations with the policies that match the device's PTX version
+        NV_IF_TARGET(NV_IS_DEVICE,
+        (
+            (void)ptx_version;
+            // We're on the device, so initialize the kernel dispatch configurations with the current PTX policy
+            select_if_config.template Init<PtxSelectIfPolicyT>();
+        ), (
+            // We're on the host, so lookup and initialize the kernel dispatch configurations with the policies that match the device's PTX version
 
-                // (There's only one policy right now)
-                (void)ptx_version;
-                select_if_config.template Init<typename Policy350::SelectIfPolicyT>();
-            #endif
-        }
+            // (There's only one policy right now)
+            (void)ptx_version;
+            select_if_config.template Init<typename Policy350::SelectIfPolicyT>();
+        ));
     }
 
 

--- a/cub/grid/grid_queue.cuh
+++ b/cub/grid/grid_queue.cuh
@@ -33,8 +33,10 @@
 
 #pragma once
 
-#include "../config.cuh"
-#include "../util_debug.cuh"
+#include <cub/config.cuh>
+#include <cub/util_debug.cuh>
+
+#include <nv/target>
 
 CUB_NAMESPACE_BEGIN
 
@@ -120,21 +122,20 @@ public:
         cudaStream_t stream = 0)
     {
         cudaError_t result = cudaErrorUnknown;
-        if (CUB_IS_DEVICE_CODE) {
-            #if CUB_INCLUDE_DEVICE_CODE
-                (void)stream;
-                d_counters[FILL] = fill_size;
-                d_counters[DRAIN] = 0;
-                result = cudaSuccess;
-            #endif
-        } else {
-            #if CUB_INCLUDE_HOST_CODE
-                OffsetT counters[2];
-                counters[FILL] = fill_size;
-                counters[DRAIN] = 0;
-                result = CubDebug(cudaMemcpyAsync(d_counters, counters, sizeof(OffsetT) * 2, cudaMemcpyHostToDevice, stream));
-            #endif
-        }
+
+        NV_IF_TARGET(NV_IS_DEVICE,
+        (
+            (void)stream;
+            d_counters[FILL] = fill_size;
+            d_counters[DRAIN] = 0;
+            result = cudaSuccess;
+        ), (
+            OffsetT counters[2];
+            counters[FILL] = fill_size;
+            counters[DRAIN] = 0;
+            result = CubDebug(cudaMemcpyAsync(d_counters, counters, sizeof(OffsetT) * 2, cudaMemcpyHostToDevice, stream));
+        ));
+
         return result;
     }
 
@@ -143,17 +144,16 @@ public:
     __host__ __device__ __forceinline__ cudaError_t ResetDrain(cudaStream_t stream = 0)
     {
         cudaError_t result = cudaErrorUnknown;
-        if (CUB_IS_DEVICE_CODE) {
-            #if CUB_INCLUDE_DEVICE_CODE
-                (void)stream;
-                d_counters[DRAIN] = 0;
-                result = cudaSuccess;
-            #endif
-        } else {
-            #if CUB_INCLUDE_HOST_CODE
-                result = CubDebug(cudaMemsetAsync(d_counters + DRAIN, 0, sizeof(OffsetT), stream));
-            #endif
-        }
+
+        NV_IF_TARGET(NV_IS_DEVICE,
+        (
+            (void)stream;
+            d_counters[DRAIN] = 0;
+            result = cudaSuccess;
+        ), (
+            result = CubDebug(cudaMemsetAsync(d_counters + DRAIN, 0, sizeof(OffsetT), stream));
+        ));
+
         return result;
     }
 
@@ -162,17 +162,16 @@ public:
     __host__ __device__ __forceinline__ cudaError_t ResetFill(cudaStream_t stream = 0)
     {
         cudaError_t result = cudaErrorUnknown;
-        if (CUB_IS_DEVICE_CODE) {
-            #if CUB_INCLUDE_DEVICE_CODE
-                (void)stream;
-                d_counters[FILL] = 0;
-                result = cudaSuccess;
-            #endif
-        } else {
-            #if CUB_INCLUDE_HOST_CODE
-                result = CubDebug(cudaMemsetAsync(d_counters + FILL, 0, sizeof(OffsetT), stream));
-            #endif
-        }
+
+        NV_IF_TARGET(NV_IS_DEVICE,
+        (
+            (void)stream;
+            d_counters[FILL] = 0;
+            result = cudaSuccess;
+        ), (
+            result = CubDebug(cudaMemsetAsync(d_counters + FILL, 0, sizeof(OffsetT), stream));
+        ));
+
         return result;
     }
 
@@ -183,17 +182,16 @@ public:
         cudaStream_t stream = 0)
     {
         cudaError_t result = cudaErrorUnknown;
-        if (CUB_IS_DEVICE_CODE) {
-            #if CUB_INCLUDE_DEVICE_CODE
-                (void)stream;
-                fill_size = d_counters[FILL];
-                result = cudaSuccess;
-            #endif
-        } else {
-            #if CUB_INCLUDE_HOST_CODE
-                result = CubDebug(cudaMemcpyAsync(&fill_size, d_counters + FILL, sizeof(OffsetT), cudaMemcpyDeviceToHost, stream));
-            #endif
-        }
+
+        NV_IF_TARGET(NV_IS_DEVICE,
+        (
+            (void)stream;
+            fill_size = d_counters[FILL];
+            result = cudaSuccess;
+        ), (
+            result = CubDebug(cudaMemcpyAsync(&fill_size, d_counters + FILL, sizeof(OffsetT), cudaMemcpyDeviceToHost, stream));
+        ));
+
         return result;
     }
 

--- a/cub/iterator/tex_obj_input_iterator.cuh
+++ b/cub/iterator/tex_obj_input_iterator.cuh
@@ -33,14 +33,16 @@
 
 #pragma once
 
+#include <cub/config.cuh>
+#include <cub/thread/thread_load.cuh>
+#include <cub/thread/thread_store.cuh>
+#include <cub/util_debug.cuh>
+#include <cub/util_device.cuh>
+
+#include <nv/target>
+
 #include <iterator>
 #include <iostream>
-
-#include "../thread/thread_load.cuh"
-#include "../thread/thread_store.cuh"
-#include "../util_device.cuh"
-#include "../util_debug.cuh"
-#include "../config.cuh"
 
 #if (THRUST_VERSION >= 100700)
     // This iterator is compatible with Thrust API 1.7 and newer
@@ -200,37 +202,9 @@ public:
     /// Indirection
     __host__ __device__ __forceinline__ reference operator*() const
     {
-        if (CUB_IS_HOST_CODE) {
-            #if CUB_INCLUDE_HOST_CODE
-                // Simply dereference the pointer on the host
-                return ptr[tex_offset];
-            #else
-                // Never executed, just need a return value for this codepath.
-                // The `reference` type is actually just T, so we can fake this
-                // easily.
-                return reference{};
-            #endif
-        } else {
-            #if CUB_INCLUDE_DEVICE_CODE
-                // Move array of uninitialized words, then alias and assign to return value
-                TextureWord words[TEXTURE_MULTIPLE];
-
-                #pragma unroll
-                for (int i = 0; i < TEXTURE_MULTIPLE; ++i)
-                {
-                    words[i] = tex1Dfetch<TextureWord>(
-                        tex_obj,
-                        (tex_offset * TEXTURE_MULTIPLE) + i);
-                }
-
-                // Load from words
-                return *reinterpret_cast<T*>(words);
-            #else
-                // This is dead code which will never be executed.  It is here
-                // only to avoid warnings about missing return statements.
-                return ptr[tex_offset];
-            #endif
-        }
+        NV_IF_TARGET(NV_IS_HOST,
+                     (return ptr[tex_offset];),
+                     (return this->device_deref();));
     }
 
     /// Addition
@@ -312,6 +286,26 @@ public:
         return os;
     }
 
+private:
+    // This is hoisted out of operator* because #pragma can't be used inside of
+    // NV_IF_TARGET
+    __device__ __forceinline__ reference device_deref() const
+    {
+        // Move array of uninitialized words, then alias and assign to return
+        // value
+        TextureWord words[TEXTURE_MULTIPLE];
+
+        const auto tex_idx_base = tex_offset * TEXTURE_MULTIPLE;
+
+        #pragma unroll
+        for (int i = 0; i < TEXTURE_MULTIPLE; ++i)
+        {
+          words[i] = tex1Dfetch<TextureWord>(tex_obj, tex_idx_base + i);
+        }
+
+        // Load from words
+        return *reinterpret_cast<T *>(words);
+    }
 };
 
 

--- a/cub/thread/thread_load.cuh
+++ b/cub/thread/thread_load.cuh
@@ -268,24 +268,11 @@ struct IterateThreadLoad<MAX, MAX>
 /**
  * Define powers-of-two ThreadLoad specializations for the various Cache load modifiers
  */
-#if CUB_PTX_ARCH >= 200
-    _CUB_LOAD_ALL(LOAD_CA, ca)
-    _CUB_LOAD_ALL(LOAD_CG, cg)
-    _CUB_LOAD_ALL(LOAD_CS, cs)
-    _CUB_LOAD_ALL(LOAD_CV, cv)
-#else
-    _CUB_LOAD_ALL(LOAD_CA, global)
-    // Use volatile to ensure coherent reads when this PTX is JIT'd to run on newer architectures with L1
-    _CUB_LOAD_ALL(LOAD_CG, volatile.global)
-    _CUB_LOAD_ALL(LOAD_CS, global)
-    _CUB_LOAD_ALL(LOAD_CV, volatile.global)
-#endif
-
-#if CUB_PTX_ARCH >= 350
-    _CUB_LOAD_ALL(LOAD_LDG, global.nc)
-#else
-    _CUB_LOAD_ALL(LOAD_LDG, global)
-#endif
+_CUB_LOAD_ALL(LOAD_CA, ca)
+_CUB_LOAD_ALL(LOAD_CG, cg)
+_CUB_LOAD_ALL(LOAD_CS, cs)
+_CUB_LOAD_ALL(LOAD_CV, cv)
+_CUB_LOAD_ALL(LOAD_LDG, global.nc)
 
 
 // Macro cleanup

--- a/cub/thread/thread_store.cuh
+++ b/cub/thread/thread_store.cuh
@@ -257,18 +257,10 @@ struct IterateThreadStore<MAX, MAX>
 /**
  * Define ThreadStore specializations for the various Cache load modifiers
  */
-#if CUB_PTX_ARCH >= 200
-    _CUB_STORE_ALL(STORE_WB, wb)
-    _CUB_STORE_ALL(STORE_CG, cg)
-    _CUB_STORE_ALL(STORE_CS, cs)
-    _CUB_STORE_ALL(STORE_WT, wt)
-#else
-    _CUB_STORE_ALL(STORE_WB, global)
-    _CUB_STORE_ALL(STORE_CG, global)
-    _CUB_STORE_ALL(STORE_CS, global)
-    _CUB_STORE_ALL(STORE_WT, volatile.global)
-#endif
-
+_CUB_STORE_ALL(STORE_WB, wb)
+_CUB_STORE_ALL(STORE_CG, cg)
+_CUB_STORE_ALL(STORE_CS, cs)
+_CUB_STORE_ALL(STORE_WT, wt)
 
 // Macro cleanup
 #undef _CUB_STORE_ALL

--- a/cub/util_arch.cuh
+++ b/cub/util_arch.cuh
@@ -92,7 +92,7 @@ CUB_NAMESPACE_BEGIN
 
 /// Whether or not the source targeted by the active compiler pass is allowed to  invoke device kernels or methods from the CUDA runtime API.
 #ifndef CUB_RUNTIME_FUNCTION
-    #if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__>= 350 && defined(__CUDACC_RDC__))
+    #if !defined(__CUDA_ARCH__) || defined(__CUDACC_RDC__)
         #define CUB_RUNTIME_ENABLED
         #define CUB_RUNTIME_FUNCTION __host__ __device__
     #else

--- a/cub/util_arch.cuh
+++ b/cub/util_arch.cuh
@@ -83,12 +83,10 @@ CUB_NAMESPACE_BEGIN
 
 /// Maximum number of devices supported.
 #ifndef CUB_MAX_DEVICES
-    #define CUB_MAX_DEVICES 128
+    #define CUB_MAX_DEVICES (128)
 #endif
 
-#if CUB_CPP_DIALECT >= 2011
-    static_assert(CUB_MAX_DEVICES > 0, "CUB_MAX_DEVICES must be greater than 0.");
-#endif
+static_assert(CUB_MAX_DEVICES > 0, "CUB_MAX_DEVICES must be greater than 0.");
 
 /// Whether or not the source targeted by the active compiler pass is allowed to  invoke device kernels or methods from the CUDA runtime API.
 #ifndef CUB_RUNTIME_FUNCTION
@@ -103,49 +101,35 @@ CUB_NAMESPACE_BEGIN
 
 /// Number of threads per warp
 #ifndef CUB_LOG_WARP_THREADS
-    #define CUB_LOG_WARP_THREADS(arch)                      \
-        (5)
-    #define CUB_WARP_THREADS(arch)                          \
-        (1 << CUB_LOG_WARP_THREADS(arch))
+    #define CUB_LOG_WARP_THREADS(unused) (5)
+    #define CUB_WARP_THREADS(unused) (1 << CUB_LOG_WARP_THREADS(0))
 
-    #define CUB_PTX_WARP_THREADS        CUB_WARP_THREADS(CUB_PTX_ARCH)
-    #define CUB_PTX_LOG_WARP_THREADS    CUB_LOG_WARP_THREADS(CUB_PTX_ARCH)
+    #define CUB_PTX_WARP_THREADS        CUB_WARP_THREADS(0)
+    #define CUB_PTX_LOG_WARP_THREADS    CUB_LOG_WARP_THREADS(0)
 #endif
 
 
 /// Number of smem banks
 #ifndef CUB_LOG_SMEM_BANKS
-    #define CUB_LOG_SMEM_BANKS(arch)                        \
-        ((arch >= 200) ?                                    \
-            (5) :                                           \
-            (4))
-    #define CUB_SMEM_BANKS(arch)                            \
-        (1 << CUB_LOG_SMEM_BANKS(arch))
+    #define CUB_LOG_SMEM_BANKS(unused) (5)
+    #define CUB_SMEM_BANKS(unused) (1 << CUB_LOG_SMEM_BANKS(0))
 
-    #define CUB_PTX_LOG_SMEM_BANKS      CUB_LOG_SMEM_BANKS(CUB_PTX_ARCH)
-    #define CUB_PTX_SMEM_BANKS          CUB_SMEM_BANKS(CUB_PTX_ARCH)
+    #define CUB_PTX_LOG_SMEM_BANKS      CUB_LOG_SMEM_BANKS(0)
+    #define CUB_PTX_SMEM_BANKS          CUB_SMEM_BANKS
 #endif
 
 
 /// Oversubscription factor
 #ifndef CUB_SUBSCRIPTION_FACTOR
-    #define CUB_SUBSCRIPTION_FACTOR(arch)                   \
-        ((arch >= 300) ?                                    \
-            (5) :                                           \
-            ((arch >= 200) ?                                \
-                (3) :                                       \
-                (10)))
-    #define CUB_PTX_SUBSCRIPTION_FACTOR             CUB_SUBSCRIPTION_FACTOR(CUB_PTX_ARCH)
+    #define CUB_SUBSCRIPTION_FACTOR(unused) (5)
+    #define CUB_PTX_SUBSCRIPTION_FACTOR CUB_SUBSCRIPTION_FACTOR(0)
 #endif
 
 
 /// Prefer padding overhead vs X-way conflicts greater than this threshold
 #ifndef CUB_PREFER_CONFLICT_OVER_PADDING
-    #define CUB_PREFER_CONFLICT_OVER_PADDING(arch)          \
-        ((arch >= 300) ?                                    \
-            (1) :                                           \
-            (4))
-    #define CUB_PTX_PREFER_CONFLICT_OVER_PADDING    CUB_PREFER_CONFLICT_OVER_PADDING(CUB_PTX_ARCH)
+    #define CUB_PREFER_CONFLICT_OVER_PADDING(unused) (1)
+    #define CUB_PTX_PREFER_CONFLICT_OVER_PADDING CUB_PREFER_CONFLICT_OVER_PADDING(0)
 #endif
 
 

--- a/cub/util_arch.cuh
+++ b/cub/util_arch.cuh
@@ -62,24 +62,32 @@ CUB_NAMESPACE_BEGIN
     #endif
 #endif
 
-#ifndef CUB_IS_DEVICE_CODE
-    #if defined(_NVHPC_CUDA)
-        #define CUB_IS_DEVICE_CODE __builtin_is_device_code()
-        #define CUB_IS_HOST_CODE (!__builtin_is_device_code())
-        #define CUB_INCLUDE_DEVICE_CODE 1
-        #define CUB_INCLUDE_HOST_CODE 1
-    #elif CUB_PTX_ARCH > 0
-        #define CUB_IS_DEVICE_CODE 1
-        #define CUB_IS_HOST_CODE 0
-        #define CUB_INCLUDE_DEVICE_CODE 1
-        #define CUB_INCLUDE_HOST_CODE 0
-    #else
-        #define CUB_IS_DEVICE_CODE 0
-        #define CUB_IS_HOST_CODE 1
-        #define CUB_INCLUDE_DEVICE_CODE 0
-        #define CUB_INCLUDE_HOST_CODE 1
+// These definitions were intended for internal use only and are now obsolete.
+// If you relied on them, consider porting your code to use the functionality
+// in libcu++'s <nv/target> header.
+// For a temporary workaround, define CUB_PROVIDE_LEGACY_ARCH_MACROS to make
+// them available again. These should be considered deprecated and will be
+// fully removed in a future version.
+#ifdef CUB_PROVIDE_LEGACY_ARCH_MACROS
+    #ifndef CUB_IS_DEVICE_CODE
+        #if defined(_NVHPC_CUDA)
+            #define CUB_IS_DEVICE_CODE __builtin_is_device_code()
+            #define CUB_IS_HOST_CODE (!__builtin_is_device_code())
+            #define CUB_INCLUDE_DEVICE_CODE 1
+            #define CUB_INCLUDE_HOST_CODE 1
+        #elif CUB_PTX_ARCH > 0
+            #define CUB_IS_DEVICE_CODE 1
+            #define CUB_IS_HOST_CODE 0
+            #define CUB_INCLUDE_DEVICE_CODE 1
+            #define CUB_INCLUDE_HOST_CODE 0
+        #else
+            #define CUB_IS_DEVICE_CODE 0
+            #define CUB_IS_HOST_CODE 1
+            #define CUB_INCLUDE_DEVICE_CODE 0
+            #define CUB_INCLUDE_HOST_CODE 1
+        #endif
     #endif
-#endif
+#endif // CUB_PROVIDE_LEGACY_ARCH_MACROS
 
 /// Maximum number of devices supported.
 #ifndef CUB_MAX_DEVICES

--- a/cub/util_debug.cuh
+++ b/cub/util_debug.cuh
@@ -36,12 +36,14 @@
 
 #pragma once
 
-#include <stdio.h>
-#include "util_namespace.cuh"
-#include "util_arch.cuh"
+#include <cub/util_namespace.cuh>
+#include <cub/util_arch.cuh>
+
+#include <nv/target>
+
+#include <cstdio>
 
 CUB_NAMESPACE_BEGIN
-
 
 /**
  * \addtogroup UtilMgmt
@@ -54,45 +56,57 @@ CUB_NAMESPACE_BEGIN
     #define CUB_STDERR
 #endif
 
-
-
 /**
- * \brief If \p CUB_STDERR is defined and \p error is not \p cudaSuccess, the corresponding error message is printed to \p stderr (or \p stdout in device code) along with the supplied source context.
+ * \brief %If \p CUB_STDERR is defined and \p error is not \p cudaSuccess, the
+ * corresponding error message is printed to \p stderr (or \p stdout in device
+ * code) along with the supplied source context.
  *
  * \return The CUDA error.
  */
-__host__ __device__ __forceinline__ cudaError_t Debug(
-    cudaError_t     error,
-    const char*     filename,
-    int             line)
+__host__ __device__
+__forceinline__
+cudaError_t Debug(cudaError_t error, const char *filename, int line)
 {
-    (void)filename;
-    (void)line;
+  (void)filename;
+  (void)line;
 
 #ifdef CUB_RUNTIME_ENABLED
-    // Clear the global CUDA error state which may have been set by the last
-    // call. Otherwise, errors may "leak" to unrelated kernel launches.
-    cudaGetLastError();
+  // Clear the global CUDA error state which may have been set by the last
+  // call. Otherwise, errors may "leak" to unrelated kernel launches.
+  cudaGetLastError();
 #endif
 
 #ifdef CUB_STDERR
-    if (error)
-    {
-        if (CUB_IS_HOST_CODE) {
-            #if CUB_INCLUDE_HOST_CODE
-                fprintf(stderr, "CUDA error %d [%s, %d]: %s\n", error, filename, line, cudaGetErrorString(error));
-                fflush(stderr);
-            #endif
-        } else {
-            #if CUB_INCLUDE_DEVICE_CODE
-                printf("CUDA error %d [block (%d,%d,%d) thread (%d,%d,%d), %s, %d]\n", error, blockIdx.z, blockIdx.y, blockIdx.x, threadIdx.z, threadIdx.y, threadIdx.x, filename, line);
-            #endif
-        }
-    }
+  if (error)
+  {
+    NV_IF_TARGET(
+      NV_IS_HOST, (
+        fprintf(stderr,
+                "CUDA error %d [%s, %d]: %s\n",
+                error,
+                filename,
+                line,
+                cudaGetErrorString(error));
+        fflush(stderr);
+      ),
+      (
+        printf("CUDA error %d [block (%d,%d,%d) thread (%d,%d,%d), %s, %d]\n",
+               error,
+               blockIdx.z,
+               blockIdx.y,
+               blockIdx.x,
+               threadIdx.z,
+               threadIdx.y,
+               threadIdx.x,
+               filename,
+               line);
+      )
+    );
+  }
 #endif
-    return error;
-}
 
+  return error;
+}
 
 /**
  * \brief Debug macro
@@ -114,43 +128,58 @@ __host__ __device__ __forceinline__ cudaError_t Debug(
  * \brief Log macro for printf statements.
  */
 #if !defined(_CubLog)
-    #if defined(_NVHPC_CUDA)
-        #define _CubLog(format, ...) (__builtin_is_device_code() \
-            ? printf("[block (%d,%d,%d), thread (%d,%d,%d)]: " format, \
-                     blockIdx.z, blockIdx.y, blockIdx.x, \
-                     threadIdx.z, threadIdx.y, threadIdx.x, __VA_ARGS__) \
-            : printf(format, __VA_ARGS__));
-    #elif !(defined(__clang__) && defined(__CUDA__))
-        #if (CUB_PTX_ARCH == 0)
-            #define _CubLog(format, ...) printf(format,__VA_ARGS__);
-        #elif (CUB_PTX_ARCH >= 200)
-            #define _CubLog(format, ...) printf("[block (%d,%d,%d), thread (%d,%d,%d)]: " format, blockIdx.z, blockIdx.y, blockIdx.x, threadIdx.z, threadIdx.y, threadIdx.x, __VA_ARGS__);
-        #endif
-    #else
-        // XXX shameless hack for clang around variadic printf...
-        //     Compilies w/o supplying -std=c++11 but shows warning,
-        //     so we sielence them :)
-        #pragma clang diagnostic ignored "-Wc++11-extensions"
-        #pragma clang diagnostic ignored "-Wunnamed-type-template-args"
-            template <class... Args>
-            inline __host__ __device__ void va_printf(char const* format, Args const&... args)
-            {
-        #ifdef __CUDA_ARCH__
-              printf(format, blockIdx.z, blockIdx.y, blockIdx.x, threadIdx.z, threadIdx.y, threadIdx.x, args...);
-        #else
-              printf(format, args...);
-        #endif
-            }
-        #ifndef __CUDA_ARCH__
-            #define _CubLog(format, ...) CUB_NS_QUALIFIER::va_printf(format,__VA_ARGS__);
-        #else
-            #define _CubLog(format, ...) CUB_NS_QUALIFIER::va_printf("[block (%d,%d,%d), thread (%d,%d,%d)]: " format, __VA_ARGS__);
-        #endif
-    #endif
+#if defined(_NVHPC_CUDA) || !(defined(__clang__) && defined(__CUDA__))
+
+// NVCC / NVC++
+#define _CubLog(format, ...)                                                   \
+  do                                                                           \
+  {                                                                            \
+    NV_IF_TARGET(NV_IS_HOST,                                                   \
+                 (printf(format, __VA_ARGS__);),                               \
+                 (printf("[block (%d,%d,%d), thread (%d,%d,%d)]: " format,     \
+                         blockIdx.z,                                           \
+                         blockIdx.y,                                           \
+                         blockIdx.x,                                           \
+                         threadIdx.z,                                          \
+                         threadIdx.y,                                          \
+                         threadIdx.x,                                          \
+                         __VA_ARGS__);));                                      \
+  } while (false)
+
+#else // Clang:
+
+// XXX shameless hack for clang around variadic printf...
+//     Compilies w/o supplying -std=c++11 but shows warning,
+//     so we silence them :)
+#pragma clang diagnostic ignored "-Wc++11-extensions"
+#pragma clang diagnostic ignored "-Wunnamed-type-template-args"
+template <class... Args>
+inline __host__ __device__ void va_printf(char const *format,
+                                          Args const &...args)
+{
+#ifdef __CUDA_ARCH__
+  printf(format,
+         blockIdx.z,
+         blockIdx.y,
+         blockIdx.x,
+         threadIdx.z,
+         threadIdx.y,
+         threadIdx.x,
+         args...);
+#else
+  printf(format, args...);
 #endif
-
-
-
+}
+#ifndef __CUDA_ARCH__
+#define _CubLog(format, ...) CUB_NS_QUALIFIER::va_printf(format, __VA_ARGS__);
+#else
+#define _CubLog(format, ...)                                                   \
+  CUB_NS_QUALIFIER::va_printf("[block (%d,%d,%d), thread "                     \
+                              "(%d,%d,%d)]: " format,                          \
+                              __VA_ARGS__);
+#endif
+#endif
+#endif
 
 /** @} */       // end group UtilMgmt
 

--- a/cub/util_ptx.cuh
+++ b/cub/util_ptx.cuh
@@ -442,17 +442,15 @@ __device__ __forceinline__ unsigned int WarpId()
  *                              hardware warp threads).
  * @param warp_id Id of virtual warp within architectural warp
  */
-template <int LOGICAL_WARP_THREADS,
-          int PTX_ARCH = CUB_PTX_ARCH>
+template <int LOGICAL_WARP_THREADS, int LEGACY_PTX_ARCH = 0>
 __host__ __device__ __forceinline__
 unsigned int WarpMask(unsigned int warp_id)
 {
   constexpr bool is_pow_of_two = PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE;
-  constexpr bool is_arch_warp = LOGICAL_WARP_THREADS ==
-                                CUB_WARP_THREADS(PTX_ARCH);
+  constexpr bool is_arch_warp  = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
 
-  unsigned int member_mask =
-    0xFFFFFFFFu >> (CUB_WARP_THREADS(PTX_ARCH) - LOGICAL_WARP_THREADS);
+  unsigned int member_mask = 0xFFFFFFFFu >>
+                             (CUB_WARP_THREADS(0) - LOGICAL_WARP_THREADS);
 
   if (is_pow_of_two && !is_arch_warp)
   {

--- a/cub/util_type.cuh
+++ b/cub/util_type.cuh
@@ -445,13 +445,8 @@ template <>
 struct UnitWord <float2>
 {
     typedef int         ShuffleWord;
-#if (CUB_PTX_ARCH > 0) && (CUB_PTX_ARCH <= 130)
-    typedef float       VolatileWord;
-    typedef uint2       DeviceWord;
-#else
     typedef unsigned long long   VolatileWord;
     typedef unsigned long long   DeviceWord;
-#endif
     typedef float2      TextureWord;
 };
 
@@ -460,13 +455,8 @@ template <>
 struct UnitWord <float4>
 {
     typedef int         ShuffleWord;
-#if (CUB_PTX_ARCH > 0) && (CUB_PTX_ARCH <= 130)
-    typedef float               VolatileWord;
-    typedef uint4               DeviceWord;
-#else
     typedef unsigned long long  VolatileWord;
     typedef ulonglong2          DeviceWord;
-#endif
     typedef float4              TextureWord;
 };
 
@@ -476,13 +466,8 @@ template <>
 struct UnitWord <char2>
 {
     typedef unsigned short      ShuffleWord;
-#if (CUB_PTX_ARCH > 0) && (CUB_PTX_ARCH <= 130)
-    typedef unsigned short      VolatileWord;
-    typedef short               DeviceWord;
-#else
     typedef unsigned short      VolatileWord;
     typedef unsigned short      DeviceWord;
-#endif
     typedef unsigned short      TextureWord;
 };
 

--- a/cub/warp/specializations/warp_reduce_shfl.cuh
+++ b/cub/warp/specializations/warp_reduce_shfl.cuh
@@ -51,7 +51,7 @@ CUB_NAMESPACE_BEGIN
 template <
     typename    T,                      ///< Data type being reduced
     int         LOGICAL_WARP_THREADS,   ///< Number of threads per logical warp
-    int         PTX_ARCH>               ///< The PTX compute capability for which to to specialize this collective
+    int         LEGACY_PTX_ARCH = 0>    ///< The PTX compute capability for which to to specialize this collective
 struct WarpReduceShfl
 {
     static_assert(PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE,
@@ -64,16 +64,16 @@ struct WarpReduceShfl
     enum
     {
         /// Whether the logical warp size and the PTX warp size coincide
-        IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(PTX_ARCH)),
+        IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0)),
 
         /// The number of warp reduction steps
         STEPS = Log2<LOGICAL_WARP_THREADS>::VALUE,
 
         /// Number of logical warps in a PTX warp
-        LOGICAL_WARPS = CUB_WARP_THREADS(PTX_ARCH) / LOGICAL_WARP_THREADS,
+        LOGICAL_WARPS = CUB_WARP_THREADS(0) / LOGICAL_WARP_THREADS,
 
         /// The 5-bit SHFL mask for logically splitting warps into sub-segments starts 8-bits up
-        SHFL_C = (CUB_WARP_THREADS(PTX_ARCH) - LOGICAL_WARP_THREADS) << 8
+        SHFL_C = (CUB_WARP_THREADS(0) - LOGICAL_WARP_THREADS) << 8
 
     };
 
@@ -114,7 +114,7 @@ struct WarpReduceShfl
         TempStorage &/*temp_storage*/)
         : lane_id(static_cast<int>(LaneId()))
         , warp_id(IS_ARCH_WARP ? 0 : (lane_id / LOGICAL_WARP_THREADS))
-        , member_mask(WarpMask<LOGICAL_WARP_THREADS, PTX_ARCH>(warp_id))
+        , member_mask(WarpMask<LOGICAL_WARP_THREADS>(warp_id))
     {
         if (!IS_ARCH_WARP)
         {

--- a/cub/warp/specializations/warp_reduce_smem.cuh
+++ b/cub/warp/specializations/warp_reduce_smem.cuh
@@ -47,7 +47,7 @@ CUB_NAMESPACE_BEGIN
 template <
     typename    T,                      ///< Data type being reduced
     int         LOGICAL_WARP_THREADS,   ///< Number of threads per logical warp
-    int         PTX_ARCH>               ///< The PTX compute capability for which to to specialize this collective
+    int         LEGACY_PTX_ARCH = 0>    ///< The PTX compute capability for which to to specialize this collective
 struct WarpReduceSmem
 {
     /******************************************************************************
@@ -57,7 +57,7 @@ struct WarpReduceSmem
     enum
     {
         /// Whether the logical warp size and the PTX warp size coincide
-        IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(PTX_ARCH)),
+        IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0)),
 
         /// Whether the logical warp size is a power-of-two
         IS_POW_OF_TWO = PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE,
@@ -109,8 +109,7 @@ struct WarpReduceSmem
         : temp_storage(temp_storage.Alias())
         , lane_id(IS_ARCH_WARP ? LaneId() : LaneId() % LOGICAL_WARP_THREADS)
         , member_mask(
-            WarpMask<LOGICAL_WARP_THREADS, PTX_ARCH>(
-              LaneId() / LOGICAL_WARP_THREADS))
+            WarpMask<LOGICAL_WARP_THREADS>(LaneId() / LOGICAL_WARP_THREADS))
     {}
 
     /******************************************************************************

--- a/cub/warp/specializations/warp_reduce_smem.cuh
+++ b/cub/warp/specializations/warp_reduce_smem.cuh
@@ -351,7 +351,7 @@ struct WarpReduceSmem
         FlagT            flag,               ///< [in] Whether or not the current lane is a segment head/tail
         ReductionOp     reduction_op)       ///< [in] Reduction operator
     {
-        return SegmentedReduce<HEAD_SEGMENTED>(input, flag, reduction_op, Int2Type<(PTX_ARCH >= 200)>());
+        return SegmentedReduce<HEAD_SEGMENTED>(input, flag, reduction_op, Int2Type<true>());
     }
 
 

--- a/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/warp/specializations/warp_scan_shfl.cuh
@@ -48,7 +48,7 @@ CUB_NAMESPACE_BEGIN
 template <
     typename    T,                      ///< Data type being scanned
     int         LOGICAL_WARP_THREADS,   ///< Number of threads per logical warp
-    int         PTX_ARCH>               ///< The PTX compute capability for which to to specialize this collective
+    int         LEGACY_PTX_ARCH = 0>    ///< The PTX compute capability for which to to specialize this collective
 struct WarpScanShfl
 {
     //---------------------------------------------------------------------
@@ -58,13 +58,13 @@ struct WarpScanShfl
     enum
     {
         /// Whether the logical warp size and the PTX warp size coincide
-        IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(PTX_ARCH)),
+        IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0)),
 
         /// The number of warp scan steps
         STEPS = Log2<LOGICAL_WARP_THREADS>::VALUE,
 
         /// The 5-bit SHFL mask for logically splitting warps into sub-segments starts 8-bits up
-        SHFL_C = (CUB_WARP_THREADS(PTX_ARCH) - LOGICAL_WARP_THREADS) << 8
+        SHFL_C = (CUB_WARP_THREADS(0) - LOGICAL_WARP_THREADS) << 8
     };
 
     template <typename S>
@@ -102,7 +102,7 @@ struct WarpScanShfl
     WarpScanShfl(TempStorage & /*temp_storage*/)
         : lane_id(LaneId())
         , warp_id(IS_ARCH_WARP ? 0 : (lane_id / LOGICAL_WARP_THREADS))
-        , member_mask(WarpMask<LOGICAL_WARP_THREADS, PTX_ARCH>(warp_id))
+        , member_mask(WarpMask<LOGICAL_WARP_THREADS>(warp_id))
     {
         if (!IS_ARCH_WARP)
         {

--- a/cub/warp/specializations/warp_scan_smem.cuh
+++ b/cub/warp/specializations/warp_scan_smem.cuh
@@ -47,7 +47,7 @@ CUB_NAMESPACE_BEGIN
 template <
     typename    T,                      ///< Data type being scanned
     int         LOGICAL_WARP_THREADS,   ///< Number of threads per logical warp
-    int         PTX_ARCH>               ///< The PTX compute capability for which to to specialize this collective
+    int         LEGACY_PTX_ARCH = 0>    ///< The PTX compute capability for which to to specialize this collective
 struct WarpScanSmem
 {
     /******************************************************************************
@@ -57,7 +57,7 @@ struct WarpScanSmem
     enum
     {
         /// Whether the logical warp size and the PTX warp size coincide
-        IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(PTX_ARCH)),
+        IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0)),
 
         /// The number of warp scan steps
         STEPS = Log2<LOGICAL_WARP_THREADS>::VALUE,
@@ -103,8 +103,7 @@ struct WarpScanSmem
             LaneId() % LOGICAL_WARP_THREADS),
 
         member_mask(
-          WarpMask<LOGICAL_WARP_THREADS, PTX_ARCH>(
-            LaneId() / LOGICAL_WARP_THREADS))
+          WarpMask<LOGICAL_WARP_THREADS>(LaneId() / LOGICAL_WARP_THREADS))
     {}
 
 

--- a/cub/warp/warp_exchange.cuh
+++ b/cub/warp/warp_exchange.cuh
@@ -58,8 +58,8 @@ CUB_NAMESPACE_BEGIN
  *   targeted CUDA compute-capability (e.g., 32 threads for SM86). Must be a
  *   power of two.
  *
- * @tparam PTX_ARCH
- *   <b>[optional]</b> \ptxversion
+ * @tparam LEGACY_PTX_ARCH
+ *   Unused.
  *
  * @par Overview
  * - It is commonplace for a warp of threads to rearrange data items between
@@ -114,7 +114,7 @@ CUB_NAMESPACE_BEGIN
 template <typename InputT,
           int ITEMS_PER_THREAD,
           int LOGICAL_WARP_THREADS  = CUB_PTX_WARP_THREADS,
-          int PTX_ARCH              = CUB_PTX_ARCH>
+          int LEGACY_PTX_ARCH       = 0>
 class WarpExchange
 {
   static_assert(PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE,
@@ -123,10 +123,9 @@ class WarpExchange
   constexpr static int ITEMS_PER_TILE =
     ITEMS_PER_THREAD * LOGICAL_WARP_THREADS + 1;
 
-  constexpr static bool IS_ARCH_WARP = LOGICAL_WARP_THREADS ==
-                                       CUB_WARP_THREADS(PTX_ARCH);
+  constexpr static bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
 
-  constexpr static int LOG_SMEM_BANKS = CUB_LOG_SMEM_BANKS(PTX_ARCH);
+  constexpr static int LOG_SMEM_BANKS = CUB_LOG_SMEM_BANKS(0);
 
   // Insert padding if the number of items per thread is a power of two
   // and > 4 (otherwise we can typically use 128b loads)

--- a/cub/warp/warp_load.cuh
+++ b/cub/warp/warp_load.cuh
@@ -141,8 +141,8 @@ enum WarpLoadAlgorithm
  *   targeted CUDA compute-capability (e.g., 32 threads for SM86). Must be a
  *   power of two.
  *
- * @tparam PTX_ARCH
- *   <b>[optional]</b> \ptxversion
+ * @tparam LEGACY_PTX_ARCH
+ *   Unused.
  *
  * @par Overview
  * - The WarpLoad class provides a single data movement abstraction that can be
@@ -206,11 +206,10 @@ template <typename          InputT,
           int               ITEMS_PER_THREAD,
           WarpLoadAlgorithm ALGORITHM            = WARP_LOAD_DIRECT,
           int               LOGICAL_WARP_THREADS = CUB_PTX_WARP_THREADS,
-          int               PTX_ARCH             = CUB_PTX_ARCH>
+          int               LEGACY_PTX_ARCH      = 0>
 class WarpLoad
 {
-  constexpr static bool IS_ARCH_WARP = LOGICAL_WARP_THREADS ==
-                                       CUB_WARP_THREADS(PTX_ARCH);
+  constexpr static bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
 
   static_assert(PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE,
                 "LOGICAL_WARP_THREADS must be a power of two");
@@ -397,7 +396,7 @@ private:
   struct LoadInternal<WARP_LOAD_TRANSPOSE, DUMMY>
   {
     using WarpExchangeT =
-      WarpExchange<InputT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS, PTX_ARCH>;
+      WarpExchange<InputT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS>;
 
     struct _TempStorage : WarpExchangeT::TempStorage
     {};

--- a/cub/warp/warp_merge_sort.cuh
+++ b/cub/warp/warp_merge_sort.cuh
@@ -57,8 +57,8 @@ CUB_NAMESPACE_BEGIN
  *   <b>[optional]</b> Value type (default: cub::NullType, which indicates a
  *   keys-only sort)
  *
- * @tparam PTX_ARCH
- *   <b>[optional]</b> \ptxversion
+ * @tparam LEGACY_PTX_ARCH
+ *   Unused.
  *
  * @par Overview
  *   WarpMergeSort arranges items into ascending order using a comparison
@@ -115,19 +115,19 @@ CUB_NAMESPACE_BEGIN
 template <
   typename    KeyT,
   int         ITEMS_PER_THREAD,
-  int         LOGICAL_WARP_THREADS    = CUB_PTX_WARP_THREADS,
+  int         LOGICAL_WARP_THREADS    = CUB_WARP_THREADS(0),
   typename    ValueT                  = NullType,
-  int         PTX_ARCH                = CUB_PTX_ARCH>
+  int         LEGACY_PTX_ARCH         = 0>
 class WarpMergeSort
     : public BlockMergeSortStrategy<
         KeyT,
         ValueT,
         LOGICAL_WARP_THREADS,
         ITEMS_PER_THREAD,
-        WarpMergeSort<KeyT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS, ValueT, PTX_ARCH>>
+        WarpMergeSort<KeyT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS, ValueT>>
 {
 private:
-  constexpr static bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(PTX_ARCH);
+  constexpr static bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
   constexpr static bool KEYS_ONLY = std::is_same<ValueT, NullType>::value;
   constexpr static int TILE_SIZE = ITEMS_PER_THREAD * LOGICAL_WARP_THREADS;
 
@@ -150,7 +150,7 @@ public:
                                   ? LaneId()
                                   : (LaneId() % LOGICAL_WARP_THREADS))
       , warp_id(IS_ARCH_WARP ? 0 : (LaneId() / LOGICAL_WARP_THREADS))
-      , member_mask(WarpMask<LOGICAL_WARP_THREADS, PTX_ARCH>(warp_id))
+      , member_mask(WarpMask<LOGICAL_WARP_THREADS>(warp_id))
   {
   }
 

--- a/cub/warp/warp_reduce.cuh
+++ b/cub/warp/warp_reduce.cuh
@@ -152,7 +152,7 @@ private:
 
 public:
 
-    #ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
+#ifndef DOXYGEN_SHOULD_SKIP_THIS    // Do not document
 
     /// Internal specialization.
     /// Use SHFL-based reduction if LOGICAL_WARP_THREADS is a power-of-two

--- a/cub/warp/warp_reduce.cuh
+++ b/cub/warp/warp_reduce.cuh
@@ -52,7 +52,7 @@ CUB_NAMESPACE_BEGIN
  *
  * \tparam T                        The reduction input/output element type
  * \tparam LOGICAL_WARP_THREADS     <b>[optional]</b> The number of threads per "logical" warp (may be less than the number of hardware warp threads).  Default is the warp size of the targeted CUDA compute-capability (e.g., 32 threads for SM20).
- * \tparam PTX_ARCH                 <b>[optional]</b> \ptxversion
+ * \tparam LEGACY_PTX_ARCH          <b>[optional]</b> Unused.
  *
  * \par Overview
  * - A <a href="http://en.wikipedia.org/wiki/Reduce_(higher-order_function)"><em>reduction</em></a> (or <em>fold</em>)
@@ -132,7 +132,7 @@ CUB_NAMESPACE_BEGIN
 template <
     typename    T,
     int         LOGICAL_WARP_THREADS    = CUB_PTX_WARP_THREADS,
-    int         PTX_ARCH                = CUB_PTX_ARCH>
+    int         LEGACY_PTX_ARCH         = 0>
 class WarpReduce
 {
 private:
@@ -144,7 +144,7 @@ private:
     enum
     {
         /// Whether the logical warp size and the PTX warp size coincide
-        IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(PTX_ARCH)),
+        IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0)),
 
         /// Whether the logical warp size is a power-of-two
         IS_POW_OF_TWO = PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE,
@@ -158,8 +158,8 @@ public:
     /// Use SHFL-based reduction if LOGICAL_WARP_THREADS is a power-of-two
     using InternalWarpReduce = cub::detail::conditional_t<
       IS_POW_OF_TWO,
-      WarpReduceShfl<T, LOGICAL_WARP_THREADS, PTX_ARCH>,
-      WarpReduceSmem<T, LOGICAL_WARP_THREADS, PTX_ARCH>>;
+      WarpReduceShfl<T, LOGICAL_WARP_THREADS>,
+      WarpReduceSmem<T, LOGICAL_WARP_THREADS>>;
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 

--- a/cub/warp/warp_scan.cuh
+++ b/cub/warp/warp_scan.cuh
@@ -51,7 +51,7 @@ CUB_NAMESPACE_BEGIN
  *
  * \tparam T                        The scan input/output element type
  * \tparam LOGICAL_WARP_THREADS     <b>[optional]</b> The number of threads per "logical" warp (may be less than the number of hardware warp threads).  Default is the warp size associated with the CUDA Compute Capability targeted by the compiler (e.g., 32 threads for SM20).
- * \tparam PTX_ARCH                 <b>[optional]</b> \ptxversion
+ * \tparam LEGACY_PTX_ARCH          <b>[optional]</b> Unused.
  *
  * \par Overview
  * - Given a list of input elements and a binary reduction operator, a [<em>prefix scan</em>](http://en.wikipedia.org/wiki/Prefix_sum)
@@ -137,7 +137,7 @@ CUB_NAMESPACE_BEGIN
 template <
     typename    T,
     int         LOGICAL_WARP_THREADS    = CUB_PTX_WARP_THREADS,
-    int         PTX_ARCH                = CUB_PTX_ARCH>
+    int         LEGACY_PTX_ARCH         = 0>
 class WarpScan
 {
 private:
@@ -149,7 +149,7 @@ private:
     enum
     {
         /// Whether the logical warp size and the PTX warp size coincide
-        IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(PTX_ARCH)),
+        IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0)),
 
         /// Whether the logical warp size is a power-of-two
         IS_POW_OF_TWO = ((LOGICAL_WARP_THREADS & (LOGICAL_WARP_THREADS - 1)) == 0),
@@ -162,8 +162,8 @@ private:
     /// Use SHFL-based scan if LOGICAL_WARP_THREADS is a power-of-two
     using InternalWarpScan = cub::detail::conditional_t<
       IS_POW_OF_TWO,
-      WarpScanShfl<T, LOGICAL_WARP_THREADS, PTX_ARCH>,
-      WarpScanSmem<T, LOGICAL_WARP_THREADS, PTX_ARCH>>;
+      WarpScanShfl<T, LOGICAL_WARP_THREADS>,
+      WarpScanSmem<T, LOGICAL_WARP_THREADS>>;
 
     /// Shared memory storage layout type for WarpScan
     typedef typename InternalWarpScan::TempStorage _TempStorage;

--- a/cub/warp/warp_store.cuh
+++ b/cub/warp/warp_store.cuh
@@ -136,8 +136,8 @@ enum WarpStoreAlgorithm
  *   targeted CUDA compute-capability (e.g., 32 threads for SM86). Must be a
  *   power of two.
  *
- * @tparam PTX_ARCH
- *   <b>[optional]</b> \ptxversion
+ * @tparam LEGACY_PTX_ARCH
+ *   Unused.
  *
  * @par Overview
  * - The WarpStore class provides a single data movement abstraction that can be
@@ -204,14 +204,13 @@ template <typename           T,
           int                ITEMS_PER_THREAD,
           WarpStoreAlgorithm ALGORITHM            = WARP_STORE_DIRECT,
           int                LOGICAL_WARP_THREADS = CUB_PTX_WARP_THREADS,
-          int                PTX_ARCH             = CUB_PTX_ARCH>
+          int                LEGACY_PTX_ARCH      = 0>
 class WarpStore
 {
   static_assert(PowerOfTwo<LOGICAL_WARP_THREADS>::VALUE,
                 "LOGICAL_WARP_THREADS must be a power of two");
 
-  constexpr static bool IS_ARCH_WARP = LOGICAL_WARP_THREADS ==
-                                       CUB_WARP_THREADS(PTX_ARCH);
+  constexpr static bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
 
 private:
 
@@ -319,7 +318,7 @@ private:
   struct StoreInternal<WARP_STORE_TRANSPOSE, DUMMY>
   {
     using WarpExchangeT =
-      WarpExchange<T, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS, PTX_ARCH>;
+      WarpExchange<T, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS>;
 
     struct _TempStorage : WarpExchangeT::TempStorage
     {};

--- a/test/test_device_segmented_sort.cu
+++ b/test/test_device_segmented_sort.cu
@@ -29,6 +29,9 @@
 #define CUB_STDERR
 
 #include <cub/device/device_segmented_sort.cuh>
+
+#include <nv/target>
+
 #include <test_util.h>
 
 #include <thrust/count.h>
@@ -1500,61 +1503,56 @@ struct EdgeTestDispatch
   template <typename ActivePolicyT>
   CUB_RUNTIME_FUNCTION __forceinline__ cudaError_t Invoke()
   {
-    if (CUB_IS_HOST_CODE)
-    {
-      #if CUB_INCLUDE_HOST_CODE
-      using SmallAndMediumPolicyT =
-        typename ActivePolicyT::SmallAndMediumSegmentedSortPolicyT;
-      using LargeSegmentPolicyT = typename ActivePolicyT::LargeSegmentPolicy;
+    NV_IF_TARGET(NV_IS_HOST,
+      (using SmallAndMediumPolicyT =
+         typename ActivePolicyT::SmallAndMediumSegmentedSortPolicyT;
+       using LargeSegmentPolicyT = typename ActivePolicyT::LargeSegmentPolicy;
 
-      const int small_segment_max_segment_size =
-        SmallAndMediumPolicyT::SmallPolicyT::ITEMS_PER_TILE;
+       const int small_segment_max_segment_size =
+         SmallAndMediumPolicyT::SmallPolicyT::ITEMS_PER_TILE;
 
-      const int items_per_small_segment =
-        SmallAndMediumPolicyT::SmallPolicyT::ITEMS_PER_THREAD;
+       const int items_per_small_segment =
+         SmallAndMediumPolicyT::SmallPolicyT::ITEMS_PER_THREAD;
 
-      const int medium_segment_max_segment_size =
-        SmallAndMediumPolicyT::MediumPolicyT::ITEMS_PER_TILE;
+       const int medium_segment_max_segment_size =
+         SmallAndMediumPolicyT::MediumPolicyT::ITEMS_PER_TILE;
 
-      const int single_thread_segment_size = items_per_small_segment;
+       const int single_thread_segment_size = items_per_small_segment;
 
-      const int large_cached_segment_max_segment_size =
-        LargeSegmentPolicyT::BLOCK_THREADS *
-        LargeSegmentPolicyT::ITEMS_PER_THREAD;
+       const int large_cached_segment_max_segment_size =
+         LargeSegmentPolicyT::BLOCK_THREADS *
+         LargeSegmentPolicyT::ITEMS_PER_THREAD;
 
-      for (bool sort_descending : {ascending, descending})
-      {
-        Input<KeyT, ValueT> edge_cases =
-          InputDescription<KeyT>()
-            .add({a_lot_of, empty_short_circuit_segment_size})
-            .add({a_lot_of, copy_short_circuit_segment_size})
-            .add({a_lot_of, swap_short_circuit_segment_size})
-            .add({a_lot_of, swap_short_circuit_segment_size + 1})
-            .add({a_lot_of, swap_short_circuit_segment_size + 1})
-            .add({a_lot_of, single_thread_segment_size - 1})
-            .add({a_lot_of, single_thread_segment_size })
-            .add({a_lot_of, single_thread_segment_size + 1 })
-            .add({a_lot_of, single_thread_segment_size * 2 - 1 })
-            .add({a_lot_of, single_thread_segment_size * 2 })
-            .add({a_lot_of, single_thread_segment_size * 2 + 1 })
-            .add({a_bunch_of, small_segment_max_segment_size - 1})
-            .add({a_bunch_of, small_segment_max_segment_size})
-            .add({a_bunch_of, small_segment_max_segment_size + 1})
-            .add({a_bunch_of, medium_segment_max_segment_size - 1})
-            .add({a_bunch_of, medium_segment_max_segment_size})
-            .add({a_bunch_of, medium_segment_max_segment_size + 1})
-            .add({a_bunch_of, large_cached_segment_max_segment_size - 1})
-            .add({a_bunch_of, large_cached_segment_max_segment_size})
-            .add({a_bunch_of, large_cached_segment_max_segment_size + 1})
-            .add({a_few, large_cached_segment_max_segment_size * 2})
-            .add({a_few, large_cached_segment_max_segment_size * 3})
-            .add({a_few, large_cached_segment_max_segment_size * 5})
-            .template gen<ValueT>(sort_descending);
+       for (bool sort_descending : {ascending, descending}) {
+         Input<KeyT, ValueT> edge_cases =
+           InputDescription<KeyT>()
+             .add({a_lot_of, empty_short_circuit_segment_size})
+             .add({a_lot_of, copy_short_circuit_segment_size})
+             .add({a_lot_of, swap_short_circuit_segment_size})
+             .add({a_lot_of, swap_short_circuit_segment_size + 1})
+             .add({a_lot_of, swap_short_circuit_segment_size + 1})
+             .add({a_lot_of, single_thread_segment_size - 1})
+             .add({a_lot_of, single_thread_segment_size})
+             .add({a_lot_of, single_thread_segment_size + 1})
+             .add({a_lot_of, single_thread_segment_size * 2 - 1})
+             .add({a_lot_of, single_thread_segment_size * 2})
+             .add({a_lot_of, single_thread_segment_size * 2 + 1})
+             .add({a_bunch_of, small_segment_max_segment_size - 1})
+             .add({a_bunch_of, small_segment_max_segment_size})
+             .add({a_bunch_of, small_segment_max_segment_size + 1})
+             .add({a_bunch_of, medium_segment_max_segment_size - 1})
+             .add({a_bunch_of, medium_segment_max_segment_size})
+             .add({a_bunch_of, medium_segment_max_segment_size + 1})
+             .add({a_bunch_of, large_cached_segment_max_segment_size - 1})
+             .add({a_bunch_of, large_cached_segment_max_segment_size})
+             .add({a_bunch_of, large_cached_segment_max_segment_size + 1})
+             .add({a_few, large_cached_segment_max_segment_size * 2})
+             .add({a_few, large_cached_segment_max_segment_size * 3})
+             .add({a_few, large_cached_segment_max_segment_size * 5})
+             .template gen<ValueT>(sort_descending);
 
-        InputTest<KeyT, ValueT>(sort_descending, edge_cases);
-      }
-      #endif
-    }
+         InputTest<KeyT, ValueT>(sort_descending, edge_cases);
+       }));
 
     return cudaSuccess;
   }

--- a/test/test_iterator.cu
+++ b/test/test_iterator.cu
@@ -506,8 +506,7 @@ int main(int argc, char** argv)
     Test<long>();
     Test<long long>();
     Test<float>();
-    if (ptx_version > 120)                          // Don't check doubles on PTX120 or below because they're down-converted
-        Test<double>();
+    Test<double>();
 
     Test<char2>();
     Test<short2>();
@@ -515,8 +514,7 @@ int main(int argc, char** argv)
     Test<long2>();
     Test<longlong2>();
     Test<float2>();
-    if (ptx_version > 120)                          // Don't check doubles on PTX120 or below because they're down-converted
-        Test<double2>();
+    Test<double2>();
 
     Test<char3>();
     Test<short3>();
@@ -524,8 +522,7 @@ int main(int argc, char** argv)
     Test<long3>();
     Test<longlong3>();
     Test<float3>();
-    if (ptx_version > 120)                          // Don't check doubles on PTX120 or below because they're down-converted
-        Test<double3>();
+    Test<double3>();
 
     Test<char4>();
     Test<short4>();
@@ -533,8 +530,7 @@ int main(int argc, char** argv)
     Test<long4>();
     Test<longlong4>();
     Test<float4>();
-    if (ptx_version > 120)                          // Don't check doubles on PTX120 or below because they're down-converted
-        Test<double4>();
+    Test<double4>();
 
     Test<TestFoo>();
     Test<TestBar>();

--- a/test/test_util.h
+++ b/test/test_util.h
@@ -714,22 +714,18 @@ __host__ __device__ __forceinline__ void InitValue(
     // This specialization only appears to be used by test_warp_scan.
     // It initializes with uniform values and random keys, so we need to
     // protect the call to the host-only RandomBits.
-    if (CUB_IS_DEVICE_CODE)
-    {
-        #if CUB_INCLUDE_DEVICE_CODE
-            _CubLog("%s\n",
-                    "cub::InitValue cannot generate random numbers on device.");
-            CUB_NS_QUALIFIER::ThreadTrap();
-        #endif // CUB_INCLUDE_DEVICE_CODE
-    }
-    else
-    {
-        #if CUB_INCLUDE_HOST_CODE
-            // Assign corresponding flag with a likelihood of the last bit being set with entropy-reduction level 3
-            RandomBits(value.key, 3);
-            value.key = (value.key & 0x1);
-        #endif // CUB_INCLUDE_HOST_CODE
-    }
+    // clang-format off
+    NV_IF_TARGET(NV_IS_HOST, (
+        // Assign corresponding flag with a likelihood of the last bit
+        // being set with entropy-reduction level 3
+        RandomBits(value.key, 3);
+        value.key = (value.key & 0x1);
+      ), ( // NV_IS_DEVICE
+        _CubLog("%s\n",
+                "cub::InitValue cannot generate random numbers on device.");
+        CUB_NS_QUALIFIER::ThreadTrap();
+      ));
+    // clang-format on
 }
 
 

--- a/test/test_util.h
+++ b/test/test_util.h
@@ -51,13 +51,16 @@
 #include "half.h"
 #include "bfloat16.h"
 
-#include "cub/util_debug.cuh"
-#include "cub/util_device.cuh"
-#include "cub/util_type.cuh"
-#include "cub/util_macro.cuh"
-#include "cub/util_math.cuh"
-#include "cub/util_ptx.cuh"
-#include "cub/iterator/discard_output_iterator.cuh"
+#include <cub/util_debug.cuh>
+#include <cub/util_device.cuh>
+#include <cub/util_type.cuh>
+#include <cub/util_macro.cuh>
+#include <cub/util_math.cuh>
+#include <cub/util_namespace.cuh>
+#include <cub/util_ptx.cuh>
+#include <cub/iterator/discard_output_iterator.cuh>
+
+#include <nv/target>
 
 /******************************************************************************
  * Type conversion macros
@@ -569,82 +572,74 @@ enum GenMode
  */
 #pragma nv_exec_check_disable
 template <typename T>
-__host__ __device__ __forceinline__ void InitValue(GenMode gen_mode, T &value, std::size_t index = 0)
+__host__ __device__ __forceinline__
+void InitValue(GenMode gen_mode, T &value, std::size_t index = 0)
 {
-    // RandomBits is host-only.
-    if (CUB_IS_DEVICE_CODE)
-    {
-        #if CUB_INCLUDE_DEVICE_CODE
-            switch (gen_mode)
-            {
-                case RANDOM:
-                case RANDOM_BIT:
-                case RANDOM_MINUS_PLUS_ZERO:
-                    _CubLog("%s\n",
-                            "cub::InitValue cannot generate random numbers on device.");
-                    CUB_NS_QUALIFIER::ThreadTrap();
-                    break;
-                case UNIFORM:
-                    value = 2;
-                    break;
-                case INTEGER_SEED:
-                default:
-                    value = (T) index;
-                    break;
-            }
-        #endif // CUB_INCLUDE_DEVICE_CODE
-    }
-    else
-    {
-        #if CUB_INCLUDE_HOST_CODE
-            switch (gen_mode)
-            {
-                case RANDOM:
-                    RandomBits(value);
-                    break;
-                case RANDOM_BIT:
-                {
-                    char c;
-                    RandomBits(c, 0, 0, 1);
-                    value = (c > 0) ? (T) 1 : (T) -1;
-                    break;
-                }
-                case RANDOM_MINUS_PLUS_ZERO:
-                {
-                    // Replace roughly 1/128 of values with -0.0 or +0.0, and generate the rest randomly
-                    typedef typename CUB_NS_QUALIFIER::Traits<T>::UnsignedBits UnsignedBits;
-                    char c;
-                    RandomBits(c);
-                    if (c == 0)
-                    {
-                        // Replace 1/256 of values with +0.0 bit pattern
-                        value = SafeBitCast<T>(UnsignedBits(0));
-                    }
-                    else if (c == 1)
-                    {
-                        // Replace 1/256 of values with -0.0 bit pattern
-                        value = SafeBitCast<T>(UnsignedBits(UnsignedBits(1) <<
-                                                            (sizeof(UnsignedBits) * 8) - 1));
-                    }
-                    else
-                    {
-                        // 127/128 of values are random
-                        RandomBits(value);
-                    }
-                    break;
-                }
-                case UNIFORM:
-                    value = 2;
-                    break;
-                case INTEGER_SEED:
-                default:
-                    value = (T) index;
-                    break;
-            }
-        #endif // CUB_INCLUDE_HOST_CODE
-    }
+  // RandomBits is host-only.
+  NV_IF_TARGET(
+    NV_IS_HOST,
+    (
+      switch (gen_mode) {
+      case RANDOM:
+        RandomBits(value);
+        break;
+      case RANDOM_BIT: {
+        char c;
+        RandomBits(c, 0, 0, 1);
+        value = static_cast<T>((c > 0) ? 1 : -1);
+        break;
+      }
+      case RANDOM_MINUS_PLUS_ZERO: {
+        // Replace roughly 1/128 of values with -0.0 or +0.0, and
+        // generate the rest randomly
+        using UnsignedBits = typename CUB_NS_QUALIFIER::Traits<T>::UnsignedBits;
+        char c;
+        RandomBits(c);
+        if (c == 0)
+        {
+          // Replace 1/256 of values with +0.0 bit pattern
+          value = SafeBitCast<T>(UnsignedBits(0));
+        }
+        else if (c == 1)
+        {
+          // Replace 1/256 of values with -0.0 bit pattern
+          value = SafeBitCast<T>(
+            UnsignedBits(UnsignedBits(1) << (sizeof(UnsignedBits) * 8) - 1));
+        }
+        else
+        {
+          // 127/128 of values are random
+          RandomBits(value);
+        }
+        break;
+      }
+      case UNIFORM:
+        value = 2;
+        break;
+      case INTEGER_SEED:
+      default:
+        value = static_cast<T>(index);
+        break;
+      }),
+    ( // NV_IS_DEVICE:
+      switch (gen_mode) {
+      case RANDOM:
+      case RANDOM_BIT:
+      case RANDOM_MINUS_PLUS_ZERO:
+        _CubLog("%s\n",
+                "cub::InitValue cannot generate random numbers on device.");
+        CUB_NS_QUALIFIER::ThreadTrap();
+        break;
+      case UNIFORM:
+        value = 2;
+        break;
+      case INTEGER_SEED:
+      default:
+        value = static_cast<T>(index);
+        break;
+      }
+    ));
 }
-
 
 /**
  * Initialize value (bool)
@@ -652,51 +647,46 @@ __host__ __device__ __forceinline__ void InitValue(GenMode gen_mode, T &value, s
 #pragma nv_exec_check_disable
 __host__ __device__ __forceinline__ void InitValue(GenMode gen_mode, bool &value, std::size_t index = 0)
 {
-    // RandomBits is host-only.
-    if (CUB_IS_DEVICE_CODE)
+  // RandomBits is host-only.
+  NV_IF_TARGET(
+    NV_IS_HOST,
+    (
+      switch (gen_mode)
+      {
+      case RANDOM:
+      case RANDOM_BIT:
+          char c;
+          RandomBits(c, 0, 0, 1);
+          value = (c > 0);
+          break;
+       case UNIFORM:
+          value = true;
+          break;
+      case INTEGER_SEED:
+      default:
+          value = (index > 0);
+          break;
+      }
+    ),
+  ( // NV_IS_DEVICE,
+    switch (gen_mode)
     {
-        #if CUB_INCLUDE_DEVICE_CODE
-            switch (gen_mode)
-            {
-                case RANDOM:
-                case RANDOM_BIT:
-                case RANDOM_MINUS_PLUS_ZERO:
-                    _CubLog("%s\n",
-                            "cub::InitValue cannot generate random numbers on device.");
-                    CUB_NS_QUALIFIER::ThreadTrap();
-                    break;
-                case UNIFORM:
-                    value = true;
-                    break;
-                case INTEGER_SEED:
-                default:
-                    value = (index > 0);
-                    break;
-            }
-        #endif // CUB_INCLUDE_DEVICE_CODE
+      case RANDOM:
+      case RANDOM_BIT:
+      case RANDOM_MINUS_PLUS_ZERO:
+        _CubLog("%s\n",
+                "cub::InitValue cannot generate random numbers on device.");
+        CUB_NS_QUALIFIER::ThreadTrap();
+        break;
+      case UNIFORM:
+        value = true;
+        break;
+      case INTEGER_SEED:
+      default:
+        value = (index > 0);
+        break;
     }
-    else
-    {
-        #if CUB_INCLUDE_HOST_CODE
-            switch (gen_mode)
-            {
-                case RANDOM:
-                case RANDOM_BIT:
-                case RANDOM_MINUS_PLUS_ZERO:
-                    char c;
-                    RandomBits(c, 0, 0, 1);
-                    value = (c > 0);
-                    break;
-                case UNIFORM:
-                    value = true;
-                    break;
-                case INTEGER_SEED:
-                default:
-                    value = (index > 0);
-                    break;
-            }
-        #endif // CUB_INCLUDE_HOST_CODE
-    }
+  ));
 }
 
 

--- a/test/test_warp_mask.cu
+++ b/test/test_warp_mask.cu
@@ -45,8 +45,7 @@ void Test()
 
   for (unsigned int warp_id = 0; warp_id < warps; warp_id++)
   {
-    const unsigned int warp_mask =
-      cub::WarpMask<LOGICAL_WARP_THREADS, 860>(warp_id);
+    const unsigned int warp_mask = cub::WarpMask<LOGICAL_WARP_THREADS>(warp_id);
 
     const unsigned int warp_begin = LOGICAL_WARP_THREADS * warp_id;
     const unsigned int warp_end = warp_begin + LOGICAL_WARP_THREADS;

--- a/test/test_warp_reduce.cu
+++ b/test/test_warp_reduce.cu
@@ -36,8 +36,10 @@
 #include <stdio.h>
 #include <typeinfo>
 
-#include <cub/warp/warp_reduce.cuh>
 #include <cub/util_allocator.cuh>
+#include <cub/warp/warp_reduce.cuh>
+
+#include <nv/target>
 
 #include "test_util.h"
 
@@ -67,16 +69,14 @@ struct WrapperFunctor
     template <typename T>
     inline __host__ __device__ T operator()(const T &a, const T &b) const
     {
-      if (CUB_IS_DEVICE_CODE)
-      {
-          #if CUB_INCLUDE_DEVICE_CODE != 0
+        NV_IF_TARGET(NV_IS_DEVICE,
+        (
               if ((cub::LaneId() % LOGICAL_WARP_THREADS) >= num_valid)
               {
                   _CubLog("%s\n", "Invalid lane ID in cub::WrapperFunctor::operator()");
                   cub::ThreadTrap();
               }
-          #endif
-      }
+        ));
 
         return op(a, b);
     }


### PR DESCRIPTION
Requires NVIDIA/thrust#1605.

This PR contains an initial set of changes necessary to migrate Thrust and CUB to NV_IF_TARGET and remove dependence on `__CUDA_ARCH__`. It does not fully remove all usages of `__CUDA_ARCH__`, but rather focuses on the following:

* Establish the libcu++ dependency for both Thrust and CUB.
* Remove obsolete checks for unsupported CUDA architectures.
* Migrate host/device divergent code from `#ifdef __CUDA_ARCH__` to use `NV_IF_TARGET`.

This also includes various bug fixes for issues exposed by the above.

Future PRs will address the remaining usages of `__CUDA_ARCH__` in the CDP macros and the kernel dispatch infrastructure.

# Pre-written Release Notes

## Breaking Changes

- NVIDIA/cub#448 Add libcu++ dependency.
- NVIDIA/cub#448: The following macros are no longer defined by default. They can be re-enabled by defining `CUB_PROVIDE_LEGACY_ARCH_MACROS`. These will be completely removed in a future release.
    - `CUB_IS_HOST_CODE`: Replace with `NV_IF_TARGET`.
    - `CUB_IS_DEVICE_CODE`: Replace with `NV_IF_TARGET`.
    - `CUB_INCLUDE_HOST_CODE`: Replace with `NV_IF_TARGET`.
    - `CUB_INCLUDE_DEVICE_CODE`: Replace with `NV_IF_TARGET`.

## Other Enhancements

- NVIDIA/cub#448: Removed special case code for unsupported CUDA architectures.
- NVIDIA/cub#448: Replace several usages of `__CUDA_ARCH__` with `<nv/target>` to handle host/device code divergence.
- NVIDIA/cub#448: Mark unused PTX arch parameters as legacy.