### PR TITLE
Remove minimal supported version for NVC++

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ compilers. Unsupported versions may emit deprecation warnings, which can be
 silenced by defining CUB_IGNORE_DEPRECATED_COMPILER during compilation.
 
 - NVCC 11.0+
-- NVC++ 20.9+
 - GCC 5+
 - Clang 7+
 - MSVC 2019+ (19.20/16.0/14.20)


### PR DESCRIPTION
Addresses the following [issue](https://github.com/NVIDIA/cub/issues/540). 