### PR TITLE
Fix block radix rank for blocks with non multiple of 32 threads

### DIFF
--- a/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/agent/agent_radix_sort_downsweep.cuh
@@ -136,27 +136,9 @@ struct AgentRadixSortDownsweep
     using ValuesItr = CacheModifiedInputIterator<LOAD_MODIFIER, ValueT, OffsetT>;
 
     // Radix ranking type to use
-    using BlockRadixRankT = cub::detail::conditional_t<
-      RANK_ALGORITHM == RADIX_RANK_BASIC,
-      BlockRadixRank<BLOCK_THREADS, RADIX_BITS, IS_DESCENDING, false, SCAN_ALGORITHM>,
-      cub::detail::conditional_t<
-        RANK_ALGORITHM == RADIX_RANK_MEMOIZE,
-        BlockRadixRank<BLOCK_THREADS, RADIX_BITS, IS_DESCENDING, true, SCAN_ALGORITHM>,
-        cub::detail::conditional_t<
-          RANK_ALGORITHM == RADIX_RANK_MATCH,
-          BlockRadixRankMatch<BLOCK_THREADS, RADIX_BITS, IS_DESCENDING, SCAN_ALGORITHM>,
-          cub::detail::conditional_t<
-            RANK_ALGORITHM == RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
-            BlockRadixRankMatchEarlyCounts<BLOCK_THREADS,
-                                           RADIX_BITS,
-                                           IS_DESCENDING,
-                                           SCAN_ALGORITHM,
-                                           WARP_MATCH_ANY>,
-            BlockRadixRankMatchEarlyCounts<BLOCK_THREADS,
-                                           RADIX_BITS,
-                                           IS_DESCENDING,
-                                           SCAN_ALGORITHM,
-                                           WARP_MATCH_ATOMIC_OR>>>>>;
+    using BlockRadixRankT = 
+      cub::detail::block_radix_rank_t<
+        RANK_ALGORITHM, BLOCK_THREADS, RADIX_BITS, IS_DESCENDING, SCAN_ALGORITHM>;
 
     // Digit extractor type
     using DigitExtractorT = BFEDigitExtractor<KeyT>;

--- a/cub/block/block_radix_rank.cuh
+++ b/cub/block/block_radix_rank.cuh
@@ -559,7 +559,6 @@ private:
         WARP_THREADS                = 1 << LOG_WARP_THREADS,
         PARTIAL_WARP_THREADS        = BLOCK_THREADS % WARP_THREADS,
         WARPS                       = (BLOCK_THREADS + WARP_THREADS - 1) / WARP_THREADS,
-        PARTIAL_WARP_ID             = WARPS - 1,
 
         PADDED_WARPS            = ((WARPS & 0x1) == 0) ?
                                     WARPS + 1 :
@@ -733,7 +732,7 @@ public:
               detail::warp_in_block_matcher_t<
                 RADIX_BITS, 
                 PARTIAL_WARP_THREADS, 
-                PARTIAL_WARP_ID>::match_any(digit, warp_id);
+                WARPS - 1>::match_any(digit, warp_id);
 
             // Pointer to smem digit counter for this key
             digit_counters[ITEM] = &temp_storage.aliasable.warp_digit_counters[digit][warp_id];
@@ -1079,7 +1078,7 @@ struct BlockRadixRankMatchEarlyCounts
                 int bin = Digit(keys[u]);
                 int bin_mask = detail::warp_in_block_matcher_t<RADIX_BITS,
                                                                PARTIAL_WARP_THREADS,
-                                                               PARTIAL_WARP_ID>::match_any(bin,
+                                                               BLOCK_WARPS - 1>::match_any(bin,
                                                                                            warp);
                 int leader = (WARP_THREADS - 1) - __clz(bin_mask);
                 int warp_offset = 0;

--- a/cub/block/block_radix_rank.cuh
+++ b/cub/block/block_radix_rank.cuh
@@ -143,17 +143,34 @@ struct warp_in_block_matcher_t<Bits, 0, PartialWarpId>
  * \par Performance Considerations
  * - \granularity
  *
- * \par Examples
  * \par
- * - <b>Example 1:</b> Simple radix rank of 32-bit integer keys
- *      \code
- *      #include <cub/cub.cuh>
+ * \code
+ * #include <cub/cub.cuh>
  *
- *      template <int BLOCK_THREADS>
- *      __global__ void ExampleKernel(...)
- *      {
+ * __global__ void ExampleKernel(...)
+ * {
+ *   constexpr int block_threads = 2;
+ *   constexpr int radix_bits = 5;
  *
- *      \endcode
+ *   // Specialize BlockRadixRank for a 1D block of 2 threads 
+ *   using block_radix_rank = cub::BlockRadixRank<block_threads, radix_bits>;
+ *   using storage_t = typename block_radix_rank::TempStorage;
+ *
+ *   // Allocate shared memory for BlockRadixSort
+ *   __shared__ storage_t temp_storage;
+ *
+ *   // Obtain a segment of consecutive items that are blocked across threads
+ *   int keys[2];
+ *   int ranks[2];
+ *   ...
+ *
+ *   cub::BFEDigitExtractor<int> extractor(0, radix_bits);
+ *   block_radix_rank(temp_storage).RankKeys(keys, ranks, extractor);
+ *
+ *   ...
+ * \endcode
+ * Suppose the set of input `keys` across the block of threads is `{ [16,10], [9,11] }`.  
+ * The corresponding output `ranks` in those threads will be `{ [3,1], [0,2] }`.
  *
  * \par Re-using dynamically allocating shared memory
  * The following example under the examples/block folder illustrates usage of

--- a/cub/util_ptx.cuh
+++ b/cub/util_ptx.cuh
@@ -686,43 +686,63 @@ __device__ __forceinline__ T ShuffleIndex(
 }
 
 
+namespace detail 
+{
+
+template <int LABEL_BITS, int WARP_ACTIVE_THREADS>
+struct warp_matcher_t 
+{
+
+  static __device__ unsigned int match_any(unsigned int label)
+  {
+    return warp_matcher_t<LABEL_BITS, 32>::match_any(label) & ~(~0 << WARP_ACTIVE_THREADS);
+  }
+
+};
+
+template <int LABEL_BITS>
+struct warp_matcher_t<LABEL_BITS, CUB_PTX_WARP_THREADS> 
+{
+
+  // match.any.sync.b32 is slower when matching a few bits
+  // using a ballot loop instead
+  static __device__ unsigned int match_any(unsigned int label)
+  {
+      unsigned int retval;
+
+      // Extract masks of common threads for each bit
+      #pragma unroll
+      for (int BIT = 0; BIT < LABEL_BITS; ++BIT)
+      {
+          unsigned int mask;
+          unsigned int current_bit = 1 << BIT;
+          asm ("{\n"
+              "    .reg .pred p;\n"
+              "    and.b32 %0, %1, %2;"
+              "    setp.eq.u32 p, %0, %2;\n"
+              "    vote.ballot.sync.b32 %0, p, 0xffffffff;\n"
+              "    @!p not.b32 %0, %0;\n"
+              "}\n" : "=r"(mask) : "r"(label), "r"(current_bit));
+
+          // Remove peers who differ
+          retval = (BIT == 0) ? mask : retval & mask;
+      }
+
+      return retval;
+  }
+
+};
+
+} // namespace detail
 
 /**
  * Compute a 32b mask of threads having the same least-significant
  * LABEL_BITS of \p label as the calling thread.
  */
-template <int LABEL_BITS>
+template <int LABEL_BITS, int WARP_ACTIVE_THREADS = CUB_PTX_WARP_THREADS>
 inline __device__ unsigned int MatchAny(unsigned int label)
 {
-    unsigned int retval;
-
-    // Extract masks of common threads for each bit
-    #pragma unroll
-    for (int BIT = 0; BIT < LABEL_BITS; ++BIT)
-    {
-        unsigned int mask;
-        unsigned int current_bit = 1 << BIT;
-        asm ("{\n"
-            "    .reg .pred p;\n"
-            "    and.b32 %0, %1, %2;"
-            "    setp.eq.u32 p, %0, %2;\n"
-            "    vote.ballot.sync.b32 %0, p, 0xffffffff;\n"
-            "    @!p not.b32 %0, %0;\n"
-            "}\n" : "=r"(mask) : "r"(label), "r"(current_bit));
-
-        // Remove peers who differ
-        retval = (BIT == 0) ? mask : retval & mask;
-    }
-
-    return retval;
-
-//  // VOLTA match
-//    unsigned int retval;
-//    asm ("{\n"
-//         "    match.any.sync.b32 %0, %1, 0xffffffff;\n"
-//         "}\n" : "=r"(retval) : "r"(label));
-//    return retval;
-
+  return detail::warp_matcher_t<LABEL_BITS, WARP_ACTIVE_THREADS>::match_any(label);
 }
 
 CUB_NAMESPACE_END

--- a/cub/util_ptx.cuh
+++ b/cub/util_ptx.cuh
@@ -689,6 +689,21 @@ __device__ __forceinline__ T ShuffleIndex(
 namespace detail 
 {
 
+/** 
+ * Implementation detail for `MatchAny`. It provides specializations for full and partial warps. 
+ * For partial warps, inactive threads must be masked out. This is done in the partial warp 
+ * specialization below. 
+ * Usage:
+ * ```
+ * // returns a mask of threads with the same 4 least-significant bits of `label` 
+ * // in a warp with 16 active threads
+ * warp_matcher_t<4, 16>::match_any(label); 
+ *
+ * // returns a mask of threads with the same 4 least-significant bits of `label` 
+ * // in a warp with 32 active threads (no extra work is done)
+ * warp_matcher_t<4, 32>::match_any(label); 
+ * ```
+ */
 template <int LABEL_BITS, int WARP_ACTIVE_THREADS>
 struct warp_matcher_t 
 {

--- a/test/test_block_radix_rank.cu
+++ b/test/test_block_radix_rank.cu
@@ -1,0 +1,343 @@
+/******************************************************************************
+ * Copyright (c) 2011-2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+// Ensure printing of CUDA runtime errors to console
+#include "cub/util_type.cuh"
+#define CUB_STDERR
+
+#include <cub/block/block_load.cuh>
+#include <cub/block/block_radix_rank.cuh>
+#include <cub/block/block_store.cuh>
+#include <cub/block/radix_rank_sort_operations.cuh>
+#include <cub/util_allocator.cuh>
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+
+#include "test_util.h"
+#include <stdio.h>
+
+bool g_verbose = false;
+cub::CachingDeviceAllocator g_allocator(true);
+
+template <cub::RadixRankAlgorithm RankAlgorithm,
+          int BlockThreads,
+          int ItemsPerThread,
+          int RadixBits,
+          cub::BlockScanAlgorithm ScanAlgorithm,
+          int Descending,
+          typename Key>
+__launch_bounds__(BlockThreads, 1) __global__ void kernel(Key *d_keys, int *d_ranks)
+{
+  using block_radix_rank = cub::detail::
+    block_radix_rank_t<RankAlgorithm, BlockThreads, RadixBits, Descending, ScanAlgorithm>;
+
+  using storage_t = typename block_radix_rank::TempStorage;
+
+  // Allocate temp storage in shared memory
+  __shared__ storage_t temp_storage;
+
+  // Items per thread
+  Key keys[ItemsPerThread];
+  int ranks[ItemsPerThread];
+
+  constexpr bool uses_warp_striped_arrangement =
+    RankAlgorithm == cub::RadixRankAlgorithm::RADIX_RANK_MATCH ||
+    RankAlgorithm == cub::RadixRankAlgorithm::RADIX_RANK_MATCH_EARLY_COUNTS_ANY ||
+    RankAlgorithm == cub::RadixRankAlgorithm::RADIX_RANK_MATCH_EARLY_COUNTS_ATOMIC_OR;
+
+  if (uses_warp_striped_arrangement)
+  {
+    cub::LoadDirectWarpStriped(threadIdx.x, d_keys, keys);
+  }
+  else
+  {
+    cub::LoadDirectBlocked(threadIdx.x, d_keys, keys);
+  }
+
+  cub::BFEDigitExtractor<Key> extractor(0, RadixBits);
+  block_radix_rank(temp_storage).RankKeys(keys, ranks, extractor);
+
+  if (uses_warp_striped_arrangement)
+  {
+    cub::StoreDirectWarpStriped(threadIdx.x, d_ranks, ranks);
+  }
+  else
+  {
+    cub::StoreDirectBlocked(threadIdx.x, d_ranks, ranks);
+  }
+}
+
+//---------------------------------------------------------------------
+// Host testing subroutines
+//---------------------------------------------------------------------
+
+/**
+ * Simple key-value pairing
+ */
+template <typename Key>
+struct pair_t
+{
+  Key key;
+  int value;
+
+  bool operator<(const pair_t &b) const { return (key < b.key); }
+};
+
+template <bool DESCENDING, typename Key>
+void Initialize(GenMode gen_mode, Key *h_keys, int *h_reference_ranks, int num_items, int num_bits)
+{
+  std::unique_ptr<pair_t<Key>[]> h_pairs_storage(new pair_t<Key>[num_items]);
+  pair_t<Key> *h_pairs = h_pairs_storage.get();
+
+  for (int i = 0; i < num_items; ++i)
+  {
+    InitValue(gen_mode, h_keys[i], i);
+
+    // Mask off unwanted portions
+    std::uint64_t base = 0;
+    memcpy(&base, &h_keys[i], sizeof(Key));
+    base &= (1ull << num_bits) - 1;
+    memcpy(&h_keys[i], &base, sizeof(Key));
+
+    h_pairs[i].key   = h_keys[i];
+    h_pairs[i].value = i;
+  }
+
+  if (DESCENDING)
+  {
+    std::reverse(h_pairs, h_pairs + num_items);
+  }
+
+  std::stable_sort(h_pairs, h_pairs + num_items);
+
+  if (DESCENDING)
+  {
+    std::reverse(h_pairs, h_pairs + num_items);
+  }
+
+  for (int i = 0; i < num_items; ++i)
+  {
+    h_reference_ranks[h_pairs[i].value] = i;
+  }
+}
+
+template <cub::RadixRankAlgorithm RankAlgorithm,
+          int BlockThreads,
+          int ItemsPerThread,
+          int RadixBits,
+          cub::BlockScanAlgorithm ScanAlgorithm,
+          int Descending,
+          typename Key>
+void TestDriver(GenMode gen_mode)
+{
+  constexpr int tile_size = BlockThreads * ItemsPerThread;
+
+  // Allocate host arrays
+  std::unique_ptr<Key> h_keys(new Key[tile_size]);
+  std::unique_ptr<int> h_ranks(new int[tile_size]);
+  std::unique_ptr<int> h_reference_ranks(new int[tile_size]);
+
+  // Allocate device arrays
+  Key *d_keys  = nullptr;
+  int *d_ranks = nullptr;
+
+  CubDebugExit(g_allocator.DeviceAllocate((void **)&d_keys, sizeof(Key) * tile_size));
+  CubDebugExit(g_allocator.DeviceAllocate((void **)&d_ranks, sizeof(int) * tile_size));
+
+  // Initialize problem and solution on host
+  Initialize<Descending>(gen_mode, h_keys.get(), h_reference_ranks.get(), tile_size, RadixBits);
+
+  // Copy problem to device
+  CubDebugExit(cudaMemcpy(d_keys, h_keys.get(), sizeof(Key) * tile_size, cudaMemcpyHostToDevice));
+
+  // Run kernel
+  kernel<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, Descending, Key>
+    <<<1, BlockThreads>>>(d_keys, d_ranks);
+
+  // Flush kernel output / errors
+  CubDebugExit(cudaPeekAtLastError());
+  CubDebugExit(cudaDeviceSynchronize());
+
+  // Check keys results
+  const bool compare =
+    CompareDeviceResults(h_reference_ranks.get(), d_ranks, tile_size, g_verbose, g_verbose);
+  AssertEquals(0, compare);
+
+  if (d_keys)
+  {
+    CubDebugExit(g_allocator.DeviceFree(d_keys));
+  }
+
+  if (d_ranks)
+  {
+    CubDebugExit(g_allocator.DeviceFree(d_ranks));
+  }
+}
+
+template <cub::RadixRankAlgorithm RankAlgorithm,
+          int BlockThreads,
+          int ItemsPerThread,
+          int RadixBits,
+          cub::BlockScanAlgorithm ScanAlgorithm,
+          int Descending,
+          typename Key>
+void TestValid(cub::Int2Type<true> /*fits_smem_capacity*/)
+{
+  TestDriver<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, Descending, Key>(
+    UNIFORM);
+
+  TestDriver<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, Descending, Key>(
+    INTEGER_SEED);
+}
+
+template <cub::RadixRankAlgorithm RankAlgorithm,
+          int BlockThreads,
+          int ItemsPerThread,
+          int RadixBits,
+          cub::BlockScanAlgorithm ScanAlgorithm,
+          int Descending,
+          typename Key>
+void TestValid(cub::Int2Type<false> fits_smem_capacity)
+{}
+
+template <cub::RadixRankAlgorithm RankAlgorithm,
+          int BlockThreads,
+          int ItemsPerThread,
+          int RadixBits,
+          cub::BlockScanAlgorithm ScanAlgorithm,
+          bool Descending,
+          typename Key>
+void Test()
+{
+  // Check size of smem storage for the target arch to make sure it will fit
+  using block_radix_rank = cub::detail::
+    block_radix_rank_t<RankAlgorithm, BlockThreads, RadixBits, Descending, ScanAlgorithm>;
+  using storage_t = typename block_radix_rank::TempStorage;
+
+  cub::Int2Type<(sizeof(storage_t) <= 48 * 1024)> fits_smem_capacity;
+
+  TestValid<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, Descending, Key>(
+    fits_smem_capacity);
+}
+
+template <cub::RadixRankAlgorithm RankAlgorithm,
+          int BlockThreads,
+          int ItemsPerThread,
+          int RadixBits,
+          cub::BlockScanAlgorithm ScanAlgorithm,
+          typename Key>
+void Test()
+{
+  Test<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, true, Key>();
+  Test<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, false, Key>();
+}
+
+template <cub::RadixRankAlgorithm RankAlgorithm,
+          int BlockThreads,
+          int ItemsPerThread,
+          int RadixBits,
+          cub::BlockScanAlgorithm ScanAlgorithm>
+void Test()
+{
+  Test<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, std::uint8_t>();
+  Test<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, ScanAlgorithm, std::uint16_t>();
+}
+
+template <cub::RadixRankAlgorithm RankAlgorithm, int BlockThreads, int ItemsPerThread, int RadixBits>
+void Test()
+{
+  Test<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, cub::BLOCK_SCAN_RAKING>();
+  Test<RankAlgorithm, BlockThreads, ItemsPerThread, RadixBits, cub::BLOCK_SCAN_WARP_SCANS>();
+}
+
+template <cub::RadixRankAlgorithm RankAlgorithm, int BlockThreads, int ItemsPerThread>
+void Test()
+{
+  Test<RankAlgorithm, BlockThreads, ItemsPerThread, 1>();
+  Test<RankAlgorithm, BlockThreads, ItemsPerThread, 5>();
+}
+
+template <cub::RadixRankAlgorithm RankAlgorithm, int BlockThreads>
+void Test()
+{
+  Test<RankAlgorithm, BlockThreads, 1>();
+  Test<RankAlgorithm, BlockThreads, 4>();
+}
+
+template <int BlockThreads>
+void Test(cub::Int2Type<true> /* multiple of hw warp */)
+{
+  Test<cub::RadixRankAlgorithm::RADIX_RANK_MATCH, BlockThreads>();
+
+  // TODO(senior-zero):
+  // - RADIX_RANK_MATCH_EARLY_COUNTS_ANY
+  // - RADIX_RANK_MATCH_EARLY_COUNTS_ATOMIC_OR
+}
+
+template <int BlockThreads>
+void Test(cub::Int2Type<false> /* multiple of hw warp */)
+{}
+
+template <int BlockThreads>
+void Test()
+{
+  Test<cub::RadixRankAlgorithm::RADIX_RANK_BASIC, BlockThreads>();
+  Test<cub::RadixRankAlgorithm::RADIX_RANK_MEMOIZE, BlockThreads>();
+
+  Test<BlockThreads>(cub::Int2Type<(BlockThreads % 32) == 0>{});
+}
+
+int main(int argc, char **argv)
+{
+  // Initialize command line
+  CommandLineArgs args(argc, argv);
+  g_verbose = args.CheckCmdLineFlag("v");
+
+  // Print usage
+  if (args.CheckCmdLineFlag("help"))
+  {
+    printf("%s "
+           "[--device=<device-id>] "
+           "[--v] "
+           "\n",
+           argv[0]);
+    exit(0);
+  }
+
+  // Initialize device
+  CubDebugExit(args.DeviceInit());
+
+  Test<16>();
+  Test<32>();
+  Test<128>();
+  Test<130>();
+
+  return 0;
+}
+


### PR DESCRIPTION
This PR addresses the following [issue](https://github.com/NVIDIA/cub/issues/552) by masking inactive threads in match any. The code generation hasn't changed for thread blocks with `(BlockThreads % 32) = 0`.