### PR TITLE
Avoid making `SwitchDevice` visible to NVRTC

### DIFF
--- a/cub/util_device.cuh
+++ b/cub/util_device.cuh
@@ -139,6 +139,7 @@ CUB_RUNTIME_FUNCTION inline int CurrentDevice()
  *        specified device on construction and switches to the saved device on
  *        destruction.
  */
+#ifndef __CUDACC_RTC__  // cudaSetDevice is an undefined symbol on the device side
 struct SwitchDevice
 {
 private:
@@ -158,6 +159,7 @@ public:
             CubDebug(cudaSetDevice(old_device));
     }
 };
+#endif  // ifndef __CUDACC_RTC__
 
 /**
  * \brief Returns the number of CUDA devices available or -1 if an error


### PR DESCRIPTION
Related nvbugs: 3626733

This PR is a WAR to resume support of NVRTC + Jitify (+ CDP, optionally), despite it's still unofficial. 

The header `cub/util_device.cuh` has a host-only struct `SwitchDevice`. Normally with such functions NVRTC would hit an error ("host code is not allowed in JIT mode"); however, when compiling with NVRTC + Jitify, the latter removes all `__host__` qualifier (as a WAR for something else), thus exposing the undefined symbol `cudaSetDevice` to NVRTC.

Since this struct doesn't really make sense when using NVRTC (which is why the symbol is undefined), the easiest WAR is to remove it entirely from its sight.