### PR TITLE
Fix device-side reduce launch with large inputs

### DIFF
--- a/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/device/dispatch/dispatch_reduce.cuh
@@ -783,7 +783,7 @@ struct DispatchReduce : SelectedPolicy
         .doit(single_tile_kernel,
               d_block_reductions,
               d_out,
-              reduce_grid_size,
+              reduce_grid_size, // triple_chevron is not type safe, make sure to use int
               reduction_op,
               init);
 
@@ -841,7 +841,7 @@ struct DispatchReduce : SelectedPolicy
         DeviceReduceSingleTileKernel<MaxPolicyT,
                                      AccumT *,
                                      OutputIteratorT,
-                                     OffsetT,
+                                     int, // Always used with int offsets
                                      ReductionOpT,
                                      InitT,
                                      AccumT>);


### PR DESCRIPTION
When there are more than one tile of input items, we launch two kernels for reduction. During the second kernel launch, we accumulate partial aggregates from thread blocks. In this case, `int reduce_grid_size` is passed to `OffsetT num_items` kernel parameter. Thrust `triple_chevron` is not type safe when used on device. These facts lead to a mismatch of data size we put into a param buffer (4 bytes) and that the kernel reads from the buffer (8 bytes). This seems to be a bug that was long present in thrust, that uses dispatch layer directly with offset types different from `int32_t`. In the case of host-side usage, type conversion takes place, leading to normal execution. 