### PR TITLE
Fix cub::Debug for builds without RDC

### DIFF
--- a/cub/util_debug.cuh
+++ b/cub/util_debug.cuh
@@ -185,7 +185,22 @@ cudaError_t Debug(cudaError_t error, const char *filename, int line)
 {
   // Clear the global CUDA error state which may have been set by the last
   // call. Otherwise, errors may "leak" to unrelated kernel launches.
-  cudaGetLastError();
+
+  // clang-format off
+  #ifndef CUB_RDC_ENABLED
+  #define CUB_TEMP_DEVICE_CODE
+  #else
+  #define CUB_TEMP_DEVICE_CODE cudaGetLastError()
+  #endif
+
+  NV_IF_TARGET(
+    NV_IS_HOST, 
+    (cudaGetLastError();),
+    (CUB_TEMP_DEVICE_CODE;)
+  );
+  
+  #undef CUB_TEMP_DEVICE_CODE
+  // clang-format on
 
 #ifdef CUB_STDERR
   if (error)


### PR DESCRIPTION
`cub::Debug` is used in most device algorithms and uses `cudaGetLastError` to reset errors occurred occurred during device-scope algorithms invocations. `cudaGetLastError` usage was introduced in 22b057306da72a353af837b5bfc887f036660486. The issue consists in `cudaGetLastError` usage in `__host__ __device__` functions in build with `-rdc=false`:

```cpp
__global__ void kernel() {
  cudaGetLastError();
}

int main() {
  kernel<<<1, 1>>>();
}
```

```bash
:nvcc main.cu
ptxas fatal   : Unresolved extern function 'cudaGetLastError'
```

The issue was caused by 3c20a56ded0029a7bf8800b783962df97a3abb10, so we have to backport this into 1.17. The fix consists in invoking `cudaGetLastError` only in the case of host invocations or device ones with `-rdc=true`. 