### PR TITLE
Remove usage of find_path to locate cub/version.cuh

### DIFF
--- a/cub/cmake/cub-header-search.cmake
+++ b/cub/cmake/cub-header-search.cmake
@@ -1,5 +1,4 @@
 # Parse version information from version.h in source tree
- # Source tree
 set(_CUB_VERSION_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
 if(EXISTS "${_CUB_VERSION_INCLUDE_DIR}/cub/version.cuh")
   set(_CUB_VERSION_INCLUDE_DIR "${_CUB_VERSION_INCLUDE_DIR}" CACHE FILEPATH "" FORCE) # Clear old result

--- a/cub/cmake/cub-header-search.cmake
+++ b/cub/cmake/cub-header-search.cmake
@@ -1,7 +1,7 @@
-unset(_CUB_VERSION_INCLUDE_DIR CACHE) # Clear old result to force search
-find_path(_CUB_VERSION_INCLUDE_DIR cub/version.cuh
-  NO_DEFAULT_PATH # Only search explicit paths below:
-  PATHS
-    "${CMAKE_CURRENT_LIST_DIR}/../.."            # Source tree
-)
-set_property(CACHE _CUB_VERSION_INCLUDE_DIR PROPERTY TYPE INTERNAL)
+# Parse version information from version.h in source tree
+ # Source tree
+set(_CUB_VERSION_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../..")
+if(EXISTS "${_CUB_VERSION_INCLUDE_DIR}/cub/version.cuh")
+  set(_CUB_VERSION_INCLUDE_DIR "${_CUB_VERSION_INCLUDE_DIR}" CACHE FILEPATH "" FORCE) # Clear old result
+  set_property(CACHE _CUB_VERSION_INCLUDE_DIR PROPERTY TYPE INTERNAL)
+endif()


### PR DESCRIPTION
When a consumer of cub uses the CMake `FIND_ROOT_PATH_MODE_INCLUDE` option it will cause all find_path searches to only occur under the find root path. Since this normally doesn't include the source files, it means that cub-header-search.cmake will fail to find the cub/version.cuh file.

This issue was found when using conda-build on a project that includes cub, since conda-build sets up a cross compilation
enviornment including a find root path.