### PR TITLE
Support __{u,}int128_t in radix sort

### DIFF
--- a/cub/util_ptx.cuh
+++ b/cub/util_ptx.cuh
@@ -138,6 +138,22 @@ __device__ __forceinline__ unsigned int BFE(
     return (source >> bit_start) & MASK;
 }
 
+#if CUB_IS_INT128_ENABLED 
+/**
+ * Bitfield-extract for 128-bit types.
+ */
+template <typename UnsignedBits>
+__device__ __forceinline__ unsigned int BFE(
+    UnsignedBits            source,
+    unsigned int            bit_start,
+    unsigned int            num_bits,
+    Int2Type<16>            /*byte_len*/)
+{
+    const __uint128_t MASK = (__uint128_t{1} << num_bits) - 1;
+    return (source >> bit_start) & MASK;
+}
+#endif
+
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /**

--- a/test/catch2_test_printing.cu
+++ b/test/catch2_test_printing.cu
@@ -1,0 +1,36 @@
+#include "test_util.h"
+
+#include "catch2_test_helper.h"
+
+template <typename T>
+std::string print(T val) 
+{
+  std::stringstream ss;
+  ss << val;
+  return ss.str();
+}
+
+#if CUB_IS_INT128_ENABLED
+TEST_CASE("Test utils can print __int128", "[test][utils]")
+{
+  REQUIRE( print(__int128_t{0}) == "0" );
+  REQUIRE( print(__int128_t{42}) == "42" );
+  REQUIRE( print(__int128_t{-1}) == "-1" );
+  REQUIRE( print(__int128_t{-42}) == "-42" );
+  REQUIRE( print(__int128_t{-1} << 120) == "-1329227995784915872903807060280344576" );
+}
+
+TEST_CASE("Test utils can print __uint128", "[test][utils]")
+{
+  REQUIRE( print(__uint128_t{0}) == "0" );
+  REQUIRE( print(__uint128_t{1}) == "1" );
+  REQUIRE( print(__uint128_t{42}) == "42" );
+  REQUIRE( print(__uint128_t{1} << 120) == "1329227995784915872903807060280344576" );
+}
+#endif
+
+TEST_CASE("Test utils can print KeyValuePair", "[test][utils]")
+{
+  REQUIRE( print(cub::KeyValuePair<int, int>{42, -42}) == "(42,-42)" );
+}
+

--- a/test/test_block_radix_rank.cu
+++ b/test/test_block_radix_rank.cu
@@ -159,9 +159,9 @@ void TestDriver(GenMode gen_mode)
   constexpr int tile_size = BlockThreads * ItemsPerThread;
 
   // Allocate host arrays
-  std::unique_ptr<Key> h_keys(new Key[tile_size]);
-  std::unique_ptr<int> h_ranks(new int[tile_size]);
-  std::unique_ptr<int> h_reference_ranks(new int[tile_size]);
+  std::unique_ptr<Key[]> h_keys(new Key[tile_size]);
+  std::unique_ptr<int[]> h_ranks(new int[tile_size]);
+  std::unique_ptr<int[]> h_reference_ranks(new int[tile_size]);
 
   // Allocate device arrays
   Key *d_keys  = nullptr;

--- a/test/test_device_batch_memcpy.cu
+++ b/test/test_device_batch_memcpy.cu
@@ -312,9 +312,9 @@ void RunTest(BufferOffsetT num_buffers,
   using RandomInitAliasT         = uint16_t;
   std::size_t num_aliased_factor = sizeof(RandomInitAliasT) / sizeof(uint8_t);
   std::size_t num_aliased_units  = CUB_QUOTIENT_CEILING(num_total_bytes, num_aliased_factor);
-  std::unique_ptr<uint8_t> h_in(new uint8_t[num_aliased_units * num_aliased_factor]);
-  std::unique_ptr<uint8_t> h_out(new uint8_t[num_total_bytes]);
-  std::unique_ptr<uint8_t> h_gpu_results(new uint8_t[num_total_bytes]);
+  std::unique_ptr<uint8_t[]> h_in(new uint8_t[num_aliased_units * num_aliased_factor]);
+  std::unique_ptr<uint8_t[]> h_out(new uint8_t[num_total_bytes]);
+  std::unique_ptr<uint8_t[]> h_gpu_results(new uint8_t[num_total_bytes]);
 
   // Generate random offsets into the random-bits data buffer
   GenerateRandomData(reinterpret_cast<RandomInitAliasT *>(h_in.get()), num_aliased_units);

--- a/test/test_device_radix_sort.cu
+++ b/test/test_device_radix_sort.cu
@@ -904,9 +904,15 @@ void InitializeSolution(
             // Mask off unwanted portions
             if (num_bits < static_cast<int>(sizeof(KeyT) * 8))
             {
+#if CUB_IS_INT128_ENABLED
+                __uint128_t base = 0;
+                memcpy(&base, &h_keys[i], sizeof(KeyT));
+                base &= ((__uint128_t{1} << num_bits) - 1) << begin_bit;
+#else 
                 unsigned long long base = 0;
                 memcpy(&base, &h_keys[i], sizeof(KeyT));
                 base &= ((1ull << num_bits) - 1) << begin_bit;
+#endif
                 memcpy(&h_pairs[i].key, &base, sizeof(KeyT));
             }
             else
@@ -1929,7 +1935,7 @@ int main(int argc, char** argv)
     CubDebugExit(args.DeviceInit());
 
     // %PARAM% TEST_CDP cdp 0:1
-    // %PARAM% TEST_KEY_BYTES bytes 1:2:4:8
+    // %PARAM% TEST_KEY_BYTES bytes 1:2:4:8:16
     // %PARAM% TEST_VALUE_TYPE pairs 0:1:2:3
     //   0->Keys only
     //   1->uchar
@@ -1994,6 +2000,13 @@ int main(int argc, char** argv)
     TestGen<long long, false>         (num_items, num_segments);
     TestGen<unsigned long long, false>(num_items, num_segments);
 #endif // TEST_EXTENDED_KEY_TYPES
+
+#elif TEST_KEY_BYTES == 16
+
+#if CUB_IS_INT128_ENABLED 
+    TestGen<__int128_t,  false>(num_items, num_segments);
+    TestGen<__uint128_t, false>(num_items, num_segments);
+#endif
 
 #endif // TEST_KEY_BYTES switch
 

--- a/test/test_device_radix_sort.cu
+++ b/test/test_device_radix_sort.cu
@@ -2006,6 +2006,9 @@ int main(int argc, char** argv)
 #if CUB_IS_INT128_ENABLED 
     TestGen<__int128_t,  false>(num_items, num_segments);
     TestGen<__uint128_t, false>(num_items, num_segments);
+#else
+    // Fix unused static function for MSVC
+    BackendToString(CUB);
 #endif
 
 #endif // TEST_KEY_BYTES switch

--- a/test/test_device_radix_sort.cu
+++ b/test/test_device_radix_sort.cu
@@ -904,15 +904,11 @@ void InitializeSolution(
             // Mask off unwanted portions
             if (num_bits < static_cast<int>(sizeof(KeyT) * 8))
             {
-#if CUB_IS_INT128_ENABLED
-                __uint128_t base = 0;
+                using UnsignedBits = typename cub::Traits<KeyT>::UnsignedBits;
+
+                UnsignedBits base = 0;
                 memcpy(&base, &h_keys[i], sizeof(KeyT));
-                base &= ((__uint128_t{1} << num_bits) - 1) << begin_bit;
-#else 
-                unsigned long long base = 0;
-                memcpy(&base, &h_keys[i], sizeof(KeyT));
-                base &= ((1ull << num_bits) - 1) << begin_bit;
-#endif
+                base &= ((UnsignedBits{1} << num_bits) - 1) << begin_bit;
                 memcpy(&h_pairs[i].key, &base, sizeof(KeyT));
             }
             else

--- a/test/test_util.h
+++ b/test/test_util.h
@@ -733,14 +733,14 @@ static std::ostream& operator<<(std::ostream& os, __uint128_t val)
 {
   constexpr int max_digits = 40;
   char buffer[max_digits] = {};
-  char* digit = buffer + max_digits - 1;
+  char* digit = buffer + max_digits;
   const char* ascii = "0123456789";
 
   do 
   {
+    digit--;
     *digit = ascii[val % 10];
     val /= 10;
-    digit--;
   }
   while(val != 0);
 

--- a/test/test_util.h
+++ b/test/test_util.h
@@ -728,6 +728,43 @@ std::ostream& operator<<(std::ostream& os, const CUB_NS_QUALIFIER::KeyValuePair<
     return os;
 }
 
+#if CUB_IS_INT128_ENABLED
+static std::ostream& operator<<(std::ostream& os, __uint128_t val)
+{
+  constexpr int max_digits = 40;
+  char buffer[max_digits] = {};
+  char* digit = buffer + max_digits - 1;
+  const char* ascii = "0123456789";
+
+  do 
+  {
+    *digit = ascii[val % 10];
+    val /= 10;
+    digit--;
+  }
+  while(val != 0);
+
+  for (; digit != buffer + max_digits; digit++) {
+    os << *digit;
+  }
+
+  return os;
+}
+
+static std::ostream& operator<<(std::ostream& os, __int128_t val)
+{
+  if (val < 0) {
+    __uint128_t tmp = -val;
+    os << '-' << tmp;
+  } else {
+    __uint128_t tmp = val;
+    os << tmp;
+  }
+
+  return os;
+}
+#endif
+
 
 /******************************************************************************
  * Comparison and ostream operators for CUDA vector types


### PR DESCRIPTION
This PR supports `__int128_t` and `__uint128_t` in block/device radix sort as well as block radix rank. It's partially answering the [question](https://github.com/NVIDIA/cub/issues/52) on 128 bit types support. Performance wise, `__int128_t` utilize BW similarly to 64 bit types. 