### PR TITLE
Add DeviceMergeSort::StableSortKeysCopy API

### DIFF
--- a/cub/device/device_merge_sort.cuh
+++ b/cub/device/device_merge_sort.cuh
@@ -34,7 +34,6 @@
 
 CUB_NAMESPACE_BEGIN
 
-
 /**
  * @brief DeviceMergeSort provides device-wide, parallel operations for
  *        computing a merge sort across a sequence of data items residing within
@@ -233,26 +232,26 @@ struct DeviceMergeSort
             typename OffsetT,
             typename CompareOpT>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-  CUB_RUNTIME_FUNCTION static cudaError_t
-  SortPairs(void *d_temp_storage,
-            std::size_t &temp_storage_bytes,
-            KeyIteratorT d_keys,
-            ValueIteratorT d_items,
-            OffsetT num_items,
-            CompareOpT compare_op,
-            cudaStream_t stream,
-            bool debug_synchronous)
+      CUB_RUNTIME_FUNCTION static cudaError_t
+      SortPairs(void *d_temp_storage,
+                std::size_t &temp_storage_bytes,
+                KeyIteratorT d_keys,
+                ValueIteratorT d_items,
+                OffsetT num_items,
+                CompareOpT compare_op,
+                cudaStream_t stream,
+                bool debug_synchronous)
   {
     CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
 
     return SortPairs<KeyIteratorT, ValueIteratorT, OffsetT, CompareOpT>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_keys,
-      d_items,
-      num_items,
-      compare_op,
-      stream);
+        d_temp_storage,
+        temp_storage_bytes,
+        d_keys,
+        d_items,
+        num_items,
+        compare_op,
+        stream);
   }
 
   /**
@@ -408,17 +407,17 @@ struct DeviceMergeSort
             typename OffsetT,
             typename CompareOpT>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-  CUB_RUNTIME_FUNCTION static cudaError_t
-  SortPairsCopy(void *d_temp_storage,
-                std::size_t &temp_storage_bytes,
-                KeyInputIteratorT d_input_keys,
-                ValueInputIteratorT d_input_items,
-                KeyIteratorT d_output_keys,
-                ValueIteratorT d_output_items,
-                OffsetT num_items,
-                CompareOpT compare_op,
-                cudaStream_t stream,
-                bool debug_synchronous)
+      CUB_RUNTIME_FUNCTION static cudaError_t
+      SortPairsCopy(void *d_temp_storage,
+                    std::size_t &temp_storage_bytes,
+                    KeyInputIteratorT d_input_keys,
+                    ValueInputIteratorT d_input_items,
+                    KeyIteratorT d_output_keys,
+                    ValueIteratorT d_output_items,
+                    OffsetT num_items,
+                    CompareOpT compare_op,
+                    cudaStream_t stream,
+                    bool debug_synchronous)
   {
     CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
 
@@ -554,14 +553,14 @@ struct DeviceMergeSort
             typename OffsetT,
             typename CompareOpT>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-  CUB_RUNTIME_FUNCTION static cudaError_t
-  SortKeys(void *d_temp_storage,
-           std::size_t &temp_storage_bytes,
-           KeyIteratorT d_keys,
-           OffsetT num_items,
-           CompareOpT compare_op,
-           cudaStream_t stream,
-           bool debug_synchronous)
+      CUB_RUNTIME_FUNCTION static cudaError_t
+      SortKeys(void *d_temp_storage,
+               std::size_t &temp_storage_bytes,
+               KeyIteratorT d_keys,
+               OffsetT num_items,
+               CompareOpT compare_op,
+               cudaStream_t stream,
+               bool debug_synchronous)
   {
     CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
 
@@ -705,26 +704,26 @@ struct DeviceMergeSort
             typename OffsetT,
             typename CompareOpT>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-  CUB_RUNTIME_FUNCTION static cudaError_t
-  SortKeysCopy(void *d_temp_storage,
-               std::size_t &temp_storage_bytes,
-               KeyInputIteratorT d_input_keys,
-               KeyIteratorT d_output_keys,
-               OffsetT num_items,
-               CompareOpT compare_op,
-               cudaStream_t stream,
-               bool debug_synchronous)
+      CUB_RUNTIME_FUNCTION static cudaError_t
+      SortKeysCopy(void *d_temp_storage,
+                   std::size_t &temp_storage_bytes,
+                   KeyInputIteratorT d_input_keys,
+                   KeyIteratorT d_output_keys,
+                   OffsetT num_items,
+                   CompareOpT compare_op,
+                   cudaStream_t stream,
+                   bool debug_synchronous)
   {
     CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
 
     return SortKeysCopy<KeyInputIteratorT, KeyIteratorT, OffsetT, CompareOpT>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_input_keys,
-      d_output_keys,
-      num_items,
-      compare_op,
-      stream);
+        d_temp_storage,
+        temp_storage_bytes,
+        d_input_keys,
+        d_output_keys,
+        num_items,
+        compare_op,
+        stream);
   }
 
   /**
@@ -833,13 +832,13 @@ struct DeviceMergeSort
                   cudaStream_t stream = 0)
   {
     return SortPairs<KeyIteratorT, ValueIteratorT, OffsetT, CompareOpT>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_keys,
-      d_items,
-      num_items,
-      compare_op,
-      stream);
+        d_temp_storage,
+        temp_storage_bytes,
+        d_keys,
+        d_items,
+        num_items,
+        compare_op,
+        stream);
   }
 
   template <typename KeyIteratorT,
@@ -847,26 +846,26 @@ struct DeviceMergeSort
             typename OffsetT,
             typename CompareOpT>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-  CUB_RUNTIME_FUNCTION static cudaError_t
-  StableSortPairs(void *d_temp_storage,
-                  std::size_t &temp_storage_bytes,
-                  KeyIteratorT d_keys,
-                  ValueIteratorT d_items,
-                  OffsetT num_items,
-                  CompareOpT compare_op,
-                  cudaStream_t stream,
-                  bool debug_synchronous)
+      CUB_RUNTIME_FUNCTION static cudaError_t
+      StableSortPairs(void *d_temp_storage,
+                      std::size_t &temp_storage_bytes,
+                      KeyIteratorT d_keys,
+                      ValueIteratorT d_items,
+                      OffsetT num_items,
+                      CompareOpT compare_op,
+                      cudaStream_t stream,
+                      bool debug_synchronous)
   {
     CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
 
     return StableSortPairs<KeyIteratorT, ValueIteratorT, OffsetT, CompareOpT>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_keys,
-      d_items,
-      num_items,
-      compare_op,
-      stream);
+        d_temp_storage,
+        temp_storage_bytes,
+        d_keys,
+        d_items,
+        num_items,
+        compare_op,
+        stream);
   }
 
   /**
@@ -976,14 +975,14 @@ struct DeviceMergeSort
             typename OffsetT,
             typename CompareOpT>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-  CUB_RUNTIME_FUNCTION static cudaError_t
-  StableSortKeys(void *d_temp_storage,
-                 std::size_t &temp_storage_bytes,
-                 KeyIteratorT d_keys,
-                 OffsetT num_items,
-                 CompareOpT compare_op,
-                 cudaStream_t stream,
-                 bool debug_synchronous)
+      CUB_RUNTIME_FUNCTION static cudaError_t
+      StableSortKeys(void *d_temp_storage,
+                     std::size_t &temp_storage_bytes,
+                     KeyIteratorT d_keys,
+                     OffsetT num_items,
+                     CompareOpT compare_op,
+                     cudaStream_t stream,
+                     bool debug_synchronous)
   {
     CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
 
@@ -993,6 +992,54 @@ struct DeviceMergeSort
                                                              num_items,
                                                              compare_op,
                                                              stream);
+  }
+
+  template <typename KeyInputIteratorT,
+            typename KeyIteratorT,
+            typename OffsetT,
+            typename CompareOpT>
+  CUB_RUNTIME_FUNCTION static cudaError_t
+  StableSortKeysCopy(void *d_temp_storage,
+                     std::size_t &temp_storage_bytes,
+                     KeyInputIteratorT d_input_keys,
+                     KeyIteratorT d_output_keys,
+                     OffsetT num_items,
+                     CompareOpT compare_op,
+                     cudaStream_t stream = 0)
+  {
+    return SortKeysCopy<KeyInputIteratorT, KeyIteratorT, OffsetT, CompareOpT>(d_temp_storage,
+                                                                              temp_storage_bytes,
+                                                                              d_input_keys,
+                                                                              d_output_keys,
+                                                                              num_items,
+                                                                              compare_op,
+                                                                              stream);
+  }
+
+  template <typename KeyInputIteratorT,
+            typename KeyIteratorT,
+            typename OffsetT,
+            typename CompareOpT>
+  CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
+      CUB_RUNTIME_FUNCTION static cudaError_t
+      StableSortKeysCopy(void *d_temp_storage,
+                         std::size_t &temp_storage_bytes,
+                         KeyInputIteratorT d_input_keys,
+                         KeyIteratorT d_output_keys,
+                         OffsetT num_items,
+                         CompareOpT compare_op,
+                         cudaStream_t stream,
+                         bool debug_synchronous)
+  {
+    CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
+
+    return StableSortKeysCopy<KeyInputIteratorT, KeyIteratorT, OffsetT, CompareOpT>(d_temp_storage,
+                                                                                    temp_storage_bytes,
+                                                                                    d_input_keys,
+                                                                                    d_output_keys,
+                                                                                    num_items,
+                                                                                    compare_op,
+                                                                                    stream);
   }
 };
 

--- a/cub/device/device_merge_sort.cuh
+++ b/cub/device/device_merge_sort.cuh
@@ -34,6 +34,7 @@
 
 CUB_NAMESPACE_BEGIN
 
+
 /**
  * @brief DeviceMergeSort provides device-wide, parallel operations for
  *        computing a merge sort across a sequence of data items residing within
@@ -232,26 +233,26 @@ struct DeviceMergeSort
             typename OffsetT,
             typename CompareOpT>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-      CUB_RUNTIME_FUNCTION static cudaError_t
-      SortPairs(void *d_temp_storage,
-                std::size_t &temp_storage_bytes,
-                KeyIteratorT d_keys,
-                ValueIteratorT d_items,
-                OffsetT num_items,
-                CompareOpT compare_op,
-                cudaStream_t stream,
-                bool debug_synchronous)
+  CUB_RUNTIME_FUNCTION static cudaError_t
+  SortPairs(void *d_temp_storage,
+            std::size_t &temp_storage_bytes,
+            KeyIteratorT d_keys,
+            ValueIteratorT d_items,
+            OffsetT num_items,
+            CompareOpT compare_op,
+            cudaStream_t stream,
+            bool debug_synchronous)
   {
     CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
 
     return SortPairs<KeyIteratorT, ValueIteratorT, OffsetT, CompareOpT>(
-        d_temp_storage,
-        temp_storage_bytes,
-        d_keys,
-        d_items,
-        num_items,
-        compare_op,
-        stream);
+      d_temp_storage,
+      temp_storage_bytes,
+      d_keys,
+      d_items,
+      num_items,
+      compare_op,
+      stream);
   }
 
   /**
@@ -407,17 +408,17 @@ struct DeviceMergeSort
             typename OffsetT,
             typename CompareOpT>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-      CUB_RUNTIME_FUNCTION static cudaError_t
-      SortPairsCopy(void *d_temp_storage,
-                    std::size_t &temp_storage_bytes,
-                    KeyInputIteratorT d_input_keys,
-                    ValueInputIteratorT d_input_items,
-                    KeyIteratorT d_output_keys,
-                    ValueIteratorT d_output_items,
-                    OffsetT num_items,
-                    CompareOpT compare_op,
-                    cudaStream_t stream,
-                    bool debug_synchronous)
+  CUB_RUNTIME_FUNCTION static cudaError_t
+  SortPairsCopy(void *d_temp_storage,
+                std::size_t &temp_storage_bytes,
+                KeyInputIteratorT d_input_keys,
+                ValueInputIteratorT d_input_items,
+                KeyIteratorT d_output_keys,
+                ValueIteratorT d_output_items,
+                OffsetT num_items,
+                CompareOpT compare_op,
+                cudaStream_t stream,
+                bool debug_synchronous)
   {
     CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
 
@@ -553,14 +554,14 @@ struct DeviceMergeSort
             typename OffsetT,
             typename CompareOpT>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-      CUB_RUNTIME_FUNCTION static cudaError_t
-      SortKeys(void *d_temp_storage,
-               std::size_t &temp_storage_bytes,
-               KeyIteratorT d_keys,
-               OffsetT num_items,
-               CompareOpT compare_op,
-               cudaStream_t stream,
-               bool debug_synchronous)
+  CUB_RUNTIME_FUNCTION static cudaError_t
+  SortKeys(void *d_temp_storage,
+           std::size_t &temp_storage_bytes,
+           KeyIteratorT d_keys,
+           OffsetT num_items,
+           CompareOpT compare_op,
+           cudaStream_t stream,
+           bool debug_synchronous)
   {
     CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
 
@@ -704,26 +705,26 @@ struct DeviceMergeSort
             typename OffsetT,
             typename CompareOpT>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-      CUB_RUNTIME_FUNCTION static cudaError_t
-      SortKeysCopy(void *d_temp_storage,
-                   std::size_t &temp_storage_bytes,
-                   KeyInputIteratorT d_input_keys,
-                   KeyIteratorT d_output_keys,
-                   OffsetT num_items,
-                   CompareOpT compare_op,
-                   cudaStream_t stream,
-                   bool debug_synchronous)
+  CUB_RUNTIME_FUNCTION static cudaError_t
+  SortKeysCopy(void *d_temp_storage,
+               std::size_t &temp_storage_bytes,
+               KeyInputIteratorT d_input_keys,
+               KeyIteratorT d_output_keys,
+               OffsetT num_items,
+               CompareOpT compare_op,
+               cudaStream_t stream,
+               bool debug_synchronous)
   {
     CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
 
     return SortKeysCopy<KeyInputIteratorT, KeyIteratorT, OffsetT, CompareOpT>(
-        d_temp_storage,
-        temp_storage_bytes,
-        d_input_keys,
-        d_output_keys,
-        num_items,
-        compare_op,
-        stream);
+      d_temp_storage,
+      temp_storage_bytes,
+      d_input_keys,
+      d_output_keys,
+      num_items,
+      compare_op,
+      stream);
   }
 
   /**
@@ -832,13 +833,13 @@ struct DeviceMergeSort
                   cudaStream_t stream = 0)
   {
     return SortPairs<KeyIteratorT, ValueIteratorT, OffsetT, CompareOpT>(
-        d_temp_storage,
-        temp_storage_bytes,
-        d_keys,
-        d_items,
-        num_items,
-        compare_op,
-        stream);
+      d_temp_storage,
+      temp_storage_bytes,
+      d_keys,
+      d_items,
+      num_items,
+      compare_op,
+      stream);
   }
 
   template <typename KeyIteratorT,
@@ -846,26 +847,26 @@ struct DeviceMergeSort
             typename OffsetT,
             typename CompareOpT>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-      CUB_RUNTIME_FUNCTION static cudaError_t
-      StableSortPairs(void *d_temp_storage,
-                      std::size_t &temp_storage_bytes,
-                      KeyIteratorT d_keys,
-                      ValueIteratorT d_items,
-                      OffsetT num_items,
-                      CompareOpT compare_op,
-                      cudaStream_t stream,
-                      bool debug_synchronous)
+  CUB_RUNTIME_FUNCTION static cudaError_t
+  StableSortPairs(void *d_temp_storage,
+                  std::size_t &temp_storage_bytes,
+                  KeyIteratorT d_keys,
+                  ValueIteratorT d_items,
+                  OffsetT num_items,
+                  CompareOpT compare_op,
+                  cudaStream_t stream,
+                  bool debug_synchronous)
   {
     CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
 
     return StableSortPairs<KeyIteratorT, ValueIteratorT, OffsetT, CompareOpT>(
-        d_temp_storage,
-        temp_storage_bytes,
-        d_keys,
-        d_items,
-        num_items,
-        compare_op,
-        stream);
+      d_temp_storage,
+      temp_storage_bytes,
+      d_keys,
+      d_items,
+      num_items,
+      compare_op,
+      stream);
   }
 
   /**
@@ -975,14 +976,14 @@ struct DeviceMergeSort
             typename OffsetT,
             typename CompareOpT>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-      CUB_RUNTIME_FUNCTION static cudaError_t
-      StableSortKeys(void *d_temp_storage,
-                     std::size_t &temp_storage_bytes,
-                     KeyIteratorT d_keys,
-                     OffsetT num_items,
-                     CompareOpT compare_op,
-                     cudaStream_t stream,
-                     bool debug_synchronous)
+  CUB_RUNTIME_FUNCTION static cudaError_t
+  StableSortKeys(void *d_temp_storage,
+                 std::size_t &temp_storage_bytes,
+                 KeyIteratorT d_keys,
+                 OffsetT num_items,
+                 CompareOpT compare_op,
+                 cudaStream_t stream,
+                 bool debug_synchronous)
   {
     CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
 
@@ -993,6 +994,7 @@ struct DeviceMergeSort
                                                              compare_op,
                                                              stream);
   }
+
 
   template <typename KeyInputIteratorT,
             typename KeyIteratorT,
@@ -1041,6 +1043,7 @@ struct DeviceMergeSort
                                                                                     compare_op,
                                                                                     stream);
   }
+
 };
 
 CUB_NAMESPACE_END

--- a/cub/device/device_merge_sort.cuh
+++ b/cub/device/device_merge_sort.cuh
@@ -995,7 +995,103 @@ struct DeviceMergeSort
                                                              stream);
   }
 
-
+  /**
+   * @brief Sorts items using a merge sorting method.
+   *
+   * @par
+   * - StableSortKeysCopy is stable: it preserves the relative ordering of equivalent
+   *   elements. That is, if `x` and `y` are elements such that `x` precedes `y`,
+   *   and if the two elements are equivalent (neither `x < y` nor `y < x`) then
+   *   a postcondition of stable_sort is that `x` still precedes `y`.
+   * - Input array d_input_keys is not modified
+   * - Note that the behavior is undefined if the input and output ranges overlap
+   *   in any way.
+   *
+   * @par Snippet
+   * The code snippet below illustrates the sorting of a device vector of `int`
+   * keys.
+   * \par
+   * \code
+   * #include <cub/cub.cuh>
+   * // or equivalently <cub/device/device_merge_sort.cuh>
+   *
+   * // Declare, allocate, and initialize device-accessible pointers for
+   * // sorting data
+   * int  num_items;       // e.g., 7
+   * int  *d_input_keys;   // e.g., [8, 6, 7, 5, 3, 0, 9]
+   * int  *d_output_keys;  // must hold at least num_items elements
+   * ...
+   *
+   * // Initialize comparator
+   * CustomOpT custom_op;
+   *
+   * // Determine temporary device storage requirements
+   * void *d_temp_storage = nullptr;
+   * std::size_t temp_storage_bytes = 0;
+   * cub::DeviceMergeSort::StableSortKeysCopy(
+   *   d_temp_storage, temp_storage_bytes,
+   *   d_input_keys, d_output_keys, num_items, custom_op);
+   *
+   * // Allocate temporary storage
+   * cudaMalloc(&d_temp_storage, temp_storage_bytes);
+   *
+   * // Run sorting operation
+   * cub::DeviceMergeSort::StableSortKeysCopy(
+   *   d_temp_storage, temp_storage_bytes,
+   *   d_input_keys, d_output_keys, num_items, custom_op);
+   *
+   * // d_output_keys   <-- [0, 3, 5, 6, 7, 8, 9]
+   * @endcode
+   *
+   * @tparam KeyInputIteratorT
+   *   is a model of [Random Access Iterator]. Its `value_type` is a model of
+   *   [LessThan Comparable]. This `value_type`'s ordering relation is a
+   *   *strict weak ordering* as defined in the [LessThan Comparable]
+   *   requirements.
+   *
+   * @tparam KeyIteratorT
+   *   is a model of [Random Access Iterator]. `KeyIteratorT` is mutable, and
+   *   its `value_type` is a model of [LessThan Comparable]. This `value_type`'s
+   *   ordering relation is a *strict weak ordering* as defined in
+   *   the [LessThan Comparable] requirements.
+   *
+   * @tparam OffsetT
+   *   is an integer type for global offsets.
+   *
+   * @tparam CompareOpT
+   *   is a type of callable object with the signature
+   *   `bool operator()(KeyT lhs, KeyT rhs)` that models
+   *   the [Strict Weak Ordering] concept.
+   *
+   * @param[in] d_temp_storage
+   *   Device-accessible allocation of temporary storage. When `nullptr`, the
+   *   required allocation size is written to `temp_storage_bytes` and no work
+   *   is done.
+   *
+   * @param[in,out] temp_storage_bytes
+   *   Reference to size in bytes of `d_temp_storage` allocation
+   *
+   * @param[in] d_input_keys
+   *   Pointer to the input sequence of unsorted input keys
+   *
+   * @param[out] d_output_keys
+   *   Pointer to the output sequence of sorted input keys
+   *
+   * @param[in] num_items
+   *   Number of elements in d_input_keys to sort
+   *
+   * @param[in] compare_op
+   *   Comparison function object which returns true if the first argument is
+   *   ordered before the second
+   *
+   * @param[in] stream
+   *   **[optional]** CUDA stream to launch kernels within. Default is
+   *   stream<sub>0</sub>.
+   *
+   * [Random Access Iterator]: https://en.cppreference.com/w/cpp/iterator/random_access_iterator
+   * [Strict Weak Ordering]: https://en.cppreference.com/w/cpp/concepts/strict_weak_order
+   * [LessThan Comparable]: https://en.cppreference.com/w/cpp/named_req/LessThanComparable
+   */
   template <typename KeyInputIteratorT,
             typename KeyIteratorT,
             typename OffsetT,

--- a/cub/device/device_merge_sort.cuh
+++ b/cub/device/device_merge_sort.cuh
@@ -1113,33 +1113,6 @@ struct DeviceMergeSort
                                                                               compare_op,
                                                                               stream);
   }
-
-  template <typename KeyInputIteratorT,
-            typename KeyIteratorT,
-            typename OffsetT,
-            typename CompareOpT>
-  CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-      CUB_RUNTIME_FUNCTION static cudaError_t
-      StableSortKeysCopy(void *d_temp_storage,
-                         std::size_t &temp_storage_bytes,
-                         KeyInputIteratorT d_input_keys,
-                         KeyIteratorT d_output_keys,
-                         OffsetT num_items,
-                         CompareOpT compare_op,
-                         cudaStream_t stream,
-                         bool debug_synchronous)
-  {
-    CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
-
-    return StableSortKeysCopy<KeyInputIteratorT, KeyIteratorT, OffsetT, CompareOpT>(d_temp_storage,
-                                                                                    temp_storage_bytes,
-                                                                                    d_input_keys,
-                                                                                    d_output_keys,
-                                                                                    num_items,
-                                                                                    compare_op,
-                                                                                    stream);
-  }
-
 };
 
 CUB_NAMESPACE_END

--- a/test/test_device_merge_sort.cu
+++ b/test/test_device_merge_sort.cu
@@ -121,12 +121,12 @@ void Test(std::int64_t num_items,
   thrust::device_vector<char> tmp(temp_size);
 
   CubDebugExit(cub::DeviceMergeSort::SortPairs(
-      thrust::raw_pointer_cast(tmp.data()),
-      temp_size,
-      thrust::raw_pointer_cast(d_keys.data()),
-      thrust::raw_pointer_cast(d_values.data()),
-      num_items,
-      CustomLess()));
+    thrust::raw_pointer_cast(tmp.data()),
+    temp_size,
+    thrust::raw_pointer_cast(d_keys.data()),
+    thrust::raw_pointer_cast(d_values.data()),
+    num_items,
+    CustomLess()));
 
   thrust::device_vector<KeyType> d_keys_after_sort_copy(d_keys);
   thrust::device_vector<DataType> d_values_after_sort_copy(d_values);
@@ -134,14 +134,14 @@ void Test(std::int64_t num_items,
   AssertTrue(CheckResult(d_values));
 
   CubDebugExit(cub::DeviceMergeSort::SortPairsCopy(
-      thrust::raw_pointer_cast(tmp.data()),
-      temp_size,
-      thrust::raw_pointer_cast(d_keys_before_sort.data()),
-      thrust::raw_pointer_cast(d_values_before_sort.data()),
-      thrust::raw_pointer_cast(d_keys.data()),
-      thrust::raw_pointer_cast(d_values.data()),
-      num_items,
-      CustomLess()));
+    thrust::raw_pointer_cast(tmp.data()),
+    temp_size,
+    thrust::raw_pointer_cast(d_keys_before_sort.data()),
+    thrust::raw_pointer_cast(d_values_before_sort.data()),
+    thrust::raw_pointer_cast(d_keys.data()),
+    thrust::raw_pointer_cast(d_values.data()),
+    num_items,
+    CustomLess()));
 
   AssertEquals(d_keys, d_keys_after_sort_copy);
   AssertEquals(d_values, d_values_after_sort_copy);
@@ -151,24 +151,24 @@ void Test(std::int64_t num_items,
   // At the moment stable sort is an alias to sort, so it's safe to use
   // temp_size storage allocated before
   CubDebugExit(cub::DeviceMergeSort::StableSortPairs(
-      thrust::raw_pointer_cast(tmp.data()),
-      temp_size,
-      thrust::raw_pointer_cast(d_keys.data()),
-      thrust::raw_pointer_cast(d_values.data()),
-      num_items,
-      CustomLess()));
+    thrust::raw_pointer_cast(tmp.data()),
+    temp_size,
+    thrust::raw_pointer_cast(d_keys.data()),
+    thrust::raw_pointer_cast(d_values.data()),
+    num_items,
+    CustomLess()));
 
   AssertTrue(CheckResult(d_values));
 
   CubDebugExit(cub::DeviceMergeSort::SortPairsCopy(
-      thrust::raw_pointer_cast(tmp.data()),
-      temp_size,
-      thrust::constant_iterator<KeyType>(KeyType(42)),
-      thrust::counting_iterator<DataType>(DataType(0)),
-      thrust::raw_pointer_cast(d_keys.data()),
-      thrust::raw_pointer_cast(d_values.data()),
-      num_items,
-      CustomLess()));
+    thrust::raw_pointer_cast(tmp.data()),
+    temp_size,
+    thrust::constant_iterator<KeyType>(KeyType(42)),
+    thrust::counting_iterator<DataType>(DataType(0)),
+    thrust::raw_pointer_cast(d_keys.data()),
+    thrust::raw_pointer_cast(d_values.data()),
+    num_items,
+    CustomLess()));
 
   thrust::sequence(d_values_before_sort.begin(), d_values_before_sort.end());
 
@@ -194,32 +194,32 @@ void TestKeys(std::int64_t num_items,
 
   size_t temp_size = 0;
   cub::DeviceMergeSort::SortKeys(
-      nullptr,
-      temp_size,
-      thrust::raw_pointer_cast(d_keys.data()),
-      num_items,
-      CustomLess());
+    nullptr,
+    temp_size,
+    thrust::raw_pointer_cast(d_keys.data()),
+    num_items,
+    CustomLess());
 
   thrust::device_vector<char> tmp(temp_size);
 
   CubDebugExit(cub::DeviceMergeSort::SortKeys(
-      thrust::raw_pointer_cast(tmp.data()),
-      temp_size,
-      thrust::raw_pointer_cast(d_keys.data()),
-      num_items,
-      CustomLess()));
+    thrust::raw_pointer_cast(tmp.data()),
+    temp_size,
+    thrust::raw_pointer_cast(d_keys.data()),
+    num_items,
+    CustomLess()));
 
   thrust::device_vector<KeyType> d_after_sort(d_keys);
 
   AssertTrue(CheckResult(d_keys));
 
   CubDebugExit(cub::DeviceMergeSort::SortKeysCopy(
-      thrust::raw_pointer_cast(tmp.data()),
-      temp_size,
-      thrust::raw_pointer_cast(d_before_sort.data()),
-      thrust::raw_pointer_cast(d_keys.data()),
-      num_items,
-      CustomLess()));
+    thrust::raw_pointer_cast(tmp.data()),
+    temp_size,
+    thrust::raw_pointer_cast(d_before_sort.data()),
+    thrust::raw_pointer_cast(d_keys.data()),
+    num_items,
+    CustomLess()));
 
   AssertTrue(d_keys == d_after_sort);
   AssertTrue(d_before_sort == d_before_sort_copy);
@@ -227,11 +227,11 @@ void TestKeys(std::int64_t num_items,
   // At the moment stable sort is an alias to sort, so it's safe to use
   // temp_size storage allocated before
   CubDebugExit(cub::DeviceMergeSort::StableSortKeys(
-      thrust::raw_pointer_cast(tmp.data()),
-      temp_size,
-      thrust::raw_pointer_cast(d_keys.data()),
-      num_items,
-      CustomLess()));
+    thrust::raw_pointer_cast(tmp.data()),
+    temp_size,
+    thrust::raw_pointer_cast(d_keys.data()),
+    num_items,
+    CustomLess()));
 
   AssertTrue(CheckResult(d_keys));
 
@@ -267,14 +267,13 @@ struct TestHelper<false>
 {
   template <typename, typename>
   static void AllocateAndTest(thrust::default_random_engine &, unsigned int)
-  {
-  }
+  {}
 };
 
 template <typename DataType>
 void Test(thrust::default_random_engine &rng, unsigned int num_items)
 {
-  TestHelper<sizeof(DataType) <= sizeof(std::uint8_t)>::template AllocateAndTest<std::uint8_t, DataType>(rng, num_items);
+  TestHelper<sizeof(DataType) <= sizeof(std::uint8_t) >::template AllocateAndTest<std::uint8_t,  DataType>(rng, num_items);
   TestHelper<sizeof(DataType) <= sizeof(std::uint32_t)>::template AllocateAndTest<std::uint32_t, DataType>(rng, num_items);
   TestHelper<sizeof(DataType) <= sizeof(std::uint64_t)>::template AllocateAndTest<std::uint64_t, DataType>(rng, num_items);
 }
@@ -295,22 +294,22 @@ void AllocateAndTestIterators(unsigned int num_items)
 
   size_t temp_size = 0;
   cub::DeviceMergeSort::SortPairs(
-      nullptr,
-      temp_size,
-      reverse_iter,
-      thrust::raw_pointer_cast(d_values.data()),
-      num_items,
-      CustomLess());
+    nullptr,
+    temp_size,
+    reverse_iter,
+    thrust::raw_pointer_cast(d_values.data()),
+    num_items,
+    CustomLess());
 
   thrust::device_vector<char> tmp(temp_size);
 
   cub::DeviceMergeSort::SortPairs(
-      thrust::raw_pointer_cast(tmp.data()),
-      temp_size,
-      reverse_iter,
-      thrust::raw_pointer_cast(d_values.data()),
-      num_items,
-      CustomLess());
+    thrust::raw_pointer_cast(tmp.data()),
+    temp_size,
+    reverse_iter,
+    thrust::raw_pointer_cast(d_values.data()),
+    num_items,
+    CustomLess());
 
   AssertTrue(CheckResult(d_values));
 }
@@ -346,7 +345,7 @@ void Test(thrust::default_random_engine &rng)
   }
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   CommandLineArgs args(argc, argv);
 

--- a/test/test_device_merge_sort.cu
+++ b/test/test_device_merge_sort.cu
@@ -121,12 +121,12 @@ void Test(std::int64_t num_items,
   thrust::device_vector<char> tmp(temp_size);
 
   CubDebugExit(cub::DeviceMergeSort::SortPairs(
-    thrust::raw_pointer_cast(tmp.data()),
-    temp_size,
-    thrust::raw_pointer_cast(d_keys.data()),
-    thrust::raw_pointer_cast(d_values.data()),
-    num_items,
-    CustomLess()));
+      thrust::raw_pointer_cast(tmp.data()),
+      temp_size,
+      thrust::raw_pointer_cast(d_keys.data()),
+      thrust::raw_pointer_cast(d_values.data()),
+      num_items,
+      CustomLess()));
 
   thrust::device_vector<KeyType> d_keys_after_sort_copy(d_keys);
   thrust::device_vector<DataType> d_values_after_sort_copy(d_values);
@@ -134,14 +134,14 @@ void Test(std::int64_t num_items,
   AssertTrue(CheckResult(d_values));
 
   CubDebugExit(cub::DeviceMergeSort::SortPairsCopy(
-    thrust::raw_pointer_cast(tmp.data()),
-    temp_size,
-    thrust::raw_pointer_cast(d_keys_before_sort.data()),
-    thrust::raw_pointer_cast(d_values_before_sort.data()),
-    thrust::raw_pointer_cast(d_keys.data()),
-    thrust::raw_pointer_cast(d_values.data()),
-    num_items,
-    CustomLess()));
+      thrust::raw_pointer_cast(tmp.data()),
+      temp_size,
+      thrust::raw_pointer_cast(d_keys_before_sort.data()),
+      thrust::raw_pointer_cast(d_values_before_sort.data()),
+      thrust::raw_pointer_cast(d_keys.data()),
+      thrust::raw_pointer_cast(d_values.data()),
+      num_items,
+      CustomLess()));
 
   AssertEquals(d_keys, d_keys_after_sort_copy);
   AssertEquals(d_values, d_values_after_sort_copy);
@@ -151,24 +151,24 @@ void Test(std::int64_t num_items,
   // At the moment stable sort is an alias to sort, so it's safe to use
   // temp_size storage allocated before
   CubDebugExit(cub::DeviceMergeSort::StableSortPairs(
-    thrust::raw_pointer_cast(tmp.data()),
-    temp_size,
-    thrust::raw_pointer_cast(d_keys.data()),
-    thrust::raw_pointer_cast(d_values.data()),
-    num_items,
-    CustomLess()));
+      thrust::raw_pointer_cast(tmp.data()),
+      temp_size,
+      thrust::raw_pointer_cast(d_keys.data()),
+      thrust::raw_pointer_cast(d_values.data()),
+      num_items,
+      CustomLess()));
 
   AssertTrue(CheckResult(d_values));
 
   CubDebugExit(cub::DeviceMergeSort::SortPairsCopy(
-    thrust::raw_pointer_cast(tmp.data()),
-    temp_size,
-    thrust::constant_iterator<KeyType>(KeyType(42)),
-    thrust::counting_iterator<DataType>(DataType(0)),
-    thrust::raw_pointer_cast(d_keys.data()),
-    thrust::raw_pointer_cast(d_values.data()),
-    num_items,
-    CustomLess()));
+      thrust::raw_pointer_cast(tmp.data()),
+      temp_size,
+      thrust::constant_iterator<KeyType>(KeyType(42)),
+      thrust::counting_iterator<DataType>(DataType(0)),
+      thrust::raw_pointer_cast(d_keys.data()),
+      thrust::raw_pointer_cast(d_values.data()),
+      num_items,
+      CustomLess()));
 
   thrust::sequence(d_values_before_sort.begin(), d_values_before_sort.end());
 
@@ -194,32 +194,32 @@ void TestKeys(std::int64_t num_items,
 
   size_t temp_size = 0;
   cub::DeviceMergeSort::SortKeys(
-    nullptr,
-    temp_size,
-    thrust::raw_pointer_cast(d_keys.data()),
-    num_items,
-    CustomLess());
+      nullptr,
+      temp_size,
+      thrust::raw_pointer_cast(d_keys.data()),
+      num_items,
+      CustomLess());
 
   thrust::device_vector<char> tmp(temp_size);
 
   CubDebugExit(cub::DeviceMergeSort::SortKeys(
-    thrust::raw_pointer_cast(tmp.data()),
-    temp_size,
-    thrust::raw_pointer_cast(d_keys.data()),
-    num_items,
-    CustomLess()));
+      thrust::raw_pointer_cast(tmp.data()),
+      temp_size,
+      thrust::raw_pointer_cast(d_keys.data()),
+      num_items,
+      CustomLess()));
 
   thrust::device_vector<KeyType> d_after_sort(d_keys);
 
   AssertTrue(CheckResult(d_keys));
 
   CubDebugExit(cub::DeviceMergeSort::SortKeysCopy(
-    thrust::raw_pointer_cast(tmp.data()),
-    temp_size,
-    thrust::raw_pointer_cast(d_before_sort.data()),
-    thrust::raw_pointer_cast(d_keys.data()),
-    num_items,
-    CustomLess()));
+      thrust::raw_pointer_cast(tmp.data()),
+      temp_size,
+      thrust::raw_pointer_cast(d_before_sort.data()),
+      thrust::raw_pointer_cast(d_keys.data()),
+      num_items,
+      CustomLess()));
 
   AssertTrue(d_keys == d_after_sort);
   AssertTrue(d_before_sort == d_before_sort_copy);
@@ -227,13 +227,25 @@ void TestKeys(std::int64_t num_items,
   // At the moment stable sort is an alias to sort, so it's safe to use
   // temp_size storage allocated before
   CubDebugExit(cub::DeviceMergeSort::StableSortKeys(
-    thrust::raw_pointer_cast(tmp.data()),
-    temp_size,
-    thrust::raw_pointer_cast(d_keys.data()),
-    num_items,
-    CustomLess()));
+      thrust::raw_pointer_cast(tmp.data()),
+      temp_size,
+      thrust::raw_pointer_cast(d_keys.data()),
+      num_items,
+      CustomLess()));
 
   AssertTrue(CheckResult(d_keys));
+
+  CubDebugExit(cub::DeviceMergeSort::StableSortKeysCopy(
+      thrust::raw_pointer_cast(tmp.data()),
+      temp_size,
+      thrust::raw_pointer_cast(d_before_sort.data()),
+      thrust::raw_pointer_cast(d_keys.data()),
+      num_items,
+      CustomLess()));
+
+  // AssertTrue(CheckResult(d_keys));
+  AssertTrue(d_keys == d_after_sort);
+  AssertTrue(d_before_sort == d_before_sort_copy);
 }
 
 template <bool data_dont_exceed_key_size>
@@ -255,13 +267,14 @@ struct TestHelper<false>
 {
   template <typename, typename>
   static void AllocateAndTest(thrust::default_random_engine &, unsigned int)
-  {}
+  {
+  }
 };
 
 template <typename DataType>
 void Test(thrust::default_random_engine &rng, unsigned int num_items)
 {
-  TestHelper<sizeof(DataType) <= sizeof(std::uint8_t) >::template AllocateAndTest<std::uint8_t,  DataType>(rng, num_items);
+  TestHelper<sizeof(DataType) <= sizeof(std::uint8_t)>::template AllocateAndTest<std::uint8_t, DataType>(rng, num_items);
   TestHelper<sizeof(DataType) <= sizeof(std::uint32_t)>::template AllocateAndTest<std::uint32_t, DataType>(rng, num_items);
   TestHelper<sizeof(DataType) <= sizeof(std::uint64_t)>::template AllocateAndTest<std::uint64_t, DataType>(rng, num_items);
 }
@@ -282,22 +295,22 @@ void AllocateAndTestIterators(unsigned int num_items)
 
   size_t temp_size = 0;
   cub::DeviceMergeSort::SortPairs(
-    nullptr,
-    temp_size,
-    reverse_iter,
-    thrust::raw_pointer_cast(d_values.data()),
-    num_items,
-    CustomLess());
+      nullptr,
+      temp_size,
+      reverse_iter,
+      thrust::raw_pointer_cast(d_values.data()),
+      num_items,
+      CustomLess());
 
   thrust::device_vector<char> tmp(temp_size);
 
   cub::DeviceMergeSort::SortPairs(
-    thrust::raw_pointer_cast(tmp.data()),
-    temp_size,
-    reverse_iter,
-    thrust::raw_pointer_cast(d_values.data()),
-    num_items,
-    CustomLess());
+      thrust::raw_pointer_cast(tmp.data()),
+      temp_size,
+      reverse_iter,
+      thrust::raw_pointer_cast(d_values.data()),
+      num_items,
+      CustomLess());
 
   AssertTrue(CheckResult(d_values));
 }
@@ -333,7 +346,7 @@ void Test(thrust::default_random_engine &rng)
   }
 }
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
   CommandLineArgs args(argc, argv);
 

--- a/test/test_device_merge_sort.cu
+++ b/test/test_device_merge_sort.cu
@@ -235,6 +235,7 @@ void TestKeys(std::int64_t num_items,
 
   AssertTrue(CheckResult(d_keys));
 
+  thrust::fill(d_keys.begin(), d_keys.end(), KeyType{});
   CubDebugExit(cub::DeviceMergeSort::StableSortKeysCopy(
       thrust::raw_pointer_cast(tmp.data()),
       temp_size,


### PR DESCRIPTION
CUB has a  `SortKeysCopy` and a `StableSortKeys`. This PR adds `StableSortKeysCopy` so a sort in-place is not required. The in-place `StableSortKeys`  requires a temporary vector if a copy is needed.

Since `StableSortKeys` calls `SortKeys` and `SortKeysCopy` uses the same kernels as `SortKeys` (which appear to already be stable-sort enabled), the new `StableSortKeysCopy` simply calls `SortKeysCopy`.