### PR TITLE
Don't use char in tests

### DIFF
--- a/test/test_block_load_store.cu
+++ b/test/test_block_load_store.cu
@@ -517,7 +517,7 @@ int main(int argc, char** argv)
 
     // Compile/run thorough tests
 #if TEST_VALUE_TYPES == 0
-    TestThreads<char>(2, 0.8f);
+    TestThreads<signed char>(2, 0.8f);
     TestThreads<int>(2, 0.8f);
     TestThreads<long>(2, 0.8f);
 #elif TEST_VALUE_TYPES == 1

--- a/test/test_block_radix_sort.cu
+++ b/test/test_block_radix_sort.cu
@@ -531,7 +531,7 @@ template <
 void TestKeysAndPairs()
 {
     // Test pairs sorting with only 4-byte configs
-    Test<BLOCK_THREADS, ITEMS_PER_THREAD, RADIX_BITS, MEMOIZE_OUTER_SCAN, INNER_SCAN_ALGORITHM, cudaSharedMemBankSizeFourByte, Key, char>();        // With small-values
+    Test<BLOCK_THREADS, ITEMS_PER_THREAD, RADIX_BITS, MEMOIZE_OUTER_SCAN, INNER_SCAN_ALGORITHM, cudaSharedMemBankSizeFourByte, Key, signed char>(); // With small-values
     Test<BLOCK_THREADS, ITEMS_PER_THREAD, RADIX_BITS, MEMOIZE_OUTER_SCAN, INNER_SCAN_ALGORITHM, cudaSharedMemBankSizeFourByte, Key, Key>();         // With same-values
     Test<BLOCK_THREADS, ITEMS_PER_THREAD, RADIX_BITS, MEMOIZE_OUTER_SCAN, INNER_SCAN_ALGORITHM, cudaSharedMemBankSizeFourByte, Key, TestFoo>();     // With large values
 }
@@ -560,7 +560,7 @@ void Test()
 
 #elif TEST_VALUE_TYPES == 2
     // Test signed and fp types with paired values
-    TestKeysAndPairs<BLOCK_THREADS, ITEMS_PER_THREAD, RADIX_BITS, MEMOIZE_OUTER_SCAN, INNER_SCAN_ALGORITHM, char>();
+    TestKeysAndPairs<BLOCK_THREADS, ITEMS_PER_THREAD, RADIX_BITS, MEMOIZE_OUTER_SCAN, INNER_SCAN_ALGORITHM, signed char>();
     TestKeysAndPairs<BLOCK_THREADS, ITEMS_PER_THREAD, RADIX_BITS, MEMOIZE_OUTER_SCAN, INNER_SCAN_ALGORITHM, short>();
     TestKeysAndPairs<BLOCK_THREADS, ITEMS_PER_THREAD, RADIX_BITS, MEMOIZE_OUTER_SCAN, INNER_SCAN_ALGORITHM, int>();
 #elif TEST_VALUE_TYPES == 3

--- a/test/test_block_reduce.cu
+++ b/test/test_block_reduce.cu
@@ -734,7 +734,7 @@ int main(int argc, char** argv)
 
     // primitives
 #if TEST_VALUE_TYPES == 0
-    Test<char>();
+    Test<signed char>();
     Test<short>();
     Test<int>();
     Test<long long>();

--- a/test/test_device_radix_sort.cu
+++ b/test/test_device_radix_sort.cu
@@ -1946,7 +1946,7 @@ int main(int argc, char** argv)
     // Compile/run thorough tests
 #if TEST_KEY_BYTES == 1
 
-    TestGen<char, true>               (num_items, num_segments);
+    TestGen<signed char, true>        (num_items, num_segments);
 
 #ifdef TEST_EXTENDED_KEY_TYPES
     TestGen<bool, false>              (num_items, num_segments);

--- a/test/test_device_reduce.cu
+++ b/test/test_device_reduce.cu
@@ -1473,9 +1473,9 @@ int main(int argc, char** argv)
     // %PARAM% TEST_TYPES types 0:1:2:3
 
 #if TEST_TYPES == 0
-    TestType<char, char>(max_items, max_segments);
+    TestType<signed char, signed char>(max_items, max_segments);
     TestType<unsigned char, unsigned char>(max_items, max_segments);
-    TestType<char, int>(max_items, max_segments);
+    TestType<signed char, int>(max_items, max_segments);
 #elif TEST_TYPES == 1
     TestType<short, short>(max_items, max_segments);
     TestType<int, int>(max_items, max_segments);

--- a/test/test_device_reduce_by_key.cu
+++ b/test/test_device_reduce_by_key.cu
@@ -719,7 +719,7 @@ int main(int argc, char** argv)
     // %PARAM% TEST_CDP cdp 0:1
 
     // Test different input types
-    TestOp<int, char>(num_items);
+    TestOp<int, signed char>(num_items);
     TestOp<int, short>(num_items);
     TestOp<int, int>(num_items);
     TestOp<int, long>(num_items);
@@ -735,7 +735,7 @@ int main(int argc, char** argv)
     TestOp<int, TestFoo>(num_items);
     TestOp<int, TestBar>(num_items);
 
-    TestOp<char, int>(num_items);
+    TestOp<signed char, int>(num_items);
     TestOp<long long, int>(num_items);
     TestOp<TestFoo, int>(num_items);
     TestOp<TestBar, int>(num_items);

--- a/test/test_device_run_length_encode.cu
+++ b/test/test_device_run_length_encode.cu
@@ -749,7 +749,7 @@ int main(int argc, char** argv)
     // %PARAM% TEST_CDP cdp 0:1
 
     // Test different input types
-    TestSize<char, int, int>(num_items);
+    TestSize<signed char, int, int>(num_items);
     TestSize<short, int, int>(num_items);
     TestSize<int, int, int>(num_items);
     TestSize<long, int, int>(num_items);

--- a/test/test_device_scan.cu
+++ b/test/test_device_scan.cu
@@ -1221,7 +1221,7 @@ int main(int argc, char** argv)
 
     // Test same input+output data types
     TestSize<unsigned char>(num_items, (unsigned char)0, (unsigned char)99);
-    TestSize<char>(num_items, (char)0, (char)99);
+    TestSize<signed char>(num_items, (char)0, (char)99);
     TestSize<unsigned short>(num_items, (unsigned short)0, (unsigned short)99);
     TestSize<unsigned int>(num_items, (unsigned int)0, (unsigned int)99);
     TestSize<unsigned long long>(num_items,

--- a/test/test_device_scan_by_key.cu
+++ b/test/test_device_scan_by_key.cu
@@ -1036,7 +1036,7 @@ int main(int argc, char** argv)
 
     // Test same input+output data types
     TestSize<unsigned char>(num_items, (unsigned char)0, (unsigned char)99);
-    TestSize<char>(num_items, (char)0, (char)99);
+    TestSize<signed char>(num_items, (char)0, (char)99);
 
 #elif TEST_VALUE_TYPES == 1
 

--- a/test/test_device_spmv.cu
+++ b/test/test_device_spmv.cu
@@ -566,7 +566,7 @@ void test_types()
 {
   test_type<float>();
   test_type<double>();
-  test_type<char>();
+  test_type<signed char>();
   test_type<int>();
   test_type<unsigned long long>();
 }

--- a/test/test_iterator.cu
+++ b/test/test_iterator.cu
@@ -500,7 +500,7 @@ int main(int argc, char** argv)
     CubDebugExit(PtxVersion(ptx_version));
 
     // Evaluate different data types
-    Test<char>();
+    Test<signed char>();
     Test<short>();
     Test<int>();
     Test<long>();

--- a/test/test_iterator_deprecated.cu
+++ b/test/test_iterator_deprecated.cu
@@ -264,7 +264,7 @@ int main(int argc, char** argv)
     CubDebugExit(args.DeviceInit());
 
     // Evaluate different data types
-    Test<char>();
+    Test<signed char>();
     Test<short>();
     Test<int>();
     Test<long>();

--- a/test/test_util.h
+++ b/test/test_util.h
@@ -1134,7 +1134,7 @@ std::ostream& operator<<(std::ostream& os, const CUB_NS_QUALIFIER::KeyValuePair<
 /**
  * Define for types
  */
-CUB_VEC_OVERLOAD(char, char)
+CUB_VEC_OVERLOAD(char, signed char)
 CUB_VEC_OVERLOAD(short, short)
 CUB_VEC_OVERLOAD(int, int)
 CUB_VEC_OVERLOAD(long, long)

--- a/test/test_warp_reduce.cu
+++ b/test/test_warp_reduce.cu
@@ -721,7 +721,7 @@ template <
 void Test(GenMode gen_mode)
 {
     // primitive
-    Test<WARPS, LOGICAL_WARP_THREADS, char>(                gen_mode, Sum());
+    Test<WARPS, LOGICAL_WARP_THREADS, signed char>(         gen_mode, Sum());
     Test<WARPS, LOGICAL_WARP_THREADS, short>(               gen_mode, Sum());
     Test<WARPS, LOGICAL_WARP_THREADS, int>(                 gen_mode, Sum());
     Test<WARPS, LOGICAL_WARP_THREADS, long long>(           gen_mode, Sum());


### PR DESCRIPTION
There are compilation issues for our tests on some platforms due to `char` usage. According to the standard:
> Type char is a distinct type that has an implementation-defined choice of “signed char” or “unsigned char” as its underlying type.

CUDA vector types add to this confusion by using `char2` as a synonym for `signed char` instead of `char`. Ideally, we'd use `std::int8_t` and `std::uint8_t` here, but I'd like to postpone this refactoring, since the process of replacing primitive types with `std::*` ones in already in progress ([Catch2 PR](https://github.com/NVIDIA/cub/pull/365)). As a quick fix, I use signed char when applicable for now.  