### PR TITLE
Better name for in-place flag in adj diff

### DIFF
--- a/cub/agent/agent_adjacent_difference.cuh
+++ b/cub/agent/agent_adjacent_difference.cuh
@@ -64,7 +64,7 @@ template <typename Policy,
           typename OffsetT,
           typename InputT,
           typename OutputT,
-          bool InPlace,
+          bool MayAlias,
           bool ReadLeft>
 struct AgentDifference
 {
@@ -148,8 +148,8 @@ struct AgentDifference
       }
       else
       {
-        InputT tile_prev_input = InPlace ? first_tile_previous[tile_idx]
-                                         : *(input_it + tile_base - 1);
+        InputT tile_prev_input = MayAlias ? first_tile_previous[tile_idx]
+                                          : *(input_it + tile_base - 1);
 
         BlockAdjacentDifferenceT(temp_storage.adjacent_difference)
           .SubtractLeft(input, output, difference_op, tile_prev_input);
@@ -164,8 +164,9 @@ struct AgentDifference
       }
       else
       {
-        InputT tile_next_input = InPlace ? first_tile_previous[tile_idx]
-                                         : *(input_it + tile_base + ITEMS_PER_TILE);
+        InputT tile_next_input = MayAlias
+                               ? first_tile_previous[tile_idx]
+                               : *(input_it + tile_base + ITEMS_PER_TILE);
 
         BlockAdjacentDifferenceT(temp_storage.adjacent_difference)
           .SubtractRight(input, output, difference_op, tile_next_input);

--- a/cub/device/device_adjacent_difference.cuh
+++ b/cub/device/device_adjacent_difference.cuh
@@ -99,7 +99,7 @@ CUB_NAMESPACE_BEGIN
 struct DeviceAdjacentDifference
 {
 private:
-  template <bool in_place,
+  template <bool may_alias,
             bool read_left,
             typename NumItemsT,
             typename InputIteratorT,
@@ -121,7 +121,7 @@ private:
                                                  OutputIteratorT,
                                                  DifferenceOpT,
                                                  OffsetT,
-                                                 in_place,
+                                                 may_alias,
                                                  read_left>;
 
     return DispatchT::Dispatch(d_temp_storage,
@@ -255,17 +255,17 @@ public:
                    cudaStream_t stream         = 0,
                    bool debug_synchronous      = false)
   {
-    constexpr bool in_place = false;
+    constexpr bool may_alias = false;
     constexpr bool read_left = true;
 
-    return AdjacentDifference<in_place, read_left>(d_temp_storage,
-                                                   temp_storage_bytes,
-                                                   d_input,
-                                                   d_output,
-                                                   num_items,
-                                                   difference_op,
-                                                   stream,
-                                                   debug_synchronous);
+    return AdjacentDifference<may_alias, read_left>(d_temp_storage,
+                                                    temp_storage_bytes,
+                                                    d_input,
+                                                    d_output,
+                                                    num_items,
+                                                    difference_op,
+                                                    stream,
+                                                    debug_synchronous);
   }
 
   /**
@@ -372,17 +372,17 @@ public:
                cudaStream_t stream         = 0,
                bool debug_synchronous      = false)
   {
-    constexpr bool in_place = true;
+    constexpr bool may_alias = true;
     constexpr bool read_left = true;
 
-    return AdjacentDifference<in_place, read_left>(d_temp_storage,
-                                                   temp_storage_bytes,
-                                                   d_input,
-                                                   d_input,
-                                                   num_items,
-                                                   difference_op,
-                                                   stream,
-                                                   debug_synchronous);
+    return AdjacentDifference<may_alias, read_left>(d_temp_storage,
+                                                    temp_storage_bytes,
+                                                    d_input,
+                                                    d_input,
+                                                    num_items,
+                                                    difference_op,
+                                                    stream,
+                                                    debug_synchronous);
   }
 
   /**
@@ -504,17 +504,17 @@ public:
                     cudaStream_t stream         = 0,
                     bool debug_synchronous      = false)
   {
-    constexpr bool in_place  = false;
+    constexpr bool may_alias  = false;
     constexpr bool read_left = false;
 
-    return AdjacentDifference<in_place, read_left>(d_temp_storage,
-                                                   temp_storage_bytes,
-                                                   d_input,
-                                                   d_output,
-                                                   num_items,
-                                                   difference_op,
-                                                   stream,
-                                                   debug_synchronous);
+    return AdjacentDifference<may_alias, read_left>(d_temp_storage,
+                                                    temp_storage_bytes,
+                                                    d_input,
+                                                    d_output,
+                                                    num_items,
+                                                    difference_op,
+                                                    stream,
+                                                    debug_synchronous);
   }
 
   /**
@@ -611,17 +611,17 @@ public:
                 cudaStream_t stream         = 0,
                 bool debug_synchronous      = false)
   {
-    constexpr bool in_place = true;
+    constexpr bool may_alias = true;
     constexpr bool read_left = false;
 
-    return AdjacentDifference<in_place, read_left>(d_temp_storage,
-                                                   temp_storage_bytes,
-                                                   d_input,
-                                                   d_input,
-                                                   num_items,
-                                                   difference_op,
-                                                   stream,
-                                                   debug_synchronous);
+    return AdjacentDifference<may_alias, read_left>(d_temp_storage,
+                                                    temp_storage_bytes,
+                                                    d_input,
+                                                    d_input,
+                                                    num_items,
+                                                    difference_op,
+                                                    stream,
+                                                    debug_synchronous);
   }
 };
 


### PR DESCRIPTION
In continuation of the following [discussion](https://github.com/NVIDIA/thrust/pull/1512#discussion_r867071509), I've renamed the `InPlace` flag to `MayAlias`. 