### PR TITLE
Fix BlockReduceRaking non-commutative docs

### DIFF
--- a/cub/block/specializations/block_reduce_raking.cuh
+++ b/cub/block/specializations/block_reduce_raking.cuh
@@ -51,9 +51,9 @@ CUB_NAMESPACE_BEGIN
  * honor the relative ordering of items and partial reductions when applying the
  * reduction operator.
  *
- * Compared to the implementation of BlockReduceRaking (which does not support
- * non-commutative operators), this implementation requires a few extra
- * rounds of inter-thread communication.
+ * Compared to the implementation of BlockReduceRakingCommutativeOnly (which
+ * does not support non-commutative operators), this implementation requires a
+ * few extra rounds of inter-thread communication.
  */
 template <
     typename    T,              ///< Data type being reduced


### PR DESCRIPTION
The documentation contradicts itself here: BlockReduceRaking seems to support non-commutative operations, but BlockReduceRakingCommutativeOnly doesn't