### PR TITLE
Fix warp scan exlusive sum for vector types

### DIFF
--- a/cub/warp/warp_scan.cuh
+++ b/cub/warp/warp_scan.cuh
@@ -347,7 +347,7 @@ public:
         T               input,              ///< [in] Calling thread's input item.
         T               &exclusive_output)  ///< [out] Calling thread's output item.  May be aliased with \p input.
     {
-        T initial_value = 0;
+        T initial_value {};
         ExclusiveScan(input, exclusive_output, initial_value, cub::Sum());
     }
 
@@ -393,7 +393,7 @@ public:
         T               &exclusive_output,  ///< [out] Calling thread's output item.  May be aliased with \p input.
         T               &warp_aggregate)    ///< [out] Warp-wide aggregate reduction of input items.
     {
-        T initial_value = 0;
+        T initial_value {};
         ExclusiveScan(input, exclusive_output, initial_value, cub::Sum(), warp_aggregate);
     }
 

--- a/test/test_warp_scan.cu
+++ b/test/test_warp_scan.cu
@@ -124,7 +124,8 @@ __device__ __forceinline__ void DeviceTest(
 /// Exclusive sum basic
 template <
     typename    WarpScanT,
-    typename    T>
+    typename    T,
+    typename    IsPrimitiveT>
 __device__ __forceinline__ void DeviceTest(
     WarpScanT                       &warp_scan,
     T                               &data,
@@ -132,7 +133,7 @@ __device__ __forceinline__ void DeviceTest(
     Sum                             &scan_op,
     T                               &aggregate,
     Int2Type<BASIC>                 test_mode,
-    Int2Type<true>                  is_primitive)
+    IsPrimitiveT                    is_primitive)
 {
     // Test basic warp scan
     warp_scan.ExclusiveSum(data, data);
@@ -142,7 +143,8 @@ __device__ __forceinline__ void DeviceTest(
 /// Exclusive sum aggregate
 template <
     typename    WarpScanT,
-    typename    T>
+    typename    T,
+    typename    IsPrimitiveT>
 __device__ __forceinline__ void DeviceTest(
     WarpScanT                       &warp_scan,
     T                               &data,
@@ -150,7 +152,7 @@ __device__ __forceinline__ void DeviceTest(
     Sum                             &scan_op,
     T                               &aggregate,
     Int2Type<AGGREGATE>             test_mode,
-    Int2Type<true>                  is_primitive)
+    IsPrimitiveT                    is_primitive)
 {
     // Test with cumulative aggregate
     warp_scan.ExclusiveSum(data, data, aggregate);


### PR DESCRIPTION
Fixes #610 