### PR TITLE
Fix reordering in CUB member initializer lists

### DIFF
--- a/cmake/CubBuildCompilerTargets.cmake
+++ b/cmake/CubBuildCompilerTargets.cmake
@@ -9,6 +9,7 @@
 function(cub_build_compiler_targets)
   set(cxx_compile_definitions)
   set(cxx_compile_options)
+  set(cuda_compile_options)
 
   if ("MSVC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
     append_option_if_available("/W4" cxx_compile_options)
@@ -38,6 +39,8 @@ function(cub_build_compiler_targets)
     # Some tests require /bigobj to fit everything into their object files:
     append_option_if_available("/bigobj" cxx_compile_options)
   else()
+    append_option_if_available("-Wreorder" cuda_compile_options)
+
     append_option_if_available("-Werror" cxx_compile_options)
     append_option_if_available("-Wall" cxx_compile_options)
     append_option_if_available("-Wextra" cxx_compile_options)
@@ -91,6 +94,12 @@ function(cub_build_compiler_targets)
       # This is:
       # if (using CUDA and CUDA_COMPILER is NVCC) add -Xcompiler=opt:
       $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:-Xcompiler=${cxx_option}>
+    )
+  endforeach()
+
+  foreach (cuda_option IN LISTS cuda_compile_options)
+    target_compile_options(cub.compiler_interface INTERFACE
+      $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:${cuda_option}>
     )
   endforeach()
 

--- a/cub/agent/agent_histogram.cuh
+++ b/cub/agent/agent_histogram.cuh
@@ -695,12 +695,12 @@ struct AgentHistogram
     :
         temp_storage(temp_storage.Alias()),
         d_wrapped_samples(d_samples),
+        d_native_samples(NativePointer(d_wrapped_samples)),
         num_output_bins(num_output_bins),
         num_privatized_bins(num_privatized_bins),
         d_output_histograms(d_output_histograms),
-        privatized_decode_op(privatized_decode_op),
         output_decode_op(output_decode_op),
-        d_native_samples(NativePointer(d_wrapped_samples)),
+        privatized_decode_op(privatized_decode_op),
         prefer_smem((MEM_PREFERENCE == SMEM) ?
             true :                              // prefer smem privatized histograms
             (MEM_PREFERENCE == GMEM) ?

--- a/cub/agent/agent_select_if.cuh
+++ b/cub/agent/agent_select_if.cuh
@@ -231,10 +231,10 @@ struct AgentSelectIf
     :
         temp_storage(temp_storage.Alias()),
         d_in(d_in),
-        d_flags_in(d_flags_in),
         d_selected_out(d_selected_out),
-        select_op(select_op),
+        d_flags_in(d_flags_in),
         inequality_op(equality_op),
+        select_op(select_op),
         num_items(num_items)
     {}
 

--- a/cub/block/block_exchange.cuh
+++ b/cub/block/block_exchange.cuh
@@ -732,8 +732,8 @@ public:
     :
         temp_storage(PrivateStorage()),
         linear_tid(RowMajorTid(BLOCK_DIM_X, BLOCK_DIM_Y, BLOCK_DIM_Z)),
-        warp_id((WARPS == 1) ? 0 : linear_tid / WARP_THREADS),
         lane_id(LaneId()),
+        warp_id((WARPS == 1) ? 0 : linear_tid / WARP_THREADS),
         warp_offset(warp_id * WARP_TIME_SLICED_ITEMS)
     {}
 

--- a/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -1921,9 +1921,9 @@ struct DispatchSegmentedRadixSort :
         d_end_offsets(d_end_offsets),
         begin_bit(begin_bit),
         end_bit(end_bit),
-        is_overwrite_okay(is_overwrite_okay),
         stream(stream),
-        ptx_version(ptx_version)
+        ptx_version(ptx_version),
+        is_overwrite_okay(is_overwrite_okay)
     {}
 
     CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
@@ -1954,9 +1954,9 @@ struct DispatchSegmentedRadixSort :
         d_end_offsets(d_end_offsets),
         begin_bit(begin_bit),
         end_bit(end_bit),
-        is_overwrite_okay(is_overwrite_okay),
         stream(stream),
-        ptx_version(ptx_version)
+        ptx_version(ptx_version),
+        is_overwrite_okay(is_overwrite_okay)
     {
       CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
     }


### PR DESCRIPTION
This PR fixes reordering in member initializer lists. Since `-Wall` was added to host compiler, kernels were not covered. Specifying `-Wreorder` directly led to having those reordering visible. 