### PR TITLE
Fix libcu++ namespace

### DIFF
--- a/cub/detail/type_traits.cuh
+++ b/cub/detail/type_traits.cuh
@@ -44,15 +44,15 @@ namespace detail {
 template <typename Invokable, typename... Args>
 using invoke_result_t =
 #if CUB_CPP_DIALECT < 2017
-  typename cuda::std::result_of<Invokable(Args...)>::type;
+  typename ::cuda::std::result_of<Invokable(Args...)>::type;
 #else // 2017+
-  cuda::std::invoke_result_t<Invokable, Args...>;
+  ::cuda::std::invoke_result_t<Invokable, Args...>;
 #endif
 
 /// The type of intermediate accumulator (according to P2322R6)
 template <typename Invokable, typename InitT, typename InputT>
 using accumulator_t = 
-  typename cuda::std::decay<invoke_result_t<Invokable, InitT, InputT>>::type;
+  typename ::cuda::std::decay<invoke_result_t<Invokable, InitT, InputT>>::type;
 
 } // namespace detail
 CUB_NAMESPACE_END

--- a/cub/detail/uninitialized_copy.cuh
+++ b/cub/detail/uninitialized_copy.cuh
@@ -39,24 +39,24 @@ namespace detail
 
 template <typename T,
           typename U,
-          typename cuda::std::enable_if<
-            cuda::std::is_trivially_copyable<T>::value, 
+          typename ::cuda::std::enable_if<
+            ::cuda::std::is_trivially_copyable<T>::value, 
             int
           >::type = 0>
 __host__ __device__ void uninitialized_copy(T *ptr, U &&val)
 {
-  *ptr = cuda::std::forward<U>(val);
+  *ptr = ::cuda::std::forward<U>(val);
 }
 
 template <typename T, 
          typename U,
-         typename cuda::std::enable_if<
-           !cuda::std::is_trivially_copyable<T>::value,
+         typename ::cuda::std::enable_if<
+           !::cuda::std::is_trivially_copyable<T>::value,
            int
          >::type = 0>
 __host__ __device__ void uninitialized_copy(T *ptr, U &&val)
 {
-  new (ptr) T(cuda::std::forward<U>(val));
+  new (ptr) T(::cuda::std::forward<U>(val));
 }
 
 } // namespace detail

--- a/cub/thread/thread_operators.cuh
+++ b/cub/thread/thread_operators.cuh
@@ -58,7 +58,7 @@ struct Equality
   template <typename T, typename U>
   __host__ __device__ __forceinline__ bool operator()(T &&t, U &&u) const
   {
-    return cuda::std::forward<T>(t) == cuda::std::forward<U>(u);
+    return ::cuda::std::forward<T>(t) == ::cuda::std::forward<U>(u);
   }
 };
 
@@ -69,7 +69,7 @@ struct Inequality
   template <typename T, typename U>
   __host__ __device__ __forceinline__ bool operator()(T &&t, U &&u) const
   {
-    return cuda::std::forward<T>(t) != cuda::std::forward<U>(u);
+    return ::cuda::std::forward<T>(t) != ::cuda::std::forward<U>(u);
   }
 };
 
@@ -99,9 +99,9 @@ struct Sum
   /// Binary sum operator, returns `t + u`
   template <typename T, typename U>
   __host__ __device__ __forceinline__ auto operator()(T &&t, U &&u) const
-    -> decltype(cuda::std::forward<T>(t) + cuda::std::forward<U>(u))
+    -> decltype(::cuda::std::forward<T>(t) + ::cuda::std::forward<U>(u))
   {
-    return cuda::std::forward<T>(t) + cuda::std::forward<U>(u);
+    return ::cuda::std::forward<T>(t) + ::cuda::std::forward<U>(u);
   }
 };
 
@@ -111,9 +111,9 @@ struct Difference
   /// Binary difference operator, returns `t - u`
   template <typename T, typename U>
   __host__ __device__ __forceinline__ auto operator()(T &&t, U &&u) const
-    -> decltype(cuda::std::forward<T>(t) - cuda::std::forward<U>(u))
+    -> decltype(::cuda::std::forward<T>(t) - ::cuda::std::forward<U>(u))
   {
-    return cuda::std::forward<T>(t) - cuda::std::forward<U>(u);
+    return ::cuda::std::forward<T>(t) - ::cuda::std::forward<U>(u);
   }
 };
 
@@ -123,9 +123,9 @@ struct Division
   /// Binary division operator, returns `t / u`
   template <typename T, typename U>
   __host__ __device__ __forceinline__ auto operator()(T &&t, U &&u) const
-    -> decltype(cuda::std::forward<T>(t) / cuda::std::forward<U>(u))
+    -> decltype(::cuda::std::forward<T>(t) / ::cuda::std::forward<U>(u))
   {
-    return cuda::std::forward<T>(t) / cuda::std::forward<U>(u);
+    return ::cuda::std::forward<T>(t) / ::cuda::std::forward<U>(u);
   }
 };
 
@@ -135,7 +135,7 @@ struct Max
   /// Boolean max operator, returns `(t > u) ? t : u`
   template <typename T, typename U>
   __host__ __device__ __forceinline__
-    typename cuda::std::common_type<T, U>::type
+    typename ::cuda::std::common_type<T, U>::type
     operator()(T &&t, U &&u) const
   {
     return CUB_MAX(t, u);
@@ -173,7 +173,7 @@ struct Min
   /// Boolean min operator, returns `(t < u) ? t : u`
   template <typename T, typename U>
   __host__ __device__ __forceinline__
-    typename cuda::std::common_type<T, U>::type
+    typename ::cuda::std::common_type<T, U>::type
     operator()(T &&t, U &&u) const
   {
     return CUB_MIN(t, u);


### PR DESCRIPTION
This PR harmonizes libcu++ namespace usage with the following [PR](https://github.com/NVIDIA/thrust/pull/1763).