### PR TITLE
Fixes DeviceMemcpy::Batched for Pre-Volta Architectures

### DIFF
--- a/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/agent/agent_batch_memcpy.cuh
@@ -351,8 +351,9 @@ public:
     {
       // In case the bit-offset of the counter at <index> is larger than the bit range of the
       // current unit, the bit_shift amount will be larger than the bits provided by this unit. As
-      // C++'s bit-shift has undefined behaviour if the bits being shifted exceed the operand
-      // being bit-shifted, we use the PTX instruction `shr` to make sure behaviour is well-defined.
+      // C++'s bit-shift has undefined behaviour if the bits being shifted exceed the operand width, 
+      // we use the PTX instruction `shr` to make sure behaviour is well-defined.
+      // We catch negative bit-shift amounts in the ternary and set it to `NUM_BITS_PER_UNIT`
       const uint32_t bit_shift = ((i * USED_BITS_PER_UNIT) <= target_offset)
                                    ? (target_offset - i * USED_BITS_PER_UNIT)
                                    : NUM_BITS_PER_UNIT;
@@ -370,8 +371,9 @@ public:
     {
       // In case the bit-offset of the counter at <index> is larger than the bit range of the
       // current unit, the bit_shift amount will be larger than the bits provided by this unit. As
-      // C++'s bit-shift has undefined behaviour if the bits being shifted exceed the operand
-      // being bit-shifted, we use the PTX instruction `shl` to make sure behaviour is well-defined.
+      // C++'s bit-shift has undefined behaviour if the bits being shifted exceed the operand width, 
+      // we use the PTX instruction `shl` to make sure behaviour is well-defined.
+      // We catch negative bit-shift amounts in the ternary and set it to `NUM_BITS_PER_UNIT`
       const uint32_t bit_shift = ((i * USED_BITS_PER_UNIT) <= target_offset)
                                    ? (target_offset - i * USED_BITS_PER_UNIT)
                                    : NUM_BITS_PER_UNIT;

--- a/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/agent/agent_batch_memcpy.cuh
@@ -351,11 +351,11 @@ public:
     {
       // In case the bit-offset of the counter at <index> is larger than the bit range of the
       // current unit, the bit_shift amount will be larger than the bits provided by this unit. As
-      // C++'s bit-shift has undefined behaviour if the bits being shifted exceed the operand width, 
+      // C++'s bit-shift has undefined behaviour if the bits being shifted exceed the operand width,
       // we use the PTX instruction `shr` to make sure behaviour is well-defined.
       // Negative bit-shift amounts wrap around in unsigned integer math and are ultimately clamped.
       const uint32_t bit_shift = target_offset - i * USED_BITS_PER_UNIT;
-      val |= LogicShiftRight(data[i], bit_shift) & ITEM_MASK;
+      val |= detail::LogicShiftRight(data[i], bit_shift) & ITEM_MASK;
     }
     return val;
   }
@@ -369,11 +369,11 @@ public:
     {
       // In case the bit-offset of the counter at <index> is larger than the bit range of the
       // current unit, the bit_shift amount will be larger than the bits provided by this unit. As
-      // C++'s bit-shift has undefined behaviour if the bits being shifted exceed the operand width, 
+      // C++'s bit-shift has undefined behaviour if the bits being shifted exceed the operand width,
       // we use the PTX instruction `shl` to make sure behaviour is well-defined.
       // Negative bit-shift amounts wrap around in unsigned integer math and are ultimately clamped.
       const uint32_t bit_shift = target_offset - i * USED_BITS_PER_UNIT;
-      data[i] += LogicShiftLeft(value, bit_shift) & UNIT_MASK;
+      data[i] += detail::LogicShiftLeft(value, bit_shift) & UNIT_MASK;
     }
   }
 

--- a/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/agent/agent_batch_memcpy.cuh
@@ -353,10 +353,8 @@ public:
       // current unit, the bit_shift amount will be larger than the bits provided by this unit. As
       // C++'s bit-shift has undefined behaviour if the bits being shifted exceed the operand width, 
       // we use the PTX instruction `shr` to make sure behaviour is well-defined.
-      // We catch negative bit-shift amounts in the ternary and set it to `NUM_BITS_PER_UNIT`
-      const uint32_t bit_shift = ((i * USED_BITS_PER_UNIT) <= target_offset)
-                                   ? (target_offset - i * USED_BITS_PER_UNIT)
-                                   : NUM_BITS_PER_UNIT;
+      // Negative bit-shift amounts wrap around in unsigned integer math and are ultimately clamped.
+      const uint32_t bit_shift = target_offset - i * USED_BITS_PER_UNIT;
       val |= LogicShiftRight(data[i], bit_shift) & ITEM_MASK;
     }
     return val;
@@ -373,10 +371,8 @@ public:
       // current unit, the bit_shift amount will be larger than the bits provided by this unit. As
       // C++'s bit-shift has undefined behaviour if the bits being shifted exceed the operand width, 
       // we use the PTX instruction `shl` to make sure behaviour is well-defined.
-      // We catch negative bit-shift amounts in the ternary and set it to `NUM_BITS_PER_UNIT`
-      const uint32_t bit_shift = ((i * USED_BITS_PER_UNIT) <= target_offset)
-                                   ? (target_offset - i * USED_BITS_PER_UNIT)
-                                   : NUM_BITS_PER_UNIT;
+      // Negative bit-shift amounts wrap around in unsigned integer math and are ultimately clamped.
+      const uint32_t bit_shift = target_offset - i * USED_BITS_PER_UNIT;
       data[i] += LogicShiftLeft(value, bit_shift) & UNIT_MASK;
     }
   }

--- a/cub/agent/agent_batch_memcpy.cuh
+++ b/cub/agent/agent_batch_memcpy.cuh
@@ -343,37 +343,39 @@ private:
 public:
   __device__ __forceinline__ uint32_t Get(uint32_t index) const
   {
-    const int32_t target_offset = index * BITS_PER_ITEM;
-    uint32_t val                = 0;
+    const uint32_t target_offset = index * BITS_PER_ITEM;
+    uint32_t val                 = 0;
 
 #pragma unroll
     for (uint32_t i = 0; i < NUM_TOTAL_UNITS; ++i)
     {
       // In case the bit-offset of the counter at <index> is larger than the bit range of the
-      // current unit, the bit_shift amount will be larger than the bits provided by this unit. If
-      // the bit-offset of the counter at <index> is smaller than the bit range of the current unit,
-      // the computed bit-offset will be negative, which, once casted to an unsigned type will be
-      // larger than the bits provided by this unit.
-      const uint32_t bit_shift = static_cast<uint32_t>(target_offset - i * USED_BITS_PER_UNIT);
-      val |= (data[i] >> bit_shift) & ITEM_MASK;
+      // current unit, the bit_shift amount will be larger than the bits provided by this unit. As
+      // C++'s bit-shift has undefined behaviour if the bits being shifted exceed the operand
+      // being bit-shifted, we use the PTX instruction `shr` to make sure behaviour is well-defined.
+      const uint32_t bit_shift = ((i * USED_BITS_PER_UNIT) <= target_offset)
+                                   ? (target_offset - i * USED_BITS_PER_UNIT)
+                                   : NUM_BITS_PER_UNIT;
+      val |= LogicShiftRight(data[i], bit_shift) & ITEM_MASK;
     }
     return val;
   }
 
   __device__ __forceinline__ void Add(uint32_t index, uint32_t value)
   {
-    const int32_t target_offset = index * BITS_PER_ITEM;
+    const uint32_t target_offset = index * BITS_PER_ITEM;
 
 #pragma unroll
     for (uint32_t i = 0; i < NUM_TOTAL_UNITS; ++i)
     {
       // In case the bit-offset of the counter at <index> is larger than the bit range of the
-      // current unit, the bit_shift amount will be larger than the bits provided by this unit. If
-      // the bit-offset of the counter at <index> is smaller than the bit range of the current unit,
-      // the computed bit-offset will be negative, which, once casted to an unsigned type will be
-      // larger than the bits provided by this unit.
-      const uint32_t bit_shift = static_cast<uint32_t>(target_offset - i * USED_BITS_PER_UNIT);
-      data[i] += (value << bit_shift) & UNIT_MASK;
+      // current unit, the bit_shift amount will be larger than the bits provided by this unit. As
+      // C++'s bit-shift has undefined behaviour if the bits being shifted exceed the operand
+      // being bit-shifted, we use the PTX instruction `shl` to make sure behaviour is well-defined.
+      const uint32_t bit_shift = ((i * USED_BITS_PER_UNIT) <= target_offset)
+                                   ? (target_offset - i * USED_BITS_PER_UNIT)
+                                   : NUM_BITS_PER_UNIT;
+      data[i] += LogicShiftLeft(value, bit_shift) & UNIT_MASK;
     }
   }
 

--- a/cub/util_ptx.cuh
+++ b/cub/util_ptx.cuh
@@ -78,6 +78,28 @@ CUB_NAMESPACE_BEGIN
  ******************************************************************************/
 
 /**
+ * @brief Shifts \p val left by the amount specified by unsigned 32-bit value in \p num_bits. If \p
+ * num_bits is larger than 32 bits, \p num_bits is clamped to 32.
+ */
+__device__ __forceinline__ uint32_t LogicShiftLeft(uint32_t val, uint32_t num_bits)
+{
+  uint32_t ret{};
+  asm("shl.b32 %0, %1, %2;" : "=r"(ret) : "r"(val), "r"(num_bits));
+  return ret;
+}
+
+/**
+ * @brief Shifts \p val right by the amount specified by unsigned 32-bit value in \p num_bits. If \p
+ * num_bits is larger than 32 bits, \p num_bits is clamped to 32.
+ */
+__device__ __forceinline__ uint32_t LogicShiftRight(uint32_t val, unsigned int num_bits)
+{
+  uint32_t ret{};
+  asm("shr.b32 %0, %1, %2;" : "=r"(ret) : "r"(val), "r"(num_bits));
+  return ret;
+}
+
+/**
  * \brief Shift-right then add.  Returns (\p x >> \p shift) + \p addend.
  */
 __device__ __forceinline__ unsigned int SHR_ADD(

--- a/cub/util_ptx.cuh
+++ b/cub/util_ptx.cuh
@@ -78,8 +78,8 @@ CUB_NAMESPACE_BEGIN
  ******************************************************************************/
 
 /**
- * @brief Shifts \p val left by the amount specified by unsigned 32-bit value in \p num_bits. If \p
- * num_bits is larger than 32 bits, \p num_bits is clamped to 32.
+ * @brief Shifts @p val left by the amount specified by unsigned 32-bit value in @p num_bits. If @p
+ * num_bits is larger than 32 bits, @p num_bits is clamped to 32.
  */
 __device__ __forceinline__ uint32_t LogicShiftLeft(uint32_t val, uint32_t num_bits)
 {
@@ -89,10 +89,10 @@ __device__ __forceinline__ uint32_t LogicShiftLeft(uint32_t val, uint32_t num_bi
 }
 
 /**
- * @brief Shifts \p val right by the amount specified by unsigned 32-bit value in \p num_bits. If \p
- * num_bits is larger than 32 bits, \p num_bits is clamped to 32.
+ * @brief Shifts @p val right by the amount specified by unsigned 32-bit value in @p num_bits. If @p
+ * num_bits is larger than 32 bits, @p num_bits is clamped to 32.
  */
-__device__ __forceinline__ uint32_t LogicShiftRight(uint32_t val, unsigned int num_bits)
+__device__ __forceinline__ uint32_t LogicShiftRight(uint32_t val, uint32_t num_bits)
 {
   uint32_t ret{};
   asm("shr.b32 %0, %1, %2;" : "=r"(ret) : "r"(val), "r"(num_bits));

--- a/cub/util_ptx.cuh
+++ b/cub/util_ptx.cuh
@@ -77,6 +77,8 @@ CUB_NAMESPACE_BEGIN
  * Inlined PTX intrinsics
  ******************************************************************************/
 
+namespace detail
+{
 /**
  * @brief Shifts @p val left by the amount specified by unsigned 32-bit value in @p num_bits. If @p
  * num_bits is larger than 32 bits, @p num_bits is clamped to 32.
@@ -98,6 +100,7 @@ __device__ __forceinline__ uint32_t LogicShiftRight(uint32_t val, uint32_t num_b
   asm("shr.b32 %0, %1, %2;" : "=r"(ret) : "r"(val), "r"(num_bits));
   return ret;
 }
+} // namespace detail
 
 /**
  * \brief Shift-right then add.  Returns (\p x >> \p shift) + \p addend.

--- a/test/test_device_batch_memcpy.cu
+++ b/test/test_device_batch_memcpy.cu
@@ -79,9 +79,10 @@ void __global__ BaselineBatchMemCpyKernel(InputBufferIt input_buffer_it,
                                           BufferOffsetT num_buffers)
 {
   BufferOffsetT gtid = blockDim.x * blockIdx.x + threadIdx.x;
-  if (gtid >= num_buffers) {
+  if (gtid >= num_buffers)
+  {
     return;
-}
+  }
   for (BufferOffsetT i = 0; i < buffer_sizes[gtid]; i++)
   {
     reinterpret_cast<uint8_t *>(output_buffer_it[gtid])[i] =
@@ -113,9 +114,10 @@ void __global__ BaselineBatchMemCpyPerBlockKernel(InputBufferIt input_buffer_it,
                                                   BufferOffsetT num_buffers)
 {
   BufferOffsetT gbid = blockIdx.x;
-  if (gbid >= num_buffers) {
+  if (gbid >= num_buffers)
+  {
     return;
-}
+  }
   for (BufferOffsetT i = threadIdx.x; i < buffer_sizes[gbid] / 8; i += blockDim.x)
   {
     reinterpret_cast<uint64_t *>(output_buffer_it[gbid])[i] =
@@ -580,6 +582,9 @@ void TestBitPackedCounter(const std::uint_fast32_t seed = 320981U)
   // Memory for GPU-generated results
   thrust::host_vector<uint32_t> device_counts(num_increments);
 
+  // Reset counters to arbitrary random value
+  thrust::fill(device_counts.begin(), device_counts.end(), 814920U);
+
   // Run tests with densely bit-packed counters
   TestBitPackedCounterKernel<NUM_ITEMS, MAX_ITEM_VALUE, false>
     <<<1, 1>>>(thrust::raw_pointer_cast(bins_in.data()),
@@ -593,6 +598,9 @@ void TestBitPackedCounter(const std::uint_fast32_t seed = 320981U)
   {
     AssertEquals(counters[i], device_counts[i]);
   }
+
+  // Reset counters to arbitrary random value
+  thrust::fill(device_counts.begin(), device_counts.end(), 814920U);
 
   // Run tests with bit-packed counters, where bit-count is a power-of-two
   TestBitPackedCounterKernel<NUM_ITEMS, MAX_ITEM_VALUE, true>

--- a/test/test_device_batch_memcpy.cu
+++ b/test/test_device_batch_memcpy.cu
@@ -538,8 +538,8 @@ void TestBitPackedCounter(const std::uint_fast32_t seed = 320981U)
 
   // Test input data
   std::array<uint64_t, NUM_ITEMS> reference_counters{};
-  thrust::host_vector h_bins(num_increments);
-  thrust::host_vector h_increments(num_increments);
+  thrust::host_vector<uint32_t> h_bins(num_increments);
+  thrust::host_vector<uint32_t> h_increments(num_increments);
 
   // Generate random test input data
   GenerateRandomData(thrust::raw_pointer_cast(h_bins.data()),
@@ -577,10 +577,10 @@ void TestBitPackedCounter(const std::uint_fast32_t seed = 320981U)
   increments_in = h_increments;
 
   // Memory for GPU-generated results
-  thrust::host_vector<uint32_t> device_counts(num_increments);
+  thrust::host_vector<uint32_t> host_counts(num_increments);
 
   // Reset counters to arbitrary random value
-  thrust::fill(device_counts.begin(), device_counts.end(), 814920U);
+  thrust::fill(counts_out.begin(), counts_out.end(), 814920U);
 
   // Run tests with densely bit-packed counters
   TestBitPackedCounterKernel<NUM_ITEMS, MAX_ITEM_VALUE, false>
@@ -597,7 +597,7 @@ void TestBitPackedCounter(const std::uint_fast32_t seed = 320981U)
   }
 
   // Reset counters to arbitrary random value
-  thrust::fill(host_counts.begin(), host_counts.end(), 814920U);
+  thrust::fill(counts_out.begin(), counts_out.end(), 814920U);
 
   // Run tests with bit-packed counters, where bit-count is a power-of-two
   TestBitPackedCounterKernel<NUM_ITEMS, MAX_ITEM_VALUE, true>


### PR DESCRIPTION
This PR fixes an issue that exists in `DeviceMemcpy::Batched` for pre-Volta architectures. The root cause of this issue is the `BitPackedCounter` component, which previously exhibited undefined behaviour when its counters were backed by more than a single `uint32` data member. 

For pre-Volta architectures, we are allocating a power of two number of bits for each counter (specifically, 16 bits to store values `[0, 512]`). Since we needed three counters (each 16 bits), we needed two `uint32` data members, which lead to UB. 

This PR also adds test for the `BitPackedCounter` class.