### PR TITLE
Fix RDC flags on nvc++ builds.

### DIFF
--- a/cmake/CubUtilities.cmake
+++ b/cmake/CubUtilities.cmake
@@ -1,12 +1,19 @@
-# Enable RDC for a CUDA target. Encapsulates compiler hacks:
-function(cub_enable_rdc_for_cuda_target target_name)
+# Enable or disable RDC for a CUDA target.
+# Just using the CMake property won't work for our nvcxx builds, we need
+# to manually specify flags.
+# nvcc disables RDC by default, while nvc++ enables it. Thus this function
+# must be called on all CUDA targets to get consistent RDC state across all
+# platforms.
+function(cub_set_rdc_state target_name enable)
   if ("NVCXX" STREQUAL "${CMAKE_CUDA_COMPILER_ID}")
-    set_target_properties(${target_name} PROPERTIES
-      COMPILE_FLAGS "-gpu=rdc"
-    )
+    if (enable)
+      target_compile_options(${target_name} PRIVATE "-gpu=rdc")
+    else()
+      target_compile_options(${target_name} PRIVATE "-gpu=nordc")
+    endif()
   else()
     set_target_properties(${target_name} PROPERTIES
-      CUDA_SEPARABLE_COMPILATION ON
+      CUDA_SEPARABLE_COMPILATION ${enable}
     )
   endif()
 endfunction()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -43,9 +43,7 @@ function(cub_add_example target_name_var example_name example_src cub_target)
   endif()
   add_dependencies(${example_meta_target} ${example_target})
 
-  if (CUB_ENABLE_EXAMPLES_WITH_RDC)
-    cub_enable_rdc_for_cuda_target(${example_target})
-  endif()
+  cub_set_rdc_state(${example_target} ${CUB_ENABLE_EXAMPLES_WITH_RDC})
 
   add_test(NAME ${example_target}
     COMMAND "$<TARGET_FILE:${example_target}>"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -170,9 +170,7 @@ foreach (test_src IN LISTS test_srcs)
     if (num_variants EQUAL 0)
       # Only one version of this test.
       cub_add_test(test_target ${test_name} "${test_src}" ${cub_target})
-      if (CUB_ENABLE_TESTS_WITH_RDC)
-        cub_enable_rdc_for_cuda_target(${test_target})
-      endif()
+      cub_set_rdc_state(${test_target} ${CUB_ENABLE_TESTS_WITH_RDC})
     else() # has variants:
       # Meta target to build all parametrizations of the current test for the
       # current CUB_TARGET config
@@ -196,8 +194,8 @@ foreach (test_src IN LISTS test_srcs)
         string(REPLACE ":" ";" defs "${defs}")
 
         # Check if the test has explicit CDP variants:
-        _cub_has_cdp_variant(explicit_cdp "${label}")
-        _cub_is_cdp_enabled_variant(enable_cdp "${label}")
+        _cub_has_cdp_variant(has_cdp_variant "${label}")
+        _cub_is_cdp_enabled_variant(cdp_enabled "${label}")
 
         cub_add_test(test_target
           ${test_name}.${label}
@@ -215,8 +213,10 @@ foreach (test_src IN LISTS test_srcs)
         #
         # Tests that explicitly request no cdp (cdp_0 label) should never enable
         # RDC.
-        if (enable_cdp OR ((NOT explicit_cdp) AND CUB_ENABLE_TESTS_WITH_RDC))
-          cub_enable_rdc_for_cuda_target(${test_target})
+        if (cdp_enabled OR ((NOT has_cdp_variant) AND CUB_ENABLE_TESTS_WITH_RDC))
+          cub_set_rdc_state(${test_target} ON)
+        else()
+          cub_set_rdc_state(${test_target} OFF)
         endif()
       endforeach() # Variant
     endif() # Has variants


### PR DESCRIPTION
nvcc defaults to rdc-off, nvc++ defaults to rdc-on. We need to explicitly
enable or disable these flags for each CUDA target, rather than just
enabling them when needed.