### PR TITLE
Avoid system thrust usage in tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -148,7 +148,6 @@ function(cub_add_test target_name_var test_name test_src cub_target)
     set(config_c2h_target ${config_prefix}.test.catch2_helper)
     if (NOT TARGET ${config_c2h_target})
       add_library(${config_c2h_target} STATIC c2h/generators.cu)
-      target_link_libraries(${config_c2h_target} PRIVATE CUDA::curand)
       set_property(TARGET ${config_c2h_target}
         PROPERTY POSITION_INDEPENDENT_CODE ON
       )
@@ -163,6 +162,7 @@ function(cub_add_test target_name_var test_name test_src cub_target)
       )
 
       cub_clone_target_properties(${config_c2h_target} ${cub_target})
+      target_link_libraries(${config_c2h_target} PRIVATE CUDA::curand ${cub_target})
     endif() # config_c2h_target
 
     if (CUB_SEPARATE_CATCH2)

--- a/test/c2h/generators.cu
+++ b/test/c2h/generators.cu
@@ -238,8 +238,8 @@ namespace detail
 
 void gen(seed_t seed,
          char* d_out,
-         custom_type_state_t min,
-         custom_type_state_t max,
+         custom_type_state_t /* min */, 
+         custom_type_state_t /* max */,
          std::size_t elements,
          std::size_t element_size)
 {


### PR DESCRIPTION
I've missed linking Catch2 helper with Thrust specified during CMake configuration step. This led to different Thrust version being used by generator and the tests. 