### PR TITLE
CDP abstraction for CUB tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -167,6 +167,10 @@ function(cub_add_test target_name_var test_name test_src cub_target)
       if (CUB_IN_THRUST)
         thrust_fix_clang_nvcc_build_for(${config_c2h_target})
       endif()
+
+      if (CUB_ENABLE_TESTS_WITH_RDC)
+        cub_enable_rdc_for_cuda_target(${config_c2h_target})
+      endif()
     endif() # config_c2h_target
 
     if (CUB_SEPARATE_CATCH2)

--- a/test/c2h/generators.cu
+++ b/test/c2h/generators.cu
@@ -167,11 +167,11 @@ struct random_to_custom_t
 
     if (SetKeys)
     {
-      out[idx].set_key(in);
+      out->set_key(in);
     }
     else 
     {
-      out[idx].set_val(in);
+      out->set_val(in);
     }
   }
 
@@ -303,6 +303,7 @@ void gen<TYPE>( \
   INSTANTIATE_RND(TYPE); \
   INSTANTIATE_MOD(TYPE)
 
+INSTANTIATE(char);
 INSTANTIATE(std::uint8_t);
 INSTANTIATE(std::uint16_t);
 INSTANTIATE(std::uint32_t);

--- a/test/c2h/generators.cu
+++ b/test/c2h/generators.cu
@@ -303,7 +303,6 @@ void gen<TYPE>( \
   INSTANTIATE_RND(TYPE); \
   INSTANTIATE_MOD(TYPE)
 
-INSTANTIATE(char);
 INSTANTIATE(std::uint8_t);
 INSTANTIATE(std::uint16_t);
 INSTANTIATE(std::uint32_t);

--- a/test/catch2_test_cdp_helper.h
+++ b/test/catch2_test_cdp_helper.h
@@ -1,0 +1,156 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include <thrust/device_vector.h>
+#include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
+
+#include "catch2_test_helper.h"
+
+//! @file This file contains utilities for device-scope API tests
+//!
+//! Device-scope API in CUB can be launched from the host or device side.
+//! Utilities in this file facilitate testing in both cases.
+//!
+//!
+//! ```
+//! // Add PARAM to make CMake generate a test for both host and device launch:
+//! // %PARAM% TEST_CDP cdp 0:1
+//!
+//! // Declare CDP wrapper for CUB API. The wrapper will accept the same
+//! // arguments as the CUB API. The wrapper name is provided as the second argument.
+//! DECLARE_CDP_WRAPPER(cub::DeviceReduce::Sum, cub_reduce_sum);
+//!
+//! CUB_TEST("Reduce test", "[device][reduce]")
+//! {
+//!   // ...
+//!   // Invoke the wrapper from the test. It'll allocate temporary storage and
+//!   // invoke the CUB API on the host or device side while checking return
+//!   // codes and launch errors.
+//!   cub_reduce_sum(d_in, d_out, n, should_be_invoked_on_device);
+//! }
+//!
+//! ```
+//!
+//! Consult with `test/catch2_test_cdp_wrapper.cu` for more usage examples.
+
+#if !defined(TEST_CDP)
+#error Test file should contain %PARAM% TEST_CDP cdp 0:1
+#endif
+
+#define DECLARE_CDP_INVOCABLE(API, WRAPPED_API_NAME)                                               \
+  namespace                                                                                        \
+  {                                                                                                \
+  struct WRAPPED_API_NAME##_invocable_t                                                            \
+  {                                                                                                \
+    template <class... Ts>                                                                         \
+    CUB_RUNTIME_FUNCTION cudaError_t operator()(std::uint8_t *d_temp_storage,                      \
+                                                std::size_t &temp_storage_bytes,                   \
+                                                Ts... args)                                        \
+    {                                                                                              \
+      return API(d_temp_storage, temp_storage_bytes, args...);                                     \
+    }                                                                                              \
+  };                                                                                               \
+  }
+
+#if TEST_CDP == 1
+template <class ActionT, class... Args>
+__global__ void device_side_api_launch_kernel(std::uint8_t *d_temp_storage,
+                                              std::size_t *temp_storage_bytes,
+                                              cudaError_t *d_error,
+                                              ActionT action,
+                                              Args... args)
+{
+  *d_error = action(d_temp_storage, *temp_storage_bytes, args...);
+}
+
+template <class ActionT, class... Args>
+void device_side_api_launch(ActionT action, Args... args)
+{
+  std::uint8_t *d_temp_storage = nullptr;
+  thrust::device_vector<cudaError_t> d_error(1, cudaErrorInvalidValue);
+  thrust::device_vector<std::size_t> d_temp_storage_bytes(1, 0);
+  device_side_api_launch_kernel<<<1, 1>>>(d_temp_storage,
+                                          thrust::raw_pointer_cast(d_temp_storage_bytes.data()),
+                                          thrust::raw_pointer_cast(d_error.data()),
+                                          action,
+                                          args...);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE(cudaSuccess == d_error[0]);
+
+  thrust::device_vector<std::uint8_t> temp_storage(d_temp_storage_bytes[0]);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  device_side_api_launch_kernel<<<1, 1>>>(d_temp_storage,
+                                          thrust::raw_pointer_cast(d_temp_storage_bytes.data()),
+                                          thrust::raw_pointer_cast(d_error.data()),
+                                          action,
+                                          args...);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE(cudaSuccess == d_error[0]);
+}
+
+#define cdp_launch device_side_api_launch
+
+#else
+
+template <class ActionT, class... Args>
+void host_side_api_launch(ActionT action, Args... args)
+{
+  std::uint8_t *d_temp_storage = nullptr;
+  std::size_t temp_storage_bytes{};
+  cudaError_t error = action(d_temp_storage, temp_storage_bytes, args...);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE(cudaSuccess == error);
+
+  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  error = action(d_temp_storage, temp_storage_bytes, args...);
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+  REQUIRE(cudaSuccess == error);
+}
+
+#define cdp_launch host_side_api_launch
+
+#endif
+
+#define DECLARE_CDP_WRAPPER(API, WRAPPED_API_NAME)                                                 \
+  DECLARE_CDP_INVOCABLE(API, WRAPPED_API_NAME);                                                    \
+  namespace                                                                                        \
+  {                                                                                                \
+  template <class... As>                                                                           \
+  void WRAPPED_API_NAME(As... args)                                                                \
+  {                                                                                                \
+    cdp_launch(WRAPPED_API_NAME##_invocable_t{}, args...);                                         \
+  }                                                                                                \
+  }

--- a/test/catch2_test_cdp_wrapper.cu
+++ b/test/catch2_test_cdp_wrapper.cu
@@ -1,0 +1,229 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include <thrust/count.h>
+
+#include <cuda/std/tuple>
+
+// Has to go after all cub headers. Otherwise, this test won't catch unused
+// variables in cub kernels.
+#include "catch2_test_cdp_helper.h"
+#include "catch2_test_helper.h"
+
+// %PARAM% TEST_CDP cdp 0:1
+
+template <class T>
+__global__ void cub_api_example_x2_0_kernel(const T *d_in, T *d_out, int num_items)
+{
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (i < num_items)
+  {
+    d_out[i] = d_in[i] * T{2};
+  }
+}
+
+template <class T>
+__global__ void cub_api_example_x0_5_kernel(const T *d_in, T *d_out, int num_items)
+{
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (i < num_items)
+  {
+    d_out[i] = d_in[i] / T{2};
+  }
+}
+
+struct cub_api_example_t
+{
+  static constexpr int threads_in_block = 256;
+
+  template <class T, class KernelT>
+  CUB_RUNTIME_FUNCTION static cudaError_t invoke(std::uint8_t *d_temp_storage,
+                                                 std::size_t &temp_storage_bytes,
+                                                 KernelT kernel,
+                                                 const T *d_in,
+                                                 T *d_out,
+                                                 int num_items,
+                                                 bool should_be_invoked_on_device)
+  {
+    NV_IF_TARGET(NV_IS_HOST,
+                 (if (should_be_invoked_on_device) { return cudaErrorLaunchFailure; }),
+                 (if (!should_be_invoked_on_device) { return cudaErrorLaunchFailure; }));
+
+    if (d_temp_storage == nullptr)
+    {
+      temp_storage_bytes = static_cast<std::size_t>(num_items);
+      return cudaSuccess;
+    }
+
+    if (temp_storage_bytes != static_cast<std::size_t>(num_items))
+    {
+      return cudaErrorInvalidValue;
+    }
+
+    const int blocks_in_grid = (num_items + threads_in_block - 1) / threads_in_block;
+
+    return thrust::cuda_cub::launcher::triple_chevron(blocks_in_grid, threads_in_block, 0, 0)
+      .doit(kernel, d_in, d_out, num_items);
+  }
+
+  template <class T>
+  CUB_RUNTIME_FUNCTION static cudaError_t x2_0(std::uint8_t *d_temp_storage,
+                                               std::size_t &temp_storage_bytes,
+                                               const T *d_in,
+                                               T *d_out,
+                                               int num_items,
+                                               bool should_be_invoked_on_device)
+  {
+    return invoke(d_temp_storage,
+                  temp_storage_bytes,
+                  cub_api_example_x2_0_kernel<T>,
+                  d_in,
+                  d_out,
+                  num_items,
+                  should_be_invoked_on_device);
+  }
+
+  template <class T>
+  CUB_RUNTIME_FUNCTION static cudaError_t x0_5(std::uint8_t *d_temp_storage,
+                                               std::size_t &temp_storage_bytes,
+                                               const T *d_in,
+                                               T *d_out,
+                                               int num_items,
+                                               bool should_be_invoked_on_device)
+  {
+    return invoke(d_temp_storage,
+                  temp_storage_bytes,
+                  cub_api_example_x0_5_kernel<T>,
+                  d_in,
+                  d_out,
+                  num_items,
+                  should_be_invoked_on_device);
+  }
+};
+
+DECLARE_CDP_WRAPPER(cub_api_example_t::x2_0, x2_0);
+DECLARE_CDP_WRAPPER(cub_api_example_t::x0_5, x0_5);
+
+CUB_TEST("CDP wrapper works with predefined invocables", "[test][utils]")
+{
+  int n = 42;
+  thrust::device_vector<int> in(n, 21);
+  thrust::device_vector<int> out(n);
+
+  int *d_in  = thrust::raw_pointer_cast(in.data());
+  int *d_out = thrust::raw_pointer_cast(out.data());
+
+  constexpr bool should_be_invoked_on_device = TEST_CDP;
+
+  {
+    x2_0(d_in, d_out, n, should_be_invoked_on_device);
+
+    const auto actual   = static_cast<std::size_t>(thrust::count(out.begin(), out.end(), 42));
+    const auto expected = static_cast<std::size_t>(n);
+
+    REQUIRE(actual == expected);
+  }
+
+  {
+    x0_5(d_out, d_out, n, should_be_invoked_on_device);
+
+    const auto actual   = static_cast<std::size_t>(thrust::count(out.begin(), out.end(), 21));
+    const auto expected = static_cast<std::size_t>(n);
+
+    REQUIRE(actual == expected);
+  }
+}
+
+struct custom_x2_0_invocable
+{
+  template <class T>
+  CUB_RUNTIME_FUNCTION cudaError_t operator()(std::uint8_t *d_temp_storage,
+                                              std::size_t &temp_storage_bytes,
+                                              const T *d_in,
+                                              T *d_out,
+                                              int num_items,
+                                              bool should_be_invoked_on_device)
+  {
+    return cub_api_example_t::x2_0(d_temp_storage,
+                                   temp_storage_bytes,
+                                   d_in,
+                                   d_out,
+                                   num_items,
+                                   should_be_invoked_on_device);
+  }
+};
+
+struct custom_x0_5_invocable
+{
+  template <class T>
+  CUB_RUNTIME_FUNCTION cudaError_t operator()(std::uint8_t *d_temp_storage,
+                                              std::size_t &temp_storage_bytes,
+                                              const T *d_in,
+                                              T *d_out,
+                                              int num_items,
+                                              bool should_be_invoked_on_device)
+  {
+    return cub_api_example_t::x0_5(d_temp_storage,
+                                   temp_storage_bytes,
+                                   d_in,
+                                   d_out,
+                                   num_items,
+                                   should_be_invoked_on_device);
+  }
+};
+
+CUB_TEST("CDP wrapper works with custom invocables", "[test][utils]")
+{
+  int n = 42;
+  thrust::device_vector<int> in(n, 21);
+  thrust::device_vector<int> out(n);
+
+  int *d_in  = thrust::raw_pointer_cast(in.data());
+  int *d_out = thrust::raw_pointer_cast(out.data());
+
+  constexpr bool should_be_invoked_on_device = TEST_CDP;
+
+  {
+    cdp_launch(custom_x2_0_invocable{}, d_in, d_out, n, should_be_invoked_on_device);
+
+    const auto actual   = static_cast<std::size_t>(thrust::count(out.begin(), out.end(), 42));
+    const auto expected = static_cast<std::size_t>(n);
+
+    REQUIRE(actual == expected);
+  }
+
+  {
+    cdp_launch(custom_x0_5_invocable{}, d_out, d_out, n, should_be_invoked_on_device);
+
+    const auto actual   = static_cast<std::size_t>(thrust::count(out.begin(), out.end(), 21));
+    const auto expected = static_cast<std::size_t>(n);
+
+    REQUIRE(actual == expected);
+  }
+}


### PR DESCRIPTION
This PR provides CDP wrappers that can ease porting device-scope API tests to Catch2. These wrappers allow us not to reimplement CDP dispatch logic in every test. PR also contains a fix for custom types data generator. 