### PR TITLE
Fix DeviceHistogram::Even for mixed float/int levels and sample types.

### DIFF
--- a/cub/detail/cpp_compatibility.cuh
+++ b/cub/detail/cpp_compatibility.cuh
@@ -1,0 +1,28 @@
+/*
+*  Copyright 2022 NVIDIA Corporation
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*/
+
+
+#pragma once
+
+#include <cub/util_cpp_dialect.cuh>
+
+#if CUB_CPP_DIALECT >= 2017 && __cpp_if_constexpr
+#  define CUB_IF_CONSTEXPR if constexpr
+#  define CUB_ELSE_IF_CONSTEXPR else if constexpr
+#else
+#  define CUB_IF_CONSTEXPR if
+#  define CUB_ELSE_IF_CONSTEXPR else if
+#endif

--- a/cub/device/device_histogram.cuh
+++ b/cub/device/device_histogram.cuh
@@ -77,6 +77,9 @@ struct DeviceHistogram
    * - The ranges `[d_samples, d_samples + num_samples)` and 
    *   `[d_histogram, d_histogram + num_levels - 1)` shall not overlap 
    *   in any way.
+   * - `cuda::std::common_type<LevelT, SampleT>` must be valid, and both LevelT
+   *   and SampleT must be valid arithmetic types. The common type must be
+   *   convertible to `int` and trivially copyable.
    * - @devicestorage
    *
    * @par Snippet
@@ -247,6 +250,9 @@ struct DeviceHistogram
    *   `row_end = row_begin + num_row_samples`. The ranges
    *   `[row_begin, row_end)` and `[d_histogram, d_histogram + num_levels - 1)` 
    *   shall not overlap in any way.
+   * - `cuda::std::common_type<LevelT, SampleT>` must be valid, and both LevelT
+   *   and SampleT must be valid arithmetic types. The common type must be
+   *   convertible to `int` and trivially copyable.
    * - @devicestorage
    *
    * @par Snippet
@@ -432,6 +438,9 @@ struct DeviceHistogram
    *   `[d_samples, d_samples + NUM_CHANNELS * num_pixels)` and 
    *   `[d_histogram[c], d_histogram[c] + num_levels[c] - 1)` shall not overlap 
    *   in any way.
+   * - `cuda::std::common_type<LevelT, SampleT>` must be valid, and both LevelT
+   *   and SampleT must be valid arithmetic types. The common type must be
+   *   convertible to `int` and trivially copyable.
    * - @devicestorage
    *
    * @par Snippet
@@ -633,6 +642,9 @@ struct DeviceHistogram
    *   `[sample_begin, sample_end)` and 
    *   `[d_histogram[c], d_histogram[c] + num_levels[c] - 1)` shall not overlap 
    *   in any way.
+   * - `cuda::std::common_type<LevelT, SampleT>` must be valid, and both LevelT
+   *   and SampleT must be valid arithmetic types. The common type must be
+   *   convertible to `int` and trivially copyable.
    * - @devicestorage
    *
    * @par Snippet


### PR DESCRIPTION
The `ScaleTransform` utility precomputes the reciprocal of the "`sample` -> `bin_idx`" scaling factor for floating point types as an optimization.

Trouble is, the `Init` method checked whether `LevelT` is fp while `BinSelect` checked `SampleT`. This caused the optimization to be incorrectly applied when one of these types is fp but the other is not.

Fixed this bug and simplified the implementation of `ScaleTransform` using `cuda::std::common_type` to consistently apply the optimization when either `LevelT` or `ScaleT` are fp.

Fixes #479 and #489 and adds regression tests for both.

### Breaking Changes:

- NVIDIA/cub#487: Fixed the `DeviceHistogram::HistogramEven` algorithms when the samples and levels are different types (NVIDIA/cub#479) and when both are integral with fractional bin sizes (NVIDIA/cub#489). These fixes introduced the following explicit restrictions:
  - Both `SampleT` and `LevelT` must support common arithmetic operations.
  - `cuda::std::common_type<SampleT, LevelT>` must have a valid definition.
  - The common type must be convertible to `int`.
  - The common type must be trivially copyable.