### PR TITLE
Fix begin_bit == end_bit == 0 for device-wide and segmented sort

### DIFF
--- a/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -1747,12 +1747,15 @@ struct DispatchRadixSort :
         }
 
         // Check if simple copy suffices (is_overwrite_okay == false at this point)
-        cudaError_t error = cudaSuccess;
-        bool has_uva = false;
-        if ((error = HasUVA(has_uva)) != cudaSuccess) return error;
-        if (begin_bit == end_bit & has_uva)
+        if (begin_bit == end_bit)
         {
-            return InvokeCopy();
+            bool has_uva = false;
+            cudaError_t error = detail::HasUVA(has_uva);
+            if (error != cudaSuccess) return error;
+            if (has_uva)
+            {
+                return InvokeCopy();
+            }
         }
 
         // Force kernel code-generation in all compiler passes

--- a/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -1694,7 +1694,7 @@ struct DispatchRadixSort :
         #endif
         cudaError_t error = cudaSuccess;
         error = cudaMemcpyAsync(d_keys.Alternate(), d_keys.Current(), num_items * sizeof(KeyT),
-                                cudaMemcpyDeviceToDevice, stream);
+                                cudaMemcpyDefault, stream);
         if (CubDebug(error))
         {
             return error;
@@ -1713,7 +1713,7 @@ struct DispatchRadixSort :
                     (long long)num_items, (long long)stream);
             #endif
             error = cudaMemcpyAsync(d_values.Alternate(), d_values.Current(),
-                                    num_items * sizeof(ValueT), cudaMemcpyDeviceToDevice, stream);
+                                    num_items * sizeof(ValueT), cudaMemcpyDefault, stream);
             if (CubDebug(error))
             {
                 return error;
@@ -1747,7 +1747,10 @@ struct DispatchRadixSort :
         }
 
         // Check if simple copy suffices (is_overwrite_okay == false at this point)
-        if (begin_bit == end_bit)
+        cudaError_t error = cudaSuccess;
+        bool has_uva = false;
+        if ((error = HasUVA(has_uva)) != cudaSuccess) return error;
+        if (begin_bit == end_bit & has_uva)
         {
             return InvokeCopy();
         }

--- a/cub/util_device.cuh
+++ b/cub/util_device.cuh
@@ -550,7 +550,7 @@ CUB_RUNTIME_FUNCTION inline cudaError_t DebugSyncStream(cudaStream_t stream)
 }
 
 /** \brief Gets whether the current device supports unified addressing */
-CUB_RUNTIME_FUNCTION cudaError_t HasUVA(bool& has_uva)
+CUB_RUNTIME_FUNCTION inline cudaError_t HasUVA(bool& has_uva)
 {
     has_uva = false;
     cudaError_t error = cudaSuccess;

--- a/cub/util_device.cuh
+++ b/cub/util_device.cuh
@@ -125,6 +125,23 @@ CUB_RUNTIME_FUNCTION inline int CurrentDevice()
     return device;
 }
 
+/** \brief Gets whether the current device supports unified addressing */
+CUB_RUNTIME_FUNCTION cudaError_t HasUVA(bool& has_uva)
+{
+    has_uva = false;
+    cudaError_t error = cudaSuccess;
+    int device = -1;
+    if (CubDebug(error = cudaGetDevice(&device)) != cudaSuccess) return error;
+    int uva = 0;
+    if (CubDebug(error = cudaDeviceGetAttribute(&uva, cudaDevAttrUnifiedAddressing, device))
+        != cudaSuccess)
+    {
+        return error;
+    }
+    has_uva = uva == 1;
+    return error;
+}
+
 /**
  * \brief RAII helper which saves the current device and switches to the
  *        specified device on construction and switches to the saved device on

--- a/cub/util_device.cuh
+++ b/cub/util_device.cuh
@@ -125,23 +125,6 @@ CUB_RUNTIME_FUNCTION inline int CurrentDevice()
     return device;
 }
 
-/** \brief Gets whether the current device supports unified addressing */
-CUB_RUNTIME_FUNCTION cudaError_t HasUVA(bool& has_uva)
-{
-    has_uva = false;
-    cudaError_t error = cudaSuccess;
-    int device = -1;
-    if (CubDebug(error = cudaGetDevice(&device)) != cudaSuccess) return error;
-    int uva = 0;
-    if (CubDebug(error = cudaDeviceGetAttribute(&uva, cudaDevAttrUnifiedAddressing, device))
-        != cudaSuccess)
-    {
-        return error;
-    }
-    has_uva = uva == 1;
-    return error;
-}
-
 /**
  * \brief RAII helper which saves the current device and switches to the
  *        specified device on construction and switches to the saved device on
@@ -564,6 +547,23 @@ CUB_RUNTIME_FUNCTION inline cudaError_t DebugSyncStream(cudaStream_t stream)
   return cudaSuccess;
 #endif
 #endif
+}
+
+/** \brief Gets whether the current device supports unified addressing */
+CUB_RUNTIME_FUNCTION cudaError_t HasUVA(bool& has_uva)
+{
+    has_uva = false;
+    cudaError_t error = cudaSuccess;
+    int device = -1;
+    if (CubDebug(error = cudaGetDevice(&device)) != cudaSuccess) return error;
+    int uva = 0;
+    if (CubDebug(error = cudaDeviceGetAttribute(&uva, cudaDevAttrUnifiedAddressing, device))
+        != cudaSuccess)
+    {
+        return error;
+    }
+    has_uva = uva == 1;
+    return error;
 }
 
 } // namespace detail

--- a/test/test_device_radix_sort.cu
+++ b/test/test_device_radix_sort.cu
@@ -1418,6 +1418,11 @@ void TestBits(
         printf("Testing key bits [%d,%d)\n", begin_bit, end_bit); fflush(stdout);
         TestDirection(h_keys, num_items, num_segments, pre_sorted, h_segment_offsets, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit);
 
+        // Equal bits
+        begin_bit = end_bit = 0;
+        printf("Testing key bits [%d,%d)\n", begin_bit, end_bit); fflush(stdout);
+        TestDirection(h_keys, num_items, num_segments, pre_sorted, h_segment_offsets, d_segment_begin_offsets, d_segment_end_offsets, begin_bit, end_bit);
+
         // Across subword boundaries
         int mid_bit = sizeof(KeyT) * 4;
         printf("Testing key bits [%d,%d)\n", mid_bit - 1, mid_bit + 1); fflush(stdout);
@@ -1587,7 +1592,7 @@ void TestGen(
 {
     if (max_items == ~std::size_t(0))
     {
-        max_items = 9000003;
+        max_items = 8000003;
     }
 
     if (max_segments < 0)
@@ -1650,7 +1655,6 @@ void TestGen(
         TestSizes(h_keys.get(), large_num_items, max_segments, true);
         fflush(stdout);
     }
-
 }
 
 


### PR DESCRIPTION
Fix `begin_bit == end_bit == 0` for device-wide and segmented sort.