### PR TITLE
Add option to opt out CDP

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,59 @@
+# https://clangd.llvm.org/config
+
+# Apply a config conditionally to all C files
+If:
+  PathMatch: .*\.(c|h)$
+
+---
+
+# Apply a config conditionally to all C++ files
+If:
+  PathMatch: .*\.(c|h)pp
+
+---
+
+# Apply a config conditionally to all CUDA files
+If:
+  PathMatch: .*\.cuh?
+CompileFlags:
+  Add:
+    # Allow variadic CUDA functions
+    - "-Xclang=-fcuda-allow-variadic-functions"
+
+---
+
+# Tweak the clangd parse settings for all files
+CompileFlags:
+  Compiler: clang++
+  CompilationDatabase: .
+  Add:
+    - -x
+    - cuda
+    # report all errors
+    - "-ferror-limit=0"
+    - "-ftemplate-backtrace-limit=0"
+  Remove:
+    - -stdpar
+    # strip CUDA fatbin args
+    - "-Xfatbin*"
+    - "-gpu=*"
+    - "--diag_suppress*"
+    # strip CUDA arch flags
+    - "-gencode*"
+    - "--generate-code*"
+    # strip gcc's -fcoroutines
+    - -fcoroutines
+    # strip CUDA flags unknown to clang
+    - "-ccbin*"
+    - "--compiler-options*"
+    - "--expt-extended-lambda"
+    - "--expt-relaxed-constexpr"
+    - "-forward-unknown-to-host-compiler"
+    - "-Werror=cross-execution-space-call"
+Diagnostics:
+  Suppress:
+    - "variadic_device_fn"
+    - "attributes_not_allowed"
+    # The NVHPC version of _NVCXX_EXPAND_PACK macro triggers this clang error.
+    # Temporarily suppressing it, but should probably fix
+    - "template_param_shadow"

--- a/cub/detail/detect_cuda_runtime.cuh
+++ b/cub/detail/detect_cuda_runtime.cuh
@@ -44,9 +44,16 @@ namespace detail
 #ifdef DOXYGEN_SHOULD_SKIP_THIS // Only parse this during doxygen passes:
 
 /**
+ * \def CUB_DISABLE_CDP
+ *
+ * If defined, support for device-side usage of CUB is disabled.
+ */
+#define CUB_DISABLE_CDP
+
+/**
  * \def CUB_RDC_ENABLED
  *
- * Defined if RDC is enabled.
+ * Defined if RDC is enabled and CUB_DISABLE_CDP is not defined.
  */
 #define CUB_RDC_ENABLED
 
@@ -76,7 +83,7 @@ namespace detail
 
 #ifndef CUB_RUNTIME_FUNCTION
 
-#if defined(__CUDACC_RDC__)
+#if defined(__CUDACC_RDC__) && !defined(CUB_DISABLE_CDP)
 
 #define CUB_RDC_ENABLED
 #define CUB_RUNTIME_FUNCTION __host__ __device__


### PR DESCRIPTION
This PR addresses the following [issue](https://github.com/NVIDIA/cub/issues/522). It's now possible to disable CDP support while building with RDC. To do so, it's sufficient to define `CUB_DISABLE_CDP` macro before including any of the CUB headers. 

Also adopted clangd helper from stdexec.