### PR TITLE
Fix seg sort for bool keys

### DIFF
--- a/cub/agent/agent_sub_warp_merge_sort.cuh
+++ b/cub/agent/agent_sub_warp_merge_sort.cuh
@@ -155,6 +155,25 @@ class AgentSubWarpSort
     return lhs == rhs;
   }
 
+  __device__ static bool get_oob_default(Int2Type<true> /* is bool */) 
+  {
+    // Traits<KeyT>::MAX_KEY for `bool` is 0xFF which is different from `true` and makes
+    // comparison with oob unreliable.
+    return !IS_DESCENDING;
+  }
+
+  __device__ static KeyT get_oob_default(Int2Type<false> /* is bool */) 
+  {
+    // For FP64 the difference is:
+    // Lowest() -> -1.79769e+308 = 00...00b -> TwiddleIn -> -0 = 10...00b
+    // LOWEST   -> -nan          = 11...11b -> TwiddleIn ->  0 = 00...00b
+
+    using UnsignedBitsT = typename Traits<KeyT>::UnsignedBits;
+    UnsignedBitsT default_key_bits = IS_DESCENDING ? Traits<KeyT>::LOWEST_KEY
+                                                   : Traits<KeyT>::MAX_KEY;
+    return reinterpret_cast<KeyT &>(default_key_bits);
+  }
+
 public:
   static constexpr bool KEYS_ONLY = std::is_same<ValueT, cub::NullType>::value;
 
@@ -229,14 +248,8 @@ public:
       KeyT keys[PolicyT::ITEMS_PER_THREAD];
       ValueT values[PolicyT::ITEMS_PER_THREAD];
 
-      // For FP64 the difference is:
-      // Lowest() -> -1.79769e+308 = 00...00b -> TwiddleIn -> -0 = 10...00b
-      // LOWEST   -> -nan          = 11...11b -> TwiddleIn ->  0 = 00...00b
-
-      using UnsignedBitsT = typename Traits<KeyT>::UnsignedBits;
-      UnsignedBitsT default_key_bits = IS_DESCENDING ? Traits<KeyT>::LOWEST_KEY
-                                                     : Traits<KeyT>::MAX_KEY;
-      KeyT oob_default = reinterpret_cast<KeyT &>(default_key_bits);
+      KeyT oob_default = 
+        AgentSubWarpSort::get_oob_default(Int2Type<std::is_same<bool, KeyT>::value>{});
 
       WarpLoadKeysT(storage.load_keys)
         .Load(keys_input, keys, segment_size, oob_default);

--- a/test/test_device_segmented_sort.cu
+++ b/test/test_device_segmented_sort.cu
@@ -963,7 +963,7 @@ void TestSameSizeSegments(int segment_size,
 
   const int *d_offsets = thrust::raw_pointer_cast(offsets.data());
 
-  const KeyT target_key {42};
+  const KeyT target_key {1};
   const ValueT target_value {42};
 
   thrust::device_vector<KeyT> keys_input(num_items);
@@ -1207,6 +1207,16 @@ bool compare_two_outputs(const thrust::host_vector<int> &offsets,
   return true;
 }
 
+template <typename ValueT>
+void RandomizeInput(thrust::host_vector<bool> &h_keys,
+                    thrust::host_vector<ValueT> &h_values)
+{
+  for (std::size_t i = 0; i < h_keys.size(); i++)
+  {
+    h_keys[i] = RandomValue((std::numeric_limits<std::uint8_t>::max)()) > 128;
+    h_values[i] = RandomValue((std::numeric_limits<ValueT>::max)());
+  }
+}
 
 template <typename KeyT,
           typename ValueT>
@@ -1924,6 +1934,7 @@ int main(int argc, char** argv)
   Test<bfloat16_t, std::uint32_t>();
 #endif
 
+  Test<bool, std::uint64_t>();
   Test<std::uint8_t, std::uint64_t>();
   Test<std::int64_t, std::uint32_t>();
 


### PR DESCRIPTION
This PR addresses the following [issue](https://github.com/NVIDIA/cub/issues/594) and enables `bool` as key type in the new device segmented sort. The issue happens only for small segments since that's what is triggering merge sort to be used. Merge sort relies on comparison and we end up comparing `true` or `false` with `oob = 0xFF`. Initially, I was trying to `Traits<KeyT>::TwiddleIn(key)` once before sorting and `Traits<KeyT>::TwiddleOut(key)` after sorting so as to get consistency with what radix counterpart is doing. Although this simplifies the code (no need to treat `__half` etc.), this also introduces noticeable slowdown (4%) into sorting of small segments on signed key types. The slowdown disappears only on `std::int64_t`. So, instead we change the way `oob` is computed. This change doesn't affect performance. 

There was also a suggestion to change `Traits<bool>::MAX_KEY` to be `true` instead of `0xFF`, but I'm afraid this is a silently breaking change. Currently, expectations of `Traits<bool>::MAX_KEY` is to get `0b1..1` which will change if we go this route. 