### PR TITLE
In-place guarantees for partition

### DIFF
--- a/cub/device/device_partition.cuh
+++ b/cub/device/device_partition.cuh
@@ -84,6 +84,10 @@ struct DevicePartition
      * - Copies of the selected items are compacted into @p d_out and maintain
      *   their original relative ordering, however copies of the unselected
      *   items are compacted into the rear of @p d_out in reverse order.
+     * - The range `[d_out, d_out + num_items)` shall not overlap 
+     *   `[d_in, d_in + num_items)` nor `[d_flags, d_flags + num_items)` in any 
+     *   way. The range `[d_in, d_in + num_items)` may overlap 
+     *  `[d_flags, d_flags + num_items)`.
      * - \devicestorage
      *
      * @par Snippet
@@ -222,6 +226,8 @@ struct DevicePartition
      * - Copies of the selected items are compacted into @p d_out and maintain
      *   their original relative ordering, however copies of the unselected
      *   items are compacted into the rear of @p d_out in reverse order.
+     * - The range `[d_out, d_out + num_items)` shall not overlap 
+     *   `[d_in, d_in + num_items)` in any way. 
      * - \devicestorage
      *
      * @par Performance
@@ -398,6 +404,11 @@ struct DevicePartition
      *   into @p d_second_part_out and maintain their original relative ordering.
      * - Copies of the unselected items are compacted into the
      *   @p d_unselected_out in reverse order.
+     * - The ranges `[d_out, d_out + num_items)`,
+     *   `[d_first_part_out, d_first_part_out + d_num_selected_out[0])`, 
+     *   `[d_second_part_out, d_second_part_out + d_num_selected_out[1])`, 
+     *   `[d_unselected_out, d_unselected_out + num_items - d_num_selected_out[0] - d_num_selected_out[1])`, 
+     *   shall not overlap in any way. 
      *
      * @par Snippet
      * The code snippet below illustrates how this algorithm can partition an


### PR DESCRIPTION
It's not allowed to alias in/out data in case of partition because unselected data might override input array for a CTA that hasn't been scheduled yet. These leads to loosing data. 