### PR TITLE
Reapply changes from NVIDIA/cub#404 that were lost in conflict resolution.

### DIFF
--- a/cub/util_device.cuh
+++ b/cub/util_device.cuh
@@ -363,14 +363,9 @@ CUB_RUNTIME_FUNCTION inline cudaError_t PtxVersionUncached(int& ptx_version)
       (
         cudaFuncAttributes empty_kernel_attrs;
 
-        do
-        {
-          if (CubDebug(result = cudaFuncGetAttributes(&empty_kernel_attrs,
-                                                      empty_kernel)))
-          {
-            break;
-          }
-        } while (0);
+        result = cudaFuncGetAttributes(&empty_kernel_attrs,
+                                       reinterpret_cast<void*>(empty_kernel));
+        CubDebug(result);
 
         ptx_version = empty_kernel_attrs.ptxVersion * 10;
       ),


### PR DESCRIPTION
Fixes the regression described in #510.