### PR TITLE
Fix RLE when items[0] is NaN

### DIFF
--- a/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/agent/agent_reduce_by_key.cuh
@@ -556,6 +556,13 @@ struct AgentReduceByKey
       scan_items[ITEM].key   = head_flags[ITEM];
     }
 
+    // Reset head-flag on the very first item to make sure we don't start a new run for data where
+    // (key[0] == key[0]) is false (e.g., when key[0] is NaN)
+    if (threadIdx.x == 0 && tile_idx == 0)
+    {
+      scan_items[0].key = 0;
+    }
+
     // Perform exclusive tile scan
     // Inclusive block-wide scan aggregate
     OffsetValuePairT block_aggregate;

--- a/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/agent/agent_reduce_by_key.cuh
@@ -13,9 +13,9 @@
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
  * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
@@ -33,8 +33,6 @@
 
 #pragma once
 
-#include <iterator>
-
 #include <cub/agent/single_pass_scan_operators.cuh>
 #include <cub/block/block_discontinuity.cuh>
 #include <cub/block/block_load.cuh>
@@ -43,6 +41,8 @@
 #include <cub/config.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
 #include <cub/iterator/constant_input_iterator.cuh>
+
+#include <iterator>
 
 CUB_NAMESPACE_BEGIN
 
@@ -146,8 +146,7 @@ struct AgentReduceByKey
   using KeyInputT = cub::detail::value_t<KeysInputIteratorT>;
 
   // The output keys type
-  using KeyOutputT =
-    cub::detail::non_void_value_t<UniqueOutputIteratorT, KeyInputT>;
+  using KeyOutputT = cub::detail::non_void_value_t<UniqueOutputIteratorT, KeyInputT>;
 
   // The input values type
   using ValueInputT = cub::detail::value_t<ValuesInputIteratorT>;
@@ -173,17 +172,14 @@ struct AgentReduceByKey
     int num_remaining;
 
     /// Constructor
-    __host__ __device__ __forceinline__
-    GuardedInequalityWrapper(_EqualityOpT op, int num_remaining)
+    __host__ __device__ __forceinline__ GuardedInequalityWrapper(_EqualityOpT op, int num_remaining)
         : op(op)
         , num_remaining(num_remaining)
     {}
 
     /// Boolean inequality operator, returns <tt>(a != b)</tt>
     template <typename T>
-    __host__ __device__ __forceinline__ bool operator()(const T &a,
-                                                        const T &b,
-                                                        int idx) const
+    __host__ __device__ __forceinline__ bool operator()(const T &a, const T &b, int idx) const
     {
       if (idx < num_remaining)
       {
@@ -196,17 +192,15 @@ struct AgentReduceByKey
   };
 
   // Constants
-  static constexpr int BLOCK_THREADS = AgentReduceByKeyPolicyT::BLOCK_THREADS;
-  static constexpr int ITEMS_PER_THREAD =
-    AgentReduceByKeyPolicyT::ITEMS_PER_THREAD;
+  static constexpr int BLOCK_THREADS     = AgentReduceByKeyPolicyT::BLOCK_THREADS;
+  static constexpr int ITEMS_PER_THREAD  = AgentReduceByKeyPolicyT::ITEMS_PER_THREAD;
   static constexpr int TILE_ITEMS        = BLOCK_THREADS * ITEMS_PER_THREAD;
   static constexpr int TWO_PHASE_SCATTER = (ITEMS_PER_THREAD > 1);
 
   // Whether or not the scan operation has a zero-valued identity value (true
   // if we're performing addition on a primitive type)
-  static constexpr int HAS_IDENTITY_ZERO =
-    (std::is_same<ReductionOpT, cub::Sum>::value) &&
-    (Traits<AccumT>::PRIMITIVE);
+  static constexpr int HAS_IDENTITY_ZERO = (std::is_same<ReductionOpT, cub::Sum>::value) &&
+                                           (Traits<AccumT>::PRIMITIVE);
 
   // Cache-modified Input iterator wrapper type (for applying cache modifier)
   // for keys Wrap the native input pointer with
@@ -214,9 +208,7 @@ struct AgentReduceByKey
   // iterator type
   using WrappedKeysInputIteratorT = cub::detail::conditional_t<
     std::is_pointer<KeysInputIteratorT>::value,
-    CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER,
-                               KeyInputT,
-                               OffsetT>,
+    CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER, KeyInputT, OffsetT>,
     KeysInputIteratorT>;
 
   // Cache-modified Input iterator wrapper type (for applying cache modifier)
@@ -225,9 +217,7 @@ struct AgentReduceByKey
   // iterator type
   using WrappedValuesInputIteratorT = cub::detail::conditional_t<
     std::is_pointer<ValuesInputIteratorT>::value,
-    CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER,
-                               ValueInputT,
-                               OffsetT>,
+    CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER, ValueInputT, OffsetT>,
     ValuesInputIteratorT>;
 
   // Cache-modified Input iterator wrapper type (for applying cache modifier)
@@ -236,33 +226,26 @@ struct AgentReduceByKey
   // iterator type
   using WrappedFixupInputIteratorT = cub::detail::conditional_t<
     std::is_pointer<AggregatesOutputIteratorT>::value,
-    CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER,
-                               ValueInputT,
-                               OffsetT>,
+    CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER, ValueInputT, OffsetT>,
     AggregatesOutputIteratorT>;
 
   // Reduce-value-by-segment scan operator
   using ReduceBySegmentOpT = ReduceBySegmentOp<ReductionOpT>;
 
   // Parameterized BlockLoad type for keys
-  using BlockLoadKeysT = BlockLoad<KeyOutputT,
-                                   BLOCK_THREADS,
-                                   ITEMS_PER_THREAD,
-                                   AgentReduceByKeyPolicyT::LOAD_ALGORITHM>;
+  using BlockLoadKeysT =
+    BlockLoad<KeyOutputT, BLOCK_THREADS, ITEMS_PER_THREAD, AgentReduceByKeyPolicyT::LOAD_ALGORITHM>;
 
   // Parameterized BlockLoad type for values
-  using BlockLoadValuesT = BlockLoad<AccumT,
-                                     BLOCK_THREADS,
-                                     ITEMS_PER_THREAD,
-                                     AgentReduceByKeyPolicyT::LOAD_ALGORITHM>;
+  using BlockLoadValuesT =
+    BlockLoad<AccumT, BLOCK_THREADS, ITEMS_PER_THREAD, AgentReduceByKeyPolicyT::LOAD_ALGORITHM>;
 
   // Parameterized BlockDiscontinuity type for keys
   using BlockDiscontinuityKeys = BlockDiscontinuity<KeyOutputT, BLOCK_THREADS>;
 
   // Parameterized BlockScan type
-  using BlockScanT = BlockScan<OffsetValuePairT,
-                               BLOCK_THREADS,
-                               AgentReduceByKeyPolicyT::SCAN_ALGORITHM>;
+  using BlockScanT =
+    BlockScan<OffsetValuePairT, BLOCK_THREADS, AgentReduceByKeyPolicyT::SCAN_ALGORITHM>;
 
   // Callback type for obtaining tile prefix during block scan
   using TilePrefixCallbackOpT =
@@ -362,15 +345,14 @@ struct AgentReduceByKey
    * @param reduction_op
    *   ValueT reduction operator
    */
-  __device__ __forceinline__
-  AgentReduceByKey(TempStorage &temp_storage,
-                   KeysInputIteratorT d_keys_in,
-                   UniqueOutputIteratorT d_unique_out,
-                   ValuesInputIteratorT d_values_in,
-                   AggregatesOutputIteratorT d_aggregates_out,
-                   NumRunsOutputIteratorT d_num_runs_out,
-                   EqualityOpT equality_op,
-                   ReductionOpT reduction_op)
+  __device__ __forceinline__ AgentReduceByKey(TempStorage &temp_storage,
+                                              KeysInputIteratorT d_keys_in,
+                                              UniqueOutputIteratorT d_unique_out,
+                                              ValuesInputIteratorT d_values_in,
+                                              AggregatesOutputIteratorT d_aggregates_out,
+                                              NumRunsOutputIteratorT d_num_runs_out,
+                                              EqualityOpT equality_op,
+                                              ReductionOpT reduction_op)
       : temp_storage(temp_storage.Alias())
       , d_keys_in(d_keys_in)
       , d_unique_out(d_unique_out)
@@ -389,10 +371,9 @@ struct AgentReduceByKey
   /**
    * Directly scatter flagged items to output offsets
    */
-  __device__ __forceinline__ void
-  ScatterDirect(KeyValuePairT (&scatter_items)[ITEMS_PER_THREAD],
-                OffsetT (&segment_flags)[ITEMS_PER_THREAD],
-                OffsetT (&segment_indices)[ITEMS_PER_THREAD])
+  __device__ __forceinline__ void ScatterDirect(KeyValuePairT (&scatter_items)[ITEMS_PER_THREAD],
+                                                OffsetT (&segment_flags)[ITEMS_PER_THREAD],
+                                                OffsetT (&segment_indices)[ITEMS_PER_THREAD])
   {
 // Scatter flagged keys and values
 #pragma unroll
@@ -413,12 +394,11 @@ struct AgentReduceByKey
    * value aggregate: the scatter offsets must be decremented for value
    * aggregates
    */
-  __device__ __forceinline__ void
-  ScatterTwoPhase(KeyValuePairT (&scatter_items)[ITEMS_PER_THREAD],
-                  OffsetT (&segment_flags)[ITEMS_PER_THREAD],
-                  OffsetT (&segment_indices)[ITEMS_PER_THREAD],
-                  OffsetT num_tile_segments,
-                  OffsetT num_tile_segments_prefix)
+  __device__ __forceinline__ void ScatterTwoPhase(KeyValuePairT (&scatter_items)[ITEMS_PER_THREAD],
+                                                  OffsetT (&segment_flags)[ITEMS_PER_THREAD],
+                                                  OffsetT (&segment_indices)[ITEMS_PER_THREAD],
+                                                  OffsetT num_tile_segments,
+                                                  OffsetT num_tile_segments_prefix)
   {
     CTA_SYNC();
 
@@ -428,18 +408,16 @@ struct AgentReduceByKey
     {
       if (segment_flags[ITEM])
       {
-        temp_storage.raw_exchange
-          .Alias()[segment_indices[ITEM] - num_tile_segments_prefix] =
+        temp_storage.raw_exchange.Alias()[segment_indices[ITEM] - num_tile_segments_prefix] =
           scatter_items[ITEM];
       }
     }
 
     CTA_SYNC();
 
-    for (int item = threadIdx.x; item < num_tile_segments;
-         item += BLOCK_THREADS)
+    for (int item = threadIdx.x; item < num_tile_segments; item += BLOCK_THREADS)
     {
-      KeyValuePairT pair = temp_storage.raw_exchange.Alias()[item];
+      KeyValuePairT pair                                = temp_storage.raw_exchange.Alias()[item];
       d_unique_out[num_tile_segments_prefix + item]     = pair.key;
       d_aggregates_out[num_tile_segments_prefix + item] = pair.value;
     }
@@ -448,12 +426,11 @@ struct AgentReduceByKey
   /**
    * Scatter flagged items
    */
-  __device__ __forceinline__ void
-  Scatter(KeyValuePairT (&scatter_items)[ITEMS_PER_THREAD],
-          OffsetT (&segment_flags)[ITEMS_PER_THREAD],
-          OffsetT (&segment_indices)[ITEMS_PER_THREAD],
-          OffsetT num_tile_segments,
-          OffsetT num_tile_segments_prefix)
+  __device__ __forceinline__ void Scatter(KeyValuePairT (&scatter_items)[ITEMS_PER_THREAD],
+                                          OffsetT (&segment_flags)[ITEMS_PER_THREAD],
+                                          OffsetT (&segment_indices)[ITEMS_PER_THREAD],
+                                          OffsetT num_tile_segments,
+                                          OffsetT num_tile_segments_prefix)
   {
     // Do a one-phase scatter if (a) two-phase is disabled or (b) the average
     // number of selected items per thread is less than one
@@ -494,10 +471,8 @@ struct AgentReduceByKey
    *   Global tile state descriptor
    */
   template <bool IS_LAST_TILE>
-  __device__ __forceinline__ void ConsumeTile(OffsetT num_remaining,
-                                              int tile_idx,
-                                              OffsetT tile_offset,
-                                              ScanTileStateT &tile_state)
+  __device__ __forceinline__ void
+  ConsumeTile(OffsetT num_remaining, int tile_idx, OffsetT tile_offset, ScanTileStateT &tile_state)
   {
     // Tile keys
     KeyOutputT keys[ITEMS_PER_THREAD];
@@ -523,8 +498,7 @@ struct AgentReduceByKey
     // Load keys
     if (IS_LAST_TILE)
     {
-      BlockLoadKeysT(temp_storage.load_keys)
-        .Load(d_keys_in + tile_offset, keys, num_remaining);
+      BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + tile_offset, keys, num_remaining);
     }
     else
     {
@@ -553,8 +527,7 @@ struct AgentReduceByKey
     }
     else
     {
-      BlockLoadValuesT(temp_storage.load_values)
-        .Load(d_values_in + tile_offset, values);
+      BlockLoadValuesT(temp_storage.load_values).Load(d_values_in + tile_offset, values);
     }
 
     CTA_SYNC();
@@ -638,11 +611,7 @@ struct AgentReduceByKey
 
     // Scatter flagged keys and values
     OffsetT num_tile_segments = block_aggregate.key;
-    Scatter(scatter_items,
-            head_flags,
-            segment_indices,
-            num_tile_segments,
-            num_segments_prefix);
+    Scatter(scatter_items, head_flags, segment_indices, num_tile_segments, num_segments_prefix);
 
     // Last thread in last tile will output final count (and last pair, if
     // necessary)
@@ -705,4 +674,3 @@ struct AgentReduceByKey
 };
 
 CUB_NAMESPACE_END
-

--- a/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/agent/agent_reduce_by_key.cuh
@@ -548,19 +548,19 @@ struct AgentReduceByKey
         .FlagHeads(head_flags, keys, prev_keys, flag_op, tile_predecessor);
     }
 
-// Zip values and head flags
+    // Reset head-flag on the very first item to make sure we don't start a new run for data where
+    // (key[0] == key[0]) is false (e.g., when key[0] is NaN)
+    if (threadIdx.x == 0 && tile_idx == 0)
+    {
+      head_flags[0] = 0;
+    }
+
+    // Zip values and head flags
 #pragma unroll
     for (int ITEM = 0; ITEM < ITEMS_PER_THREAD; ++ITEM)
     {
       scan_items[ITEM].value = values[ITEM];
       scan_items[ITEM].key   = head_flags[ITEM];
-    }
-
-    // Reset head-flag on the very first item to make sure we don't start a new run for data where
-    // (key[0] == key[0]) is false (e.g., when key[0] is NaN)
-    if (threadIdx.x == 0 && tile_idx == 0)
-    {
-      scan_items[0].key = 0;
     }
 
     // Perform exclusive tile scan

--- a/test/test_device_run_length_encode.cu
+++ b/test/test_device_run_length_encode.cu
@@ -40,127 +40,115 @@
 
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 
-#include "test_util.h"
-
 #include <cstdio>
 #include <typeinfo>
 
-using namespace cub;
+#include "test_util.h"
 
+using namespace cub;
 
 //---------------------------------------------------------------------
 // Globals, constants and typedefs
 //---------------------------------------------------------------------
 
-bool                    g_verbose           = false;
-int                     g_timing_iterations = 0;
-CachingDeviceAllocator  g_allocator(true);
+bool g_verbose          = false;
+int g_timing_iterations = 0;
+CachingDeviceAllocator g_allocator(true);
 
 // Dispatch types
 enum Backend
 {
-    CUB,        // CUB method
-    CDP,        // GPU-based (dynamic parallelism) dispatch to CUB method
+  CUB, // CUB method
+  CDP, // GPU-based (dynamic parallelism) dispatch to CUB method
 };
 
 // Operation types
 enum RleMethod
 {
-    RLE,                // Run length encode
-    NON_TRIVIAL,
+  RLE, // Run length encode
+  NON_TRIVIAL,
 };
-
 
 //---------------------------------------------------------------------
 // Dispatch to different CUB entrypoints
 //---------------------------------------------------------------------
 
-
 /**
  * Dispatch to run-length encode entrypoint
  */
-template <
-    typename                    InputIteratorT,
-    typename                    UniqueOutputIteratorT,
-    typename                    OffsetsOutputIteratorT,
-    typename                    LengthsOutputIteratorT,
-    typename                    NumRunsIterator,
-    typename                    OffsetT>
-CUB_RUNTIME_FUNCTION __forceinline__
-cudaError_t Dispatch(
-    Int2Type<RLE>               /*method*/,
-    Int2Type<CUB>               /*dispatch_to*/,
-    int                         timing_timing_iterations,
-    size_t                      */*d_temp_storage_bytes*/,
-    cudaError_t                 */*d_cdp_error*/,
+template <typename InputIteratorT,
+          typename UniqueOutputIteratorT,
+          typename OffsetsOutputIteratorT,
+          typename LengthsOutputIteratorT,
+          typename NumRunsIterator,
+          typename OffsetT>
+CUB_RUNTIME_FUNCTION __forceinline__ cudaError_t Dispatch(Int2Type<RLE> /*method*/,
+                                                          Int2Type<CUB> /*dispatch_to*/,
+                                                          int timing_timing_iterations,
+                                                          size_t * /*d_temp_storage_bytes*/,
+                                                          cudaError_t * /*d_cdp_error*/,
 
-    void*               d_temp_storage,
-    size_t                      &temp_storage_bytes,
-    InputIteratorT              d_in,
-    UniqueOutputIteratorT       d_unique_out,
-    OffsetsOutputIteratorT      /*d_offsets_out*/,
-    LengthsOutputIteratorT      d_lengths_out,
-    NumRunsIterator             d_num_runs,
-    cub::Equality               /*equality_op*/,
-    OffsetT                     num_items)
+                                                          void *d_temp_storage,
+                                                          size_t &temp_storage_bytes,
+                                                          InputIteratorT d_in,
+                                                          UniqueOutputIteratorT d_unique_out,
+                                                          OffsetsOutputIteratorT /*d_offsets_out*/,
+                                                          LengthsOutputIteratorT d_lengths_out,
+                                                          NumRunsIterator d_num_runs,
+                                                          cub::Equality /*equality_op*/,
+                                                          OffsetT num_items)
 {
-    cudaError_t error = cudaSuccess;
-    for (int i = 0; i < timing_timing_iterations; ++i)
-    {
-        error = DeviceRunLengthEncode::Encode(
-            d_temp_storage,
-            temp_storage_bytes,
-            d_in,
-            d_unique_out,
-            d_lengths_out,
-            d_num_runs,
-            num_items);
-    }
-    return error;
+  cudaError_t error = cudaSuccess;
+  for (int i = 0; i < timing_timing_iterations; ++i)
+  {
+    error = DeviceRunLengthEncode::Encode(d_temp_storage,
+                                          temp_storage_bytes,
+                                          d_in,
+                                          d_unique_out,
+                                          d_lengths_out,
+                                          d_num_runs,
+                                          num_items);
+  }
+  return error;
 }
-
 
 /**
  * Dispatch to non-trivial runs entrypoint
  */
-template <
-    typename                    InputIteratorT,
-    typename                    UniqueOutputIteratorT,
-    typename                    OffsetsOutputIteratorT,
-    typename                    LengthsOutputIteratorT,
-    typename                    NumRunsIterator,
-    typename                    OffsetT>
-CUB_RUNTIME_FUNCTION __forceinline__
-cudaError_t Dispatch(
-    Int2Type<NON_TRIVIAL>       /*method*/,
-    Int2Type<CUB>               /*dispatch_to*/,
-    int                         timing_timing_iterations,
-    size_t                      */*d_temp_storage_bytes*/,
-    cudaError_t                 */*d_cdp_error*/,
+template <typename InputIteratorT,
+          typename UniqueOutputIteratorT,
+          typename OffsetsOutputIteratorT,
+          typename LengthsOutputIteratorT,
+          typename NumRunsIterator,
+          typename OffsetT>
+CUB_RUNTIME_FUNCTION __forceinline__ cudaError_t Dispatch(Int2Type<NON_TRIVIAL> /*method*/,
+                                                          Int2Type<CUB> /*dispatch_to*/,
+                                                          int timing_timing_iterations,
+                                                          size_t * /*d_temp_storage_bytes*/,
+                                                          cudaError_t * /*d_cdp_error*/,
 
-    void*               d_temp_storage,
-    size_t                      &temp_storage_bytes,
-    InputIteratorT              d_in,
-    UniqueOutputIteratorT       /*d_unique_out*/,
-    OffsetsOutputIteratorT      d_offsets_out,
-    LengthsOutputIteratorT      d_lengths_out,
-    NumRunsIterator             d_num_runs,
-    cub::Equality               /*equality_op*/,
-    OffsetT                     num_items)
+                                                          void *d_temp_storage,
+                                                          size_t &temp_storage_bytes,
+                                                          InputIteratorT d_in,
+                                                          UniqueOutputIteratorT /*d_unique_out*/,
+                                                          OffsetsOutputIteratorT d_offsets_out,
+                                                          LengthsOutputIteratorT d_lengths_out,
+                                                          NumRunsIterator d_num_runs,
+                                                          cub::Equality /*equality_op*/,
+                                                          OffsetT num_items)
 {
-    cudaError_t error = cudaSuccess;
-    for (int i = 0; i < timing_timing_iterations; ++i)
-    {
-        error = DeviceRunLengthEncode::NonTrivialRuns(
-            d_temp_storage,
-            temp_storage_bytes,
-            d_in,
-            d_offsets_out,
-            d_lengths_out,
-            d_num_runs,
-            num_items);
-    }
-    return error;
+  cudaError_t error = cudaSuccess;
+  for (int i = 0; i < timing_timing_iterations; ++i)
+  {
+    error = DeviceRunLengthEncode::NonTrivialRuns(d_temp_storage,
+                                                  temp_storage_bytes,
+                                                  d_in,
+                                                  d_offsets_out,
+                                                  d_lengths_out,
+                                                  d_num_runs,
+                                                  num_items);
+  }
+  return error;
 }
 
 //---------------------------------------------------------------------
@@ -183,19 +171,19 @@ template <int RLE_METHOD,
           typename OffsetT>
 __global__ void CDPDispatchKernel(Int2Type<RLE_METHOD> method,
                                   Int2Type<CubBackend> cub_backend,
-                                  int                  timing_timing_iterations,
-                                  size_t              *d_temp_storage_bytes,
-                                  cudaError_t         *d_cdp_error,
+                                  int timing_timing_iterations,
+                                  size_t *d_temp_storage_bytes,
+                                  cudaError_t *d_cdp_error,
 
-                                  void                  *d_temp_storage,
-                                  size_t                 temp_storage_bytes,
-                                  InputIteratorT         d_in,
-                                  UniqueOutputIteratorT  d_unique_out,
+                                  void *d_temp_storage,
+                                  size_t temp_storage_bytes,
+                                  InputIteratorT d_in,
+                                  UniqueOutputIteratorT d_unique_out,
                                   OffsetsOutputIteratorT d_offsets_out,
                                   LengthsOutputIteratorT d_lengths_out,
-                                  NumRunsIterator        d_num_runs,
-                                  cub::Equality          equality_op,
-                                  OffsetT                num_items)
+                                  NumRunsIterator d_num_runs,
+                                  cub::Equality equality_op,
+                                  OffsetT num_items)
 {
   *d_cdp_error = Dispatch(method,
                           cub_backend,
@@ -226,49 +214,47 @@ template <int RLE_METHOD,
           typename NumRunsIterator,
           typename EqualityOp,
           typename OffsetT>
-__forceinline__ cudaError_t
-Dispatch(Int2Type<RLE_METHOD> method,
-         Int2Type<CDP> /*dispatch_to*/,
-         int          timing_timing_iterations,
-         size_t      *d_temp_storage_bytes,
-         cudaError_t *d_cdp_error,
+__forceinline__ cudaError_t Dispatch(Int2Type<RLE_METHOD> method,
+                                     Int2Type<CDP> /*dispatch_to*/,
+                                     int timing_timing_iterations,
+                                     size_t *d_temp_storage_bytes,
+                                     cudaError_t *d_cdp_error,
 
-         void                  *d_temp_storage,
-         size_t                &temp_storage_bytes,
-         InputIteratorT         d_in,
-         UniqueOutputIteratorT  d_unique_out,
-         OffsetsOutputIteratorT d_offsets_out,
-         LengthsOutputIteratorT d_lengths_out,
-         NumRunsIterator        d_num_runs,
-         EqualityOp             equality_op,
-         OffsetT                num_items)
+                                     void *d_temp_storage,
+                                     size_t &temp_storage_bytes,
+                                     InputIteratorT d_in,
+                                     UniqueOutputIteratorT d_unique_out,
+                                     OffsetsOutputIteratorT d_offsets_out,
+                                     LengthsOutputIteratorT d_lengths_out,
+                                     NumRunsIterator d_num_runs,
+                                     EqualityOp equality_op,
+                                     OffsetT num_items)
 {
   // Invoke kernel to invoke device-side dispatch
-  cudaError_t retval =
-    thrust::cuda_cub::launcher::triple_chevron(1, 1, 0, 0)
-      .doit(CDPDispatchKernel<RLE_METHOD,
-                              CUB,
-                              InputIteratorT,
-                              UniqueOutputIteratorT,
-                              OffsetsOutputIteratorT,
-                              LengthsOutputIteratorT,
-                              NumRunsIterator,
-                              EqualityOp,
-                              OffsetT>,
-            method,
-            Int2Type<CUB>{},
-            timing_timing_iterations,
-            d_temp_storage_bytes,
-            d_cdp_error,
-            d_temp_storage,
-            temp_storage_bytes,
-            d_in,
-            d_unique_out,
-            d_offsets_out,
-            d_lengths_out,
-            d_num_runs,
-            equality_op,
-            num_items);
+  cudaError_t retval = thrust::cuda_cub::launcher::triple_chevron(1, 1, 0, 0)
+                         .doit(CDPDispatchKernel<RLE_METHOD,
+                                                 CUB,
+                                                 InputIteratorT,
+                                                 UniqueOutputIteratorT,
+                                                 OffsetsOutputIteratorT,
+                                                 LengthsOutputIteratorT,
+                                                 NumRunsIterator,
+                                                 EqualityOp,
+                                                 OffsetT>,
+                               method,
+                               Int2Type<CUB>{},
+                               timing_timing_iterations,
+                               d_temp_storage_bytes,
+                               d_cdp_error,
+                               d_temp_storage,
+                               temp_storage_bytes,
+                               d_in,
+                               d_unique_out,
+                               d_offsets_out,
+                               d_lengths_out,
+                               d_num_runs,
+                               equality_op,
+                               num_items);
   CubDebugExit(retval);
 
   // Copy out temp_storage_bytes
@@ -278,10 +264,7 @@ Dispatch(Int2Type<RLE_METHOD> method,
                           cudaMemcpyDeviceToHost));
 
   // Copy out error
-  CubDebugExit(cudaMemcpy(&retval,
-                          d_cdp_error,
-                          sizeof(cudaError_t) * 1,
-                          cudaMemcpyDeviceToHost));
+  CubDebugExit(cudaMemcpy(&retval, d_cdp_error, sizeof(cudaError_t) * 1, cudaMemcpyDeviceToHost));
   return retval;
 }
 
@@ -291,427 +274,464 @@ Dispatch(Int2Type<RLE_METHOD> method,
 // Test generation
 //---------------------------------------------------------------------
 
-
 /**
  * Initialize problem
  */
 template <typename T>
-void Initialize(
-    int         entropy_reduction,
-    T           *h_in,
-    int         num_items,
-    int         max_segment)
+void Initialize(int entropy_reduction, T *h_in, int num_items, int max_segment)
 {
-    unsigned int max_int = (unsigned int) -1;
+  unsigned int max_int = (unsigned int)-1;
 
-    int key = 0;
-    int i = 0;
-    while (i < num_items)
+  int key = 0;
+  int i   = 0;
+  while (i < num_items)
+  {
+    // Select number of repeating occurrences for the current run
+    int repeat;
+    if (max_segment < 0)
     {
-        // Select number of repeating occurrences for the current run
-        int repeat;
-        if (max_segment < 0)
-        {
-            repeat = num_items;
-        }
-        else if (max_segment < 2)
-        {
-            repeat = 1;
-        }
-        else
-        {
-            RandomBits(repeat, entropy_reduction);
-            repeat = (int) ((double(repeat) * double(max_segment)) / double(max_int));
-            repeat = CUB_MAX(1, repeat);
-        }
-
-        int j = i;
-        while (j < CUB_MIN(i + repeat, num_items))
-        {
-            InitValue(INTEGER_SEED, h_in[j], key);
-            j++;
-        }
-
-        i = j;
-        key++;
+      repeat = num_items;
+    }
+    else if (max_segment < 2)
+    {
+      repeat = 1;
+    }
+    else
+    {
+      RandomBits(repeat, entropy_reduction);
+      repeat = (int)((double(repeat) * double(max_segment)) / double(max_int));
+      repeat = CUB_MAX(1, repeat);
     }
 
-    if (g_verbose)
+    int j = i;
+    while (j < CUB_MIN(i + repeat, num_items))
     {
-        printf("Input:\n");
-        DisplayResults(h_in, num_items);
-        printf("\n\n");
+      InitValue(INTEGER_SEED, h_in[j], key);
+      j++;
     }
+
+    i = j;
+    key++;
+  }
+
+  if (g_verbose)
+  {
+    printf("Input:\n");
+    DisplayResults(h_in, num_items);
+    printf("\n\n");
+  }
 }
-
 
 /**
  * Solve problem.  Returns total number of segments identified
  */
-template <
-    RleMethod       RLE_METHOD,
-    typename        InputIteratorT,
-    typename        T,
-    typename        OffsetT,
-    typename        LengthT,
-    typename        EqualityOp>
-int Solve(
-    InputIteratorT  h_in,
-    T               *h_unique_reference,
-    OffsetT         *h_offsets_reference,
-    LengthT         *h_lengths_reference,
-    EqualityOp      equality_op,
-    int             num_items)
+template <RleMethod RLE_METHOD,
+          typename InputIteratorT,
+          typename T,
+          typename OffsetT,
+          typename LengthT,
+          typename EqualityOp>
+int Solve(InputIteratorT h_in,
+          T *h_unique_reference,
+          OffsetT *h_offsets_reference,
+          LengthT *h_lengths_reference,
+          EqualityOp equality_op,
+          int num_items)
 {
-    if (num_items == 0)
-        return 0;
+  if (num_items == 0)
+    return 0;
 
-    // First item
-    T       previous        = h_in[0];
-    LengthT  length          = 1;
-    int     num_runs        = 0;
-    int     run_begin       = 0;
+  // First item
+  T previous     = h_in[0];
+  LengthT length = 1;
+  int num_runs   = 0;
+  int run_begin  = 0;
 
-    // Subsequent items
-    for (int i = 1; i < num_items; ++i)
+  // Subsequent items
+  for (int i = 1; i < num_items; ++i)
+  {
+    if (!equality_op(previous, h_in[i]))
     {
-        if (!equality_op(previous, h_in[i]))
-        {
-            if ((RLE_METHOD != NON_TRIVIAL) || (length > 1))
-            {
-                h_unique_reference[num_runs]      = previous;
-                h_offsets_reference[num_runs]     = run_begin;
-                h_lengths_reference[num_runs]     = length;
-                num_runs++;
-            }
-            length = 1;
-            run_begin = i;
-        }
-        else
-        {
-            length++;
-        }
-        previous = h_in[i];
-    }
-
-    if ((RLE_METHOD != NON_TRIVIAL) || (length > 1))
-    {
-        h_unique_reference[num_runs]    = previous;
-        h_offsets_reference[num_runs]   = run_begin;
-        h_lengths_reference[num_runs]   = length;
+      if ((RLE_METHOD != NON_TRIVIAL) || (length > 1))
+      {
+        h_unique_reference[num_runs]  = previous;
+        h_offsets_reference[num_runs] = run_begin;
+        h_lengths_reference[num_runs] = length;
         num_runs++;
+      }
+      length    = 1;
+      run_begin = i;
     }
+    else
+    {
+      length++;
+    }
+    previous = h_in[i];
+  }
 
-    return num_runs;
+  if ((RLE_METHOD != NON_TRIVIAL) || (length > 1))
+  {
+    h_unique_reference[num_runs]  = previous;
+    h_offsets_reference[num_runs] = run_begin;
+    h_lengths_reference[num_runs] = length;
+    num_runs++;
+  }
+
+  return num_runs;
 }
-
-
 
 /**
  * Test DeviceRunLengthEncode for a given problem input
  */
-template <
-    RleMethod           RLE_METHOD,
-    Backend             BACKEND,
-    typename            DeviceInputIteratorT,
-    typename            T,
-    typename            OffsetT,
-    typename            LengthT,
-    typename            EqualityOp>
-void Test(
-    DeviceInputIteratorT d_in,
-    T                   *h_unique_reference,
-    OffsetT             *h_offsets_reference,
-    LengthT             *h_lengths_reference,
-    EqualityOp          equality_op,
-    int                 num_runs,
-    int                 num_items)
+template <RleMethod RLE_METHOD,
+          Backend BACKEND,
+          typename DeviceInputIteratorT,
+          typename T,
+          typename OffsetT,
+          typename LengthT,
+          typename EqualityOp>
+void Test(DeviceInputIteratorT d_in,
+          T *h_unique_reference,
+          OffsetT *h_offsets_reference,
+          LengthT *h_lengths_reference,
+          EqualityOp equality_op,
+          int num_runs,
+          int num_items)
 {
-    // Allocate device output arrays and number of segments
-    T*          d_unique_out       = NULL;
-    LengthT*    d_offsets_out      = NULL;
-    OffsetT*    d_lengths_out      = NULL;
-    int*        d_num_runs         = NULL;
+  // Allocate device output arrays and number of segments
+  T *d_unique_out        = NULL;
+  LengthT *d_offsets_out = NULL;
+  OffsetT *d_lengths_out = NULL;
+  int *d_num_runs        = NULL;
 
-    if (RLE_METHOD == RLE)
-        CubDebugExit(g_allocator.DeviceAllocate((void**)&d_unique_out, sizeof(T) * num_items));
-    if (RLE_METHOD == NON_TRIVIAL)
-        CubDebugExit(g_allocator.DeviceAllocate((void**)&d_offsets_out, sizeof(OffsetT) * num_items));
-    CubDebugExit(g_allocator.DeviceAllocate((void**)&d_lengths_out, sizeof(LengthT) * num_items));
-    CubDebugExit(g_allocator.DeviceAllocate((void**)&d_num_runs, sizeof(int)));
+  if (RLE_METHOD == RLE)
+    CubDebugExit(g_allocator.DeviceAllocate((void **)&d_unique_out, sizeof(T) * num_items));
+  if (RLE_METHOD == NON_TRIVIAL)
+    CubDebugExit(g_allocator.DeviceAllocate((void **)&d_offsets_out, sizeof(OffsetT) * num_items));
+  CubDebugExit(g_allocator.DeviceAllocate((void **)&d_lengths_out, sizeof(LengthT) * num_items));
+  CubDebugExit(g_allocator.DeviceAllocate((void **)&d_num_runs, sizeof(int)));
 
-    // Allocate CDP device arrays
-    size_t*          d_temp_storage_bytes = NULL;
-    cudaError_t*     d_cdp_error = NULL;
-    CubDebugExit(g_allocator.DeviceAllocate((void**)&d_temp_storage_bytes,  sizeof(size_t) * 1));
-    CubDebugExit(g_allocator.DeviceAllocate((void**)&d_cdp_error,           sizeof(cudaError_t) * 1));
+  // Allocate CDP device arrays
+  size_t *d_temp_storage_bytes = NULL;
+  cudaError_t *d_cdp_error     = NULL;
+  CubDebugExit(g_allocator.DeviceAllocate((void **)&d_temp_storage_bytes, sizeof(size_t) * 1));
+  CubDebugExit(g_allocator.DeviceAllocate((void **)&d_cdp_error, sizeof(cudaError_t) * 1));
 
-    // Allocate temporary storage
-    void*           d_temp_storage = NULL;
-    size_t          temp_storage_bytes = 0;
-    CubDebugExit(Dispatch(Int2Type<RLE_METHOD>(), Int2Type<BACKEND>(), 1, d_temp_storage_bytes, d_cdp_error, d_temp_storage, temp_storage_bytes, d_in, d_unique_out, d_offsets_out, d_lengths_out, d_num_runs, equality_op, num_items));
-    CubDebugExit(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
+  // Allocate temporary storage
+  void *d_temp_storage      = NULL;
+  size_t temp_storage_bytes = 0;
+  CubDebugExit(Dispatch(Int2Type<RLE_METHOD>(),
+                        Int2Type<BACKEND>(),
+                        1,
+                        d_temp_storage_bytes,
+                        d_cdp_error,
+                        d_temp_storage,
+                        temp_storage_bytes,
+                        d_in,
+                        d_unique_out,
+                        d_offsets_out,
+                        d_lengths_out,
+                        d_num_runs,
+                        equality_op,
+                        num_items));
+  CubDebugExit(g_allocator.DeviceAllocate(&d_temp_storage, temp_storage_bytes));
 
-    // Clear device output arrays
-    if (RLE_METHOD == RLE)
-        CubDebugExit(cudaMemset(d_unique_out,   0, sizeof(T) * num_items));
-    if (RLE_METHOD == NON_TRIVIAL)
-        CubDebugExit(cudaMemset(d_offsets_out,  0, sizeof(OffsetT) * num_items));
-    CubDebugExit(cudaMemset(d_lengths_out,  0, sizeof(LengthT) * num_items));
-    CubDebugExit(cudaMemset(d_num_runs,     0, sizeof(int)));
+  // Clear device output arrays
+  if (RLE_METHOD == RLE)
+    CubDebugExit(cudaMemset(d_unique_out, 0, sizeof(T) * num_items));
+  if (RLE_METHOD == NON_TRIVIAL)
+    CubDebugExit(cudaMemset(d_offsets_out, 0, sizeof(OffsetT) * num_items));
+  CubDebugExit(cudaMemset(d_lengths_out, 0, sizeof(LengthT) * num_items));
+  CubDebugExit(cudaMemset(d_num_runs, 0, sizeof(int)));
 
-    // Run warmup/correctness iteration
-    CubDebugExit(Dispatch(Int2Type<RLE_METHOD>(), Int2Type<BACKEND>(), 1, d_temp_storage_bytes, d_cdp_error, d_temp_storage, temp_storage_bytes, d_in, d_unique_out, d_offsets_out, d_lengths_out, d_num_runs, equality_op, num_items));
+  // Run warmup/correctness iteration
+  CubDebugExit(Dispatch(Int2Type<RLE_METHOD>(),
+                        Int2Type<BACKEND>(),
+                        1,
+                        d_temp_storage_bytes,
+                        d_cdp_error,
+                        d_temp_storage,
+                        temp_storage_bytes,
+                        d_in,
+                        d_unique_out,
+                        d_offsets_out,
+                        d_lengths_out,
+                        d_num_runs,
+                        equality_op,
+                        num_items));
 
-    // Check for correctness (and display results, if specified)
-    int compare0 = 0;
-    int compare1 = 0;
-    int compare2 = 0;
-    int compare3 = 0;
+  // Check for correctness (and display results, if specified)
+  int compare0 = 0;
+  int compare1 = 0;
+  int compare2 = 0;
+  int compare3 = 0;
 
-    if (RLE_METHOD == RLE)
-    {
-        compare0 = CompareDeviceResults(h_unique_reference, d_unique_out, num_runs, true, g_verbose);
-        printf("\t Keys %s\n", compare0 ? "FAIL" : "PASS");
-    }
+  if (RLE_METHOD == RLE)
+  {
+    compare0 = CompareDeviceResults(h_unique_reference, d_unique_out, num_runs, true, g_verbose);
+    printf("\t Keys %s\n", compare0 ? "FAIL" : "PASS");
+  }
 
-    if (RLE_METHOD != RLE)
-    {
-        compare1 = CompareDeviceResults(h_offsets_reference, d_offsets_out, num_runs, true, g_verbose);
-        printf("\t Offsets %s\n", compare1 ? "FAIL" : "PASS");
-    }
+  if (RLE_METHOD != RLE)
+  {
+    compare1 = CompareDeviceResults(h_offsets_reference, d_offsets_out, num_runs, true, g_verbose);
+    printf("\t Offsets %s\n", compare1 ? "FAIL" : "PASS");
+  }
 
-    compare2 = CompareDeviceResults(h_lengths_reference, d_lengths_out, num_runs, true, g_verbose);
-    printf("\t Lengths %s\n", compare2 ? "FAIL" : "PASS");
+  compare2 = CompareDeviceResults(h_lengths_reference, d_lengths_out, num_runs, true, g_verbose);
+  printf("\t Lengths %s\n", compare2 ? "FAIL" : "PASS");
 
-    compare3 = CompareDeviceResults(&num_runs, d_num_runs, 1, true, g_verbose);
-    printf("\t Count %s\n", compare3 ? "FAIL" : "PASS");
+  compare3 = CompareDeviceResults(&num_runs, d_num_runs, 1, true, g_verbose);
+  printf("\t Count %s\n", compare3 ? "FAIL" : "PASS");
 
-    // Flush any stdout/stderr
-    fflush(stdout);
-    fflush(stderr);
+  // Flush any stdout/stderr
+  fflush(stdout);
+  fflush(stderr);
 
-    // Performance
-    GpuTimer gpu_timer;
-    gpu_timer.Start();
-    CubDebugExit(Dispatch(Int2Type<RLE_METHOD>(), Int2Type<BACKEND>(), g_timing_iterations, d_temp_storage_bytes, d_cdp_error, d_temp_storage, temp_storage_bytes, d_in, d_unique_out, d_offsets_out, d_lengths_out, d_num_runs, equality_op, num_items));
-    gpu_timer.Stop();
-    float elapsed_millis = gpu_timer.ElapsedMillis();
+  // Performance
+  GpuTimer gpu_timer;
+  gpu_timer.Start();
+  CubDebugExit(Dispatch(Int2Type<RLE_METHOD>(),
+                        Int2Type<BACKEND>(),
+                        g_timing_iterations,
+                        d_temp_storage_bytes,
+                        d_cdp_error,
+                        d_temp_storage,
+                        temp_storage_bytes,
+                        d_in,
+                        d_unique_out,
+                        d_offsets_out,
+                        d_lengths_out,
+                        d_num_runs,
+                        equality_op,
+                        num_items));
+  gpu_timer.Stop();
+  float elapsed_millis = gpu_timer.ElapsedMillis();
 
-    // Display performance
-    if (g_timing_iterations > 0)
-    {
-        float avg_millis = elapsed_millis / g_timing_iterations;
-        float giga_rate = float(num_items) / avg_millis / 1000.0f / 1000.0f;
-        int bytes_moved = (num_items * sizeof(T)) + (num_runs * (sizeof(OffsetT) + sizeof(LengthT)));
-        float giga_bandwidth = float(bytes_moved) / avg_millis / 1000.0f / 1000.0f;
-        printf(", %.3f avg ms, %.3f billion items/s, %.3f logical GB/s", avg_millis, giga_rate, giga_bandwidth);
-    }
-    printf("\n\n");
+  // Display performance
+  if (g_timing_iterations > 0)
+  {
+    float avg_millis = elapsed_millis / g_timing_iterations;
+    float giga_rate  = float(num_items) / avg_millis / 1000.0f / 1000.0f;
+    int bytes_moved  = (num_items * sizeof(T)) + (num_runs * (sizeof(OffsetT) + sizeof(LengthT)));
+    float giga_bandwidth = float(bytes_moved) / avg_millis / 1000.0f / 1000.0f;
+    printf(", %.3f avg ms, %.3f billion items/s, %.3f logical GB/s",
+           avg_millis,
+           giga_rate,
+           giga_bandwidth);
+  }
+  printf("\n\n");
 
-    // Flush any stdout/stderr
-    fflush(stdout);
-    fflush(stderr);
+  // Flush any stdout/stderr
+  fflush(stdout);
+  fflush(stderr);
 
-    // Cleanup
-    if (d_unique_out) CubDebugExit(g_allocator.DeviceFree(d_unique_out));
-    if (d_offsets_out) CubDebugExit(g_allocator.DeviceFree(d_offsets_out));
-    if (d_lengths_out) CubDebugExit(g_allocator.DeviceFree(d_lengths_out));
-    if (d_num_runs) CubDebugExit(g_allocator.DeviceFree(d_num_runs));
-    if (d_temp_storage_bytes) CubDebugExit(g_allocator.DeviceFree(d_temp_storage_bytes));
-    if (d_cdp_error) CubDebugExit(g_allocator.DeviceFree(d_cdp_error));
-    if (d_temp_storage) CubDebugExit(g_allocator.DeviceFree(d_temp_storage));
+  // Cleanup
+  if (d_unique_out)
+    CubDebugExit(g_allocator.DeviceFree(d_unique_out));
+  if (d_offsets_out)
+    CubDebugExit(g_allocator.DeviceFree(d_offsets_out));
+  if (d_lengths_out)
+    CubDebugExit(g_allocator.DeviceFree(d_lengths_out));
+  if (d_num_runs)
+    CubDebugExit(g_allocator.DeviceFree(d_num_runs));
+  if (d_temp_storage_bytes)
+    CubDebugExit(g_allocator.DeviceFree(d_temp_storage_bytes));
+  if (d_cdp_error)
+    CubDebugExit(g_allocator.DeviceFree(d_cdp_error));
+  if (d_temp_storage)
+    CubDebugExit(g_allocator.DeviceFree(d_temp_storage));
 
-    // Correctness asserts
-    AssertEquals(0, compare0 | compare1 | compare2 | compare3);
+  // Correctness asserts
+  AssertEquals(0, compare0 | compare1 | compare2 | compare3);
 }
-
 
 /**
  * Test DeviceRunLengthEncode on pointer type
  */
-template <
-    RleMethod       RLE_METHOD,
-    Backend         BACKEND,
-    typename        T,
-    typename        OffsetT,
-    typename        LengthT>
-void TestPointer(
-    int             num_items,
-    int             entropy_reduction,
-    int             max_segment)
+template <RleMethod RLE_METHOD, Backend BACKEND, typename T, typename OffsetT, typename LengthT>
+void TestPointer(int num_items, int entropy_reduction, int max_segment)
 {
-    // Allocate host arrays
-    T*      h_in                    = new T[num_items];
-    T*      h_unique_reference      = new T[num_items];
-    OffsetT* h_offsets_reference     = new OffsetT[num_items];
-    LengthT* h_lengths_reference     = new LengthT[num_items];
+  // Allocate host arrays
+  T *h_in                      = new T[num_items];
+  T *h_unique_reference        = new T[num_items];
+  OffsetT *h_offsets_reference = new OffsetT[num_items];
+  LengthT *h_lengths_reference = new LengthT[num_items];
 
-    for (int i = 0; i < num_items; ++i)
-        InitValue(INTEGER_SEED, h_offsets_reference[i], 1);
+  for (int i = 0; i < num_items; ++i)
+    InitValue(INTEGER_SEED, h_offsets_reference[i], 1);
 
-    // Initialize problem and solution
-    Equality equality_op;
-    Initialize(entropy_reduction, h_in, num_items, max_segment);
+  // Initialize problem and solution
+  Equality equality_op;
+  Initialize(entropy_reduction, h_in, num_items, max_segment);
 
-    int num_runs = Solve<RLE_METHOD>(h_in, h_unique_reference, h_offsets_reference, h_lengths_reference, equality_op, num_items);
+  int num_runs = Solve<RLE_METHOD>(h_in,
+                                   h_unique_reference,
+                                   h_offsets_reference,
+                                   h_lengths_reference,
+                                   equality_op,
+                                   num_items);
 
-    printf("\nPointer %s cub::%s on %d items, %d segments (avg run length %.3f), {%s key, %s offset, %s length}, max_segment %d, entropy_reduction %d\n",
-        (RLE_METHOD == RLE) ? "DeviceRunLengthEncode::Encode" : (RLE_METHOD == NON_TRIVIAL) ? "DeviceRunLengthEncode::NonTrivialRuns" : "Other",
-        (BACKEND == CDP) ? "CDP CUB" : "CUB",
-        num_items, num_runs, float(num_items) / num_runs,
-        typeid(T).name(), typeid(OffsetT).name(), typeid(LengthT).name(),
-        max_segment, entropy_reduction);
-    fflush(stdout);
+  printf("\nPointer %s cub::%s on %d items, %d segments (avg run length %.3f), {%s key, %s offset, "
+         "%s length}, max_segment %d, entropy_reduction %d\n",
+         (RLE_METHOD == RLE)           ? "DeviceRunLengthEncode::Encode"
+         : (RLE_METHOD == NON_TRIVIAL) ? "DeviceRunLengthEncode::NonTrivialRuns"
+                                       : "Other",
+         (BACKEND == CDP) ? "CDP CUB" : "CUB",
+         num_items,
+         num_runs,
+         float(num_items) / num_runs,
+         typeid(T).name(),
+         typeid(OffsetT).name(),
+         typeid(LengthT).name(),
+         max_segment,
+         entropy_reduction);
+  fflush(stdout);
 
-    // Allocate problem device arrays
-    T* d_in = NULL;
-    CubDebugExit(g_allocator.DeviceAllocate((void**)&d_in, sizeof(T) * num_items));
+  // Allocate problem device arrays
+  T *d_in = NULL;
+  CubDebugExit(g_allocator.DeviceAllocate((void **)&d_in, sizeof(T) * num_items));
 
-    // Initialize device input
-    CubDebugExit(cudaMemcpy(d_in, h_in, sizeof(T) * num_items, cudaMemcpyHostToDevice));
+  // Initialize device input
+  CubDebugExit(cudaMemcpy(d_in, h_in, sizeof(T) * num_items, cudaMemcpyHostToDevice));
 
-    // Run Test
-    Test<RLE_METHOD, BACKEND>(d_in, h_unique_reference, h_offsets_reference, h_lengths_reference, equality_op, num_runs, num_items);
+  // Run Test
+  Test<RLE_METHOD, BACKEND>(d_in,
+                            h_unique_reference,
+                            h_offsets_reference,
+                            h_lengths_reference,
+                            equality_op,
+                            num_runs,
+                            num_items);
 
-    // Cleanup
-    if (h_in) delete[] h_in;
-    if (h_unique_reference) delete[] h_unique_reference;
-    if (h_offsets_reference) delete[] h_offsets_reference;
-    if (h_lengths_reference) delete[] h_lengths_reference;
-    if (d_in) CubDebugExit(g_allocator.DeviceFree(d_in));
+  // Cleanup
+  if (h_in)
+    delete[] h_in;
+  if (h_unique_reference)
+    delete[] h_unique_reference;
+  if (h_offsets_reference)
+    delete[] h_offsets_reference;
+  if (h_lengths_reference)
+    delete[] h_lengths_reference;
+  if (d_in)
+    CubDebugExit(g_allocator.DeviceFree(d_in));
 }
-
 
 /**
  * Test on iterator type
  */
-template <
-    RleMethod       RLE_METHOD,
-    Backend         BACKEND,
-    typename        T,
-    typename        OffsetT,
-    typename        LengthT>
-void TestIterator(
-    int             num_items,
-    Int2Type<true>  /*is_primitive*/)
+template <RleMethod RLE_METHOD, Backend BACKEND, typename T, typename OffsetT, typename LengthT>
+void TestIterator(int num_items, Int2Type<true> /*is_primitive*/)
 {
-    // Allocate host arrays
-    T* h_unique_reference       = new T[num_items];
-    OffsetT* h_offsets_reference = new OffsetT[num_items];
-    LengthT* h_lengths_reference = new LengthT[num_items];
+  // Allocate host arrays
+  T *h_unique_reference        = new T[num_items];
+  OffsetT *h_offsets_reference = new OffsetT[num_items];
+  LengthT *h_lengths_reference = new LengthT[num_items];
 
-    T one_val;
-    InitValue(INTEGER_SEED, one_val, 1);
-    ConstantInputIterator<T, int> h_in(one_val);
+  T one_val;
+  InitValue(INTEGER_SEED, one_val, 1);
+  ConstantInputIterator<T, int> h_in(one_val);
 
-    // Initialize problem and solution
-    Equality equality_op;
-    int num_runs = Solve<RLE_METHOD>(h_in, h_unique_reference, h_offsets_reference, h_lengths_reference, equality_op, num_items);
+  // Initialize problem and solution
+  Equality equality_op;
+  int num_runs = Solve<RLE_METHOD>(h_in,
+                                   h_unique_reference,
+                                   h_offsets_reference,
+                                   h_lengths_reference,
+                                   equality_op,
+                                   num_items);
 
-    printf("\nIterator %s cub::%s on %d items, %d segments (avg run length %.3f), {%s key, %s offset, %s length}\n",
-        (RLE_METHOD == RLE) ? "DeviceRunLengthEncode::Encode" : (RLE_METHOD == NON_TRIVIAL) ? "DeviceRunLengthEncode::NonTrivialRuns" : "Other",
-        (BACKEND == CDP) ? "CDP CUB" : "CUB",
-        num_items, num_runs, float(num_items) / num_runs,
-        typeid(T).name(), typeid(OffsetT).name(), typeid(LengthT).name());
-    fflush(stdout);
+  printf("\nIterator %s cub::%s on %d items, %d segments (avg run length %.3f), {%s key, %s "
+         "offset, %s length}\n",
+         (RLE_METHOD == RLE)           ? "DeviceRunLengthEncode::Encode"
+         : (RLE_METHOD == NON_TRIVIAL) ? "DeviceRunLengthEncode::NonTrivialRuns"
+                                       : "Other",
+         (BACKEND == CDP) ? "CDP CUB" : "CUB",
+         num_items,
+         num_runs,
+         float(num_items) / num_runs,
+         typeid(T).name(),
+         typeid(OffsetT).name(),
+         typeid(LengthT).name());
+  fflush(stdout);
 
-    // Run Test
-    Test<RLE_METHOD, BACKEND>(h_in, h_unique_reference, h_offsets_reference, h_lengths_reference, equality_op, num_runs, num_items);
+  // Run Test
+  Test<RLE_METHOD, BACKEND>(h_in,
+                            h_unique_reference,
+                            h_offsets_reference,
+                            h_lengths_reference,
+                            equality_op,
+                            num_runs,
+                            num_items);
 
-    // Cleanup
-    if (h_unique_reference) delete[] h_unique_reference;
-    if (h_offsets_reference) delete[] h_offsets_reference;
-    if (h_lengths_reference) delete[] h_lengths_reference;
+  // Cleanup
+  if (h_unique_reference)
+    delete[] h_unique_reference;
+  if (h_offsets_reference)
+    delete[] h_offsets_reference;
+  if (h_lengths_reference)
+    delete[] h_lengths_reference;
 }
 
-
-template <
-    RleMethod       RLE_METHOD,
-    Backend         BACKEND,
-    typename        T,
-    typename        OffsetT,
-    typename        LengthT>
-void TestIterator(
-    int             /*num_items*/,
-    Int2Type<false> /*is_primitive*/)
+template <RleMethod RLE_METHOD, Backend BACKEND, typename T, typename OffsetT, typename LengthT>
+void TestIterator(int /*num_items*/, Int2Type<false> /*is_primitive*/)
 {}
-
 
 /**
  * Test different gen modes
  */
-template <RleMethod RLE_METHOD,
-          Backend BACKEND,
-          typename T,
-          typename OffsetT,
-          typename LengthT>
+template <RleMethod RLE_METHOD, Backend BACKEND, typename T, typename OffsetT, typename LengthT>
 void Test(int num_items)
 {
   // Test iterator (one run)
-  TestIterator<RLE_METHOD, BACKEND, T, OffsetT, LengthT>(
-    num_items,
-    Int2Type<Traits<T>::PRIMITIVE>());
+  TestIterator<RLE_METHOD, BACKEND, T, OffsetT, LengthT>(num_items,
+                                                         Int2Type<Traits<T>::PRIMITIVE>());
 
   // Evaluate different run lengths / segment sizes
   const int max_seg_limit = CUB_MIN(num_items, 1 << 16);
-  const int max_seg_inc = 4;
-  for (int max_segment = 1, entropy_reduction = 0;
-       max_segment <= max_seg_limit;
+  const int max_seg_inc   = 4;
+  for (int max_segment = 1, entropy_reduction = 0; max_segment <= max_seg_limit;
        max_segment <<= max_seg_inc, entropy_reduction++)
   {
     const int max_seg = CUB_MAX(1, max_segment);
-    TestPointer<RLE_METHOD, BACKEND, T, OffsetT, LengthT>(num_items,
-                                                          entropy_reduction,
-                                                          max_seg);
+    TestPointer<RLE_METHOD, BACKEND, T, OffsetT, LengthT>(num_items, entropy_reduction, max_seg);
   }
 }
 
 /**
  * Test different dispatch
  */
-template <
-    typename        T,
-    typename        OffsetT,
-    typename        LengthT>
-void TestDispatch(
-    int             num_items)
+template <typename T, typename OffsetT, typename LengthT>
+void TestDispatch(int num_items)
 {
 #if TEST_CDP == 0
-    Test<RLE,           CUB, T, OffsetT, LengthT>(num_items);
-    Test<NON_TRIVIAL,   CUB, T, OffsetT, LengthT>(num_items);
+  Test<RLE, CUB, T, OffsetT, LengthT>(num_items);
+  Test<NON_TRIVIAL, CUB, T, OffsetT, LengthT>(num_items);
 #elif TEST_CDP == 1
-    Test<RLE,           CDP, T, OffsetT, LengthT>(num_items);
-    Test<NON_TRIVIAL,   CDP, T, OffsetT, LengthT>(num_items);
+  Test<RLE, CDP, T, OffsetT, LengthT>(num_items);
+  Test<NON_TRIVIAL, CDP, T, OffsetT, LengthT>(num_items);
 #endif
 }
-
 
 /**
  * Test different input sizes
  */
-template <
-    typename        T,
-    typename        OffsetT,
-    typename        LengthT>
-void TestSize(
-    int             num_items)
+template <typename T, typename OffsetT, typename LengthT>
+void TestSize(int num_items)
 {
-    if (num_items < 0)
-    {
-        TestDispatch<T, OffsetT, LengthT>(0);
-        TestDispatch<T, OffsetT, LengthT>(1);
-        TestDispatch<T, OffsetT, LengthT>(100);
-        TestDispatch<T, OffsetT, LengthT>(10000);
-        TestDispatch<T, OffsetT, LengthT>(1000000);
-    }
-    else
-    {
-        TestDispatch<T, OffsetT, LengthT>(num_items);
-    }
-
+  if (num_items < 0)
+  {
+    TestDispatch<T, OffsetT, LengthT>(0);
+    TestDispatch<T, OffsetT, LengthT>(1);
+    TestDispatch<T, OffsetT, LengthT>(100);
+    TestDispatch<T, OffsetT, LengthT>(10000);
+    TestDispatch<T, OffsetT, LengthT>(1000000);
+  }
+  else
+  {
+    TestDispatch<T, OffsetT, LengthT>(num_items);
+  }
 }
-
 
 //---------------------------------------------------------------------
 // Main
@@ -720,53 +740,51 @@ void TestSize(
 /**
  * Main
  */
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
-    int num_items           = -1;
+  int num_items = -1;
 
-    // Initialize command line
-    CommandLineArgs args(argc, argv);
-    g_verbose = args.CheckCmdLineFlag("v");
-    args.GetCmdLineArgument("n", num_items);
-    args.GetCmdLineArgument("i", g_timing_iterations);
+  // Initialize command line
+  CommandLineArgs args(argc, argv);
+  g_verbose = args.CheckCmdLineFlag("v");
+  args.GetCmdLineArgument("n", num_items);
+  args.GetCmdLineArgument("i", g_timing_iterations);
 
-    // Print usage
-    if (args.CheckCmdLineFlag("help"))
-    {
-        printf("%s "
-            "[--n=<input items> "
-            "[--i=<timing iterations> "
-            "[--device=<device-id>] "
-            "[--v] "
-            "\n", argv[0]);
-        exit(0);
-    }
+  // Print usage
+  if (args.CheckCmdLineFlag("help"))
+  {
+    printf("%s "
+           "[--n=<input items> "
+           "[--i=<timing iterations> "
+           "[--device=<device-id>] "
+           "[--v] "
+           "\n",
+           argv[0]);
+    exit(0);
+  }
 
-    // Initialize device
-    CubDebugExit(args.DeviceInit());
-    printf("\n");
+  // Initialize device
+  CubDebugExit(args.DeviceInit());
+  printf("\n");
 
-    // %PARAM% TEST_CDP cdp 0:1
+  // %PARAM% TEST_CDP cdp 0:1
 
-    // Test different input types
-    TestSize<signed char, int, int>(num_items);
-    TestSize<short, int, int>(num_items);
-    TestSize<int, int, int>(num_items);
-    TestSize<long, int, int>(num_items);
-    TestSize<long long, int, int>(num_items);
-    TestSize<float, int, int>(num_items);
-    TestSize<double, int, int>(num_items);
+  // Test different input types
+  TestSize<signed char, int, int>(num_items);
+  TestSize<short, int, int>(num_items);
+  TestSize<int, int, int>(num_items);
+  TestSize<long, int, int>(num_items);
+  TestSize<long long, int, int>(num_items);
+  TestSize<float, int, int>(num_items);
+  TestSize<double, int, int>(num_items);
 
-    TestSize<uchar2, int, int>(num_items);
-    TestSize<uint2, int, int>(num_items);
-    TestSize<uint3, int, int>(num_items);
-    TestSize<uint4, int, int>(num_items);
-    TestSize<ulonglong4, int, int>(num_items);
-    TestSize<TestFoo, int, int>(num_items);
-    TestSize<TestBar, int, int>(num_items);
+  TestSize<uchar2, int, int>(num_items);
+  TestSize<uint2, int, int>(num_items);
+  TestSize<uint3, int, int>(num_items);
+  TestSize<uint4, int, int>(num_items);
+  TestSize<ulonglong4, int, int>(num_items);
+  TestSize<TestFoo, int, int>(num_items);
+  TestSize<TestBar, int, int>(num_items);
 
-    return 0;
+  return 0;
 }
-
-
-


### PR DESCRIPTION
This is a suggestion to fix #596.

## Situation

The root cause is in `cub/agent/agent_reduce_by_key.cuh`, where, for the very first tile of items, we're using `keys[0]` as the `tile_predecessor` that is later fed into the `BlockDiscontinuity`:

```
tile_predecessor = (tile_idx == 0) ? keys[0] : d_keys_in[tile_offset - 1];

...
BlockDiscontinuityKeys(temp_storage.scan_storage.discontinuity)
        .FlagHeads(head_flags, keys, prev_keys, flag_op, tile_predecessor);
```

## Problem

Since `NaN == NaN` is false: if `keys[0]` is `NaN`, `BlockDiscontinuityKeys` evaluates `tile_predecessor == keys[0]` as false and will flag `keys[0]` as the beginning of a new run.

## Suggested Solution

After having run `BlockDiscontinuity`, we reset the flag on the very first item.
```
if (threadIdx.x == 0 && tile_idx == 0)
{
  scan_items[0].key = 0;
}
```

## Alternative fix

An alternative to fix this would be to invoke a different overload of `BlockDiscontinuityKeys` for the very first tile of items. That is, invoking `BlockDiscontinuityKeys` that does not take the `tile_predecessor`. However, this comes at the cost of increased kernel size, as we'll end up with four `BlockDiscontinuityKeys` instantiations instead of two. This is the part that would have to be changed:

```
    if (IS_LAST_TILE)
    {
      // Use custom flag operator to additionally flag the first out-of-bounds
      // item
      GuardedInequalityWrapper<EqualityOpT> flag_op(equality_op, num_remaining);
      BlockDiscontinuityKeys(temp_storage.scan_storage.discontinuity)
        .FlagHeads(head_flags, keys, prev_keys, flag_op, tile_predecessor);
    }
    else
    {
      InequalityWrapper<EqualityOpT> flag_op(equality_op);
      BlockDiscontinuityKeys(temp_storage.scan_storage.discontinuity)
        .FlagHeads(head_flags, keys, prev_keys, flag_op, tile_predecessor);
    }
```