### PR TITLE
Disable managed memory for nvc++

### DIFF
--- a/cmake/CubBuildCompilerTargets.cmake
+++ b/cmake/CubBuildCompilerTargets.cmake
@@ -79,6 +79,7 @@ function(cub_build_compiler_targets)
     # * NVC++ accepts CUDA C++ in .cpp files but not .cu files.
     # TODO: This won't be necessary in the future.
     list(APPEND cxx_compile_options -cppsuffix=cu)
+    list(APPEND cxx_compile_options -gpu=nomanaged)
   endif()
 
   add_library(cub.compiler_interface INTERFACE)


### PR DESCRIPTION
Using managed memory breaks certain tests like `test_thread_sort` at least on windows / WSL

Disable it uniformly to be on the safe side and let the user deside whether they want the fast footgun