### PR TITLE
Temporarily disable tests for non-RDC architectures.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,6 +6,14 @@ foreach(cub_target IN LISTS CUB_TARGETS)
   add_dependencies(${config_prefix}.all ${config_meta_target})
 endforeach()
 
+# Update flags to reflect RDC options. See note in CubCudaConfig.cmake --
+# these flag variables behave unintuitively:
+if (CUB_ENABLE_EXAMPLES_WITH_RDC)
+  set(CMAKE_CUDA_FLAGS "${CUB_CUDA_FLAGS_BASE} ${CUB_CUDA_FLAGS_RDC}")
+else()
+  set(CMAKE_CUDA_FLAGS "${CUB_CUDA_FLAGS_BASE} ${CUB_CUDA_FLAGS_NO_RDC}")
+endif()
+
 ## cub_add_example
 #
 # Add an example executable and register it with ctest.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,11 @@
+# Some tests always build with RDC, so make sure that the sm_XX flags are
+# compatible. See note in CubCudaConfig.cmake.
+# TODO once we're using CUDA_ARCHITECTURES, we can setup non-rdc fallback
+# tests to build for non-rdc arches. But for now, all files in a given directory
+# must build with the same `CMAKE_CUDA_FLAGS` due to CMake constraints around
+# how CUDA_FLAGS works.
+set(CMAKE_CUDA_FLAGS "${CUB_CUDA_FLAGS_BASE} ${CUB_CUDA_FLAGS_RDC}")
+
 # The function below reads the filepath `src`, extracts the %PARAM% comments,
 # and fills `labels_var` with a list of `label1_value1.label2_value2...`
 # strings, and puts the corresponding `DEFINITION=value1:DEFINITION=value2`


### PR DESCRIPTION
This works around some failures in Thrust's post-commit CI.

This is due to how `CMAKE_CUDA_FLAGS` works -- all targets in a directory
must share the same flags. Now that some tests always enable RDC to test
CDP launches, we have to disable the tests for non-RDC arches (53, 62, 72).

We can fix this properly once we migrate to using `CMAKE_CUDA_ARCHITECTURES`.

See comments in this patch for details.