### PR TITLE
Add option to disable BF16 support

### DIFF
--- a/cmake/header_test.in
+++ b/cmake/header_test.in
@@ -50,3 +50,9 @@
 #define B0 CUB_MACRO_CHECK("B0", termios.h)
 
 #include <cub/${header}>
+
+#if defined(CUB_DISABLE_BF16_SUPPORT)
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+#error CUB should not include cuda_bf16.h when BF16 support is disabled
+#endif
+#endif

--- a/cub/util_type.cuh
+++ b/cub/util_type.cuh
@@ -42,8 +42,9 @@
 #if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !_NVHPC_CUDA
     #include <cuda_fp16.h>
 #endif
-#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !_NVHPC_CUDA
-    #include <cuda_bf16.h>
+#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !_NVHPC_CUDA &&   \
+  !defined(CUB_DISABLE_BF16_SUPPORT)
+#include <cuda_bf16.h>
 #endif
 
 #include <cub/util_arch.cuh>
@@ -1105,7 +1106,8 @@ struct FpLimits<__half>
 };
 #endif
 
-#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !_NVHPC_CUDA
+#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !_NVHPC_CUDA &&   \
+  !defined(CUB_DISABLE_BF16_SUPPORT)
 template <>
 struct FpLimits<__nv_bfloat16>
 {
@@ -1188,7 +1190,8 @@ template <> struct NumericTraits<double> :              BaseTraits<FLOATING_POIN
 #if (__CUDACC_VER_MAJOR__ >= 9 || CUDA_VERSION >= 9000) && !_NVHPC_CUDA
     template <> struct NumericTraits<__half> :          BaseTraits<FLOATING_POINT, true, false, unsigned short, __half> {};
 #endif
-#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !_NVHPC_CUDA
+#if (__CUDACC_VER_MAJOR__ >= 11 || CUDA_VERSION >= 11000) && !_NVHPC_CUDA &&   \
+  !defined(CUB_DISABLE_BF16_SUPPORT)
     template <> struct NumericTraits<__nv_bfloat16> :   BaseTraits<FLOATING_POINT, true, false, unsigned short, __nv_bfloat16> {};
 #endif
 


### PR DESCRIPTION
This PR addresses the following [issue](https://github.com/NVIDIA/cub/issues/478). I considered eliminating of `cuda_bf16.h` header inclusion, but it might lead to issues when algorithm header relies on some different header:
```cpp
#include <cub/util_type.cuh> // omitted bf16 specializations based on `__CUDA_BF16_TYPES_EXIST__`
#include <cuda_bf16.h> // defined `__CUDA_BF16_TYPES_EXIST__`
#include <cub/device/device_radix_sort.cuh> // expects bf16 specializations in `util_type.h` 
```
It seems to be safer to provide the disable macro that @leofang's suggested. 