### PR TITLE
Document segmented sort behaviour for unspecified ranges

### DIFF
--- a/cub/device/device_segmented_radix_sort.cuh
+++ b/cub/device/device_segmented_radix_sort.cuh
@@ -65,6 +65,9 @@ CUB_NAMESPACE_BEGIN
  * DeviceSegmentedRadixSort shares its implementation with DeviceRadixSort. See
  * that algorithm's documentation for more information.
  *
+ * @par Segments are not required to be contiguous. Any element of input(s) or 
+ * output(s) outside the specified segments will not be accessed nor modified.  
+ *
  * @par Usage Considerations
  * @cdp_class{DeviceSegmentedRadixSort}
  *
@@ -96,6 +99,9 @@ struct DeviceSegmentedRadixSort
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
    * - @devicestorageNP For sorting using only `O(P)` temporary storage, see 
    *   the sorting interface using DoubleBuffer wrappers below.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys_in[i]`, `d_values_in[i]`, 
+   *   `d_keys_out[i]`, `d_values_out[i]` will not be accessed nor modified.   
    * - @devicestorage
    *
    * @par Snippet
@@ -318,6 +324,10 @@ struct DeviceSegmentedRadixSort
    *   `[alt, alt + num_items)`. Both ranges shall not overlap
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys.Current()[i]`, 
+   *   `d_values.Current()[i]`, `d_keys.Alternate()[i]`, 
+   *   `d_values.Alternate()[i]` will not be accessed nor modified.   
    * - @devicestorageP
    * - @devicestorage
    *
@@ -522,6 +532,9 @@ struct DeviceSegmentedRadixSort
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
    * - @devicestorageNP For sorting using only `O(P)` temporary storage, see 
    *   the sorting interface using DoubleBuffer wrappers below.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys_in[i]`, `d_values_in[i]`, 
+   *   `d_keys_out[i]`, `d_values_out[i]` will not be accessed nor modified.   
    * - @devicestorage
    *
    * @par Snippet
@@ -746,6 +759,11 @@ struct DeviceSegmentedRadixSort
    *   `[alt, alt + num_items)`. Both ranges shall not overlap
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys.Current()[i]`, 
+   *   `d_values.Current()[i]`, `d_keys.Alternate()[i]`, 
+   *   `d_values.Alternate()[i]` will not be accessed nor modified.   
+   *   not to be modified. 
    * - @devicestorageP
    * - @devicestorage
    *
@@ -957,6 +975,9 @@ struct DeviceSegmentedRadixSort
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
    * - @devicestorageNP For sorting using only `O(P)` temporary storage, see 
    *   the sorting interface using DoubleBuffer wrappers below.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys_in[i]`, `d_keys_out[i]` will not 
+   *   be accessed nor modified.   
    * - @devicestorage
    *
    * @par Snippet
@@ -1149,6 +1170,9 @@ struct DeviceSegmentedRadixSort
    *   `[alt, alt + num_items)`. Both ranges shall not overlap
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys.Current()[i]`, 
+   *   `d_keys[i].Alternate()[i]` will not be accessed nor modified.   
    * - @devicestorageP
    * - @devicestorage
    *
@@ -1337,6 +1361,9 @@ struct DeviceSegmentedRadixSort
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
    * - @devicestorageNP For sorting using only `O(P)` temporary storage, see 
    *   the sorting interface using DoubleBuffer wrappers below.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys_in[i]`, `d_keys_out[i]` will not 
+   *   be accessed nor modified.   
    * - @devicestorage
    *
    * @par Snippet
@@ -1534,6 +1561,9 @@ struct DeviceSegmentedRadixSort
    *   `[alt, alt + num_items)`. Both ranges shall not overlap
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys.Current()[i]`, 
+   *   `d_keys[i].Alternate()[i]` will not be accessed nor modified.   
    * - @devicestorageP
    * - @devicestorage
    *

--- a/cub/device/device_segmented_sort.cuh
+++ b/cub/device/device_segmented_sort.cuh
@@ -72,6 +72,9 @@ CUB_NAMESPACE_BEGIN
  * (`unsigned char`, `int`, `double`, etc.) as well as CUDA's `__half` and
  * `__nv_bfloat16` 16-bit floating-point types.
  *
+ * @par Segments are not required to be contiguous. Any element of input(s) or 
+ * output(s) outside the specified segments will not be accessed nor modified.  
+ *
  * @par A simple example
  * @code
  * #include <cub/cub.cuh>
@@ -135,6 +138,9 @@ struct DeviceSegmentedSort
    *   `[d_keys_in, d_keys_in + num_items)`, 
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys_in[i]`, `d_keys_out[i]` will not 
+   *   be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments
@@ -306,6 +312,9 @@ struct DeviceSegmentedSort
    *   `[d_keys_in, d_keys_in + num_items)`, 
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys_in[i]`, `d_keys_out[i]` will not 
+   *   be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments
@@ -485,6 +494,9 @@ struct DeviceSegmentedSort
    *   `[alt, alt + num_items)`. Both ranges shall not overlap
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys.Current()[i]`, 
+   *   `d_keys[i].Alternate()[i]` will not be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments
@@ -663,6 +675,9 @@ struct DeviceSegmentedSort
    *   `[alt, alt + num_items)`. Both ranges shall not overlap
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys.Current()[i]`, 
+   *   `d_keys[i].Alternate()[i]` will not be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments
@@ -834,6 +849,9 @@ struct DeviceSegmentedSort
    *   `[d_keys_in, d_keys_in + num_items)`, 
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys_in[i]`, `d_keys_out[i]` will not 
+   *   be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments
@@ -994,6 +1012,9 @@ struct DeviceSegmentedSort
    *   `[d_keys_in, d_keys_in + num_items)`, 
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys_in[i]`, `d_keys_out[i]` will not 
+   *   be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments
@@ -1164,6 +1185,9 @@ struct DeviceSegmentedSort
    *   `[alt, alt + num_items)`. Both ranges shall not overlap
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys.Current()[i]`, 
+   *   `d_keys[i].Alternate()[i]` will not be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments
@@ -1330,6 +1354,9 @@ struct DeviceSegmentedSort
    *   `[alt, alt + num_items)`. Both ranges shall not overlap
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys.Current()[i]`, 
+   *   `d_keys[i].Alternate()[i]` will not be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments
@@ -1497,6 +1524,9 @@ struct DeviceSegmentedSort
    *   not overlap `[in, in + num_items)`, 
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys_in[i]`, `d_values_in[i]`, 
+   *   `d_keys_out[i]`, `d_values_out[i]` will not be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments
@@ -1694,6 +1724,9 @@ struct DeviceSegmentedSort
    *   not overlap `[in, in + num_items)`, 
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys_in[i]`, `d_values_in[i]`, 
+   *   `d_keys_out[i]`, `d_values_out[i]` will not be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments
@@ -1903,6 +1936,10 @@ struct DeviceSegmentedSort
    *   `[alt, alt + num_items)`. Both ranges shall not overlap
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys.Current()[i]`, 
+   *   `d_values.Current()[i]`, `d_keys.Alternate()[i]`, 
+   *   `d_values.Alternate()[i]` will not be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments
@@ -2100,6 +2137,10 @@ struct DeviceSegmentedSort
    *   `[alt, alt + num_items)`. Both ranges shall not overlap
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys.Current()[i]`, 
+   *   `d_values.Current()[i]`, `d_keys.Alternate()[i]`, 
+   *   `d_values.Alternate()[i]` will not be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments
@@ -2290,6 +2331,9 @@ struct DeviceSegmentedSort
    *   not overlap `[in, in + num_items)`, 
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys_in[i]`, `d_values_in[i]`, 
+   *   `d_keys_out[i]`, `d_values_out[i]` will not be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments
@@ -2480,6 +2524,9 @@ struct DeviceSegmentedSort
    *   not overlap `[in, in + num_items)`, 
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys_in[i]`, `d_values_in[i]`, 
+   *   `d_keys_out[i]`, `d_values_out[i]` will not be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments
@@ -2682,6 +2729,10 @@ struct DeviceSegmentedSort
    *   `[alt, alt + num_items)`. Both ranges shall not overlap
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys.Current()[i]`, 
+   *   `d_values.Current()[i]`, `d_keys.Alternate()[i]`, 
+   *   `d_values.Alternate()[i]` will not be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments
@@ -2873,6 +2924,10 @@ struct DeviceSegmentedSort
    *   `[alt, alt + num_items)`. Both ranges shall not overlap
    *   `[d_begin_offsets, d_begin_offsets + num_segments)` nor
    *   `[d_end_offsets, d_end_offsets + num_segments)` in any way.
+   * - Segments are not required to be contiguous. For all index values `i` 
+   *   outside the specified segments `d_keys.Current()[i]`, 
+   *   `d_values.Current()[i]`, `d_keys.Alternate()[i]`, 
+   *   `d_values.Alternate()[i]` will not be accessed nor modified.   
    *
    * @par Snippet
    * The code snippet below illustrates the batched sorting of three segments


### PR DESCRIPTION
This PR addresses the following [issue](https://github.com/NVIDIA/cub/issues/485) by documenting segmented sort behaviour in case of unspecified ranges. It also adds tests to ensure this behaviour. 