### PR TITLE
Deprecate cub::mutex and fix remaining narrowing conversions in tests

### DIFF
--- a/cub/host/mutex.cuh
+++ b/cub/host/mutex.cuh
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Copyright (c) 2011, Duane Merrill.  All rights reserved.
- * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -31,45 +31,24 @@
  * Simple portable mutex
  */
 
-#include "../util_cpp_dialect.cuh"
-
 #pragma once
 
-#if CUB_CPP_DIALECT >= 2011
-    #include <mutex>
-#else
-    #if defined(_WIN32) || defined(_WIN64)
-        #include <intrin.h>
+#include <mutex>
 
-        #define WIN32_LEAN_AND_MEAN
-        #define NOMINMAX
-        #include <windows.h>
-        #undef WIN32_LEAN_AND_MEAN
-        #undef NOMINMAX
-
-        /**
-         * Compiler read/write barrier
-         */
-        #pragma intrinsic(_ReadWriteBarrier)
-
-    #endif
-#endif
-
-#include "../config.cuh"
+#include <cub/config.cuh>
+#include <cub/util_deprecated.cuh>
 
 
 CUB_NAMESPACE_BEGIN
 
 
 /**
- * Simple portable mutex
- *   - Wraps std::mutex when compiled with C++11 or newer (supported on all platforms)
- *   - Uses GNU/Windows spinlock mechanisms for pre C++11 (supported on x86/x64 when compiled with cl.exe or g++)
+ * Wraps std::mutex 
+ * @deprecated [Since CUB 2.1.0] The `cub::Mutex` is deprecated and will be removed 
+ *             in a future release. Use `std::mutex` instead.
  */
-struct Mutex
+struct CUB_DEPRECATED Mutex
 {
-#if CUB_CPP_DIALECT >= 2011
-
     std::mutex mtx;
 
     void Lock()
@@ -81,82 +60,7 @@ struct Mutex
     {
         mtx.unlock();
     }
-
-#else       // C++11
-
-    #if CUB_HOST_COMPILER == CUB_HOST_COMPILER_MSVC
-
-        // Microsoft VC++
-        typedef long Spinlock;
-
-    #else
-
-        // GNU g++
-        typedef int Spinlock;
-
-        /**
-         * Compiler read/write barrier
-         */
-        __forceinline__ void _ReadWriteBarrier()
-        {
-            __sync_synchronize();
-        }
-
-        /**
-         * Atomic exchange
-         */
-        __forceinline__ long _InterlockedExchange(volatile int * const Target, const int Value)
-        {
-            // NOTE: __sync_lock_test_and_set would be an acquire barrier, so we force a full barrier
-            _ReadWriteBarrier();
-            return __sync_lock_test_and_set(Target, Value);
-        }
-
-        /**
-         * Pause instruction to prevent excess processor bus usage
-         */
-        __forceinline__ void YieldProcessor()
-        {
-        }
-
-    #endif  // MSVC
-
-        /// Lock member
-        volatile Spinlock lock;
-
-        /**
-         * Constructor
-         */
-        Mutex() : lock(0) {}
-
-        /**
-         * Return when the specified spinlock has been acquired
-         */
-        __forceinline__ void Lock()
-        {
-            while (1)
-            {
-                if (!_InterlockedExchange(&lock, 1)) return;
-                while (lock) YieldProcessor();
-            }
-        }
-
-
-        /**
-         * Release the specified spinlock
-         */
-        __forceinline__ void Unlock()
-        {
-            _ReadWriteBarrier();
-            lock = 0;
-        }
-
-#endif      // C++11
-
 };
 
 
-
-
 CUB_NAMESPACE_END
-

--- a/test/test_device_scan.cu
+++ b/test/test_device_scan.cu
@@ -1257,12 +1257,15 @@ int main(int argc, char** argv)
 
     TestSize<TestFoo>(num_items,
                       TestFoo::MakeTestFoo(0, 0, 0, 0),
-                      TestFoo::MakeTestFoo(1ll << 63,
-                                           1 << 31,
-                                           static_cast<short>(1 << 15),
-                                           static_cast<char>(1 << 7)));
+                      TestFoo::MakeTestFoo(std::numeric_limits<TestFoo::x_t>::max(),
+                                           std::numeric_limits<TestFoo::y_t>::max(),
+                                           std::numeric_limits<TestFoo::z_t>::max(),
+                                           std::numeric_limits<TestFoo::w_t>::max()));
 
-    TestSize<TestBar>(num_items, TestBar(0, 0), TestBar(1ll << 63, 1 << 31));
+    TestSize<TestBar>(num_items, 
+                      TestBar(0, 0), 
+                      TestBar(std::numeric_limits<long long>::max(), 
+                              std::numeric_limits<int>::max()));
 
     TestAccumulatorTypes();
 #endif

--- a/test/test_device_scan_by_key.cu
+++ b/test/test_device_scan_by_key.cu
@@ -44,6 +44,7 @@
 #include "test_util.h"
 
 #include <cstdio>
+#include <limits>
 #include <typeinfo>
 
 using namespace cub;
@@ -1082,17 +1083,17 @@ int main(int argc, char** argv)
 
     TestSize<TestFoo>(num_items,
                       TestFoo::MakeTestFoo(0, 0, 0, 0),
-                      TestFoo::MakeTestFoo(1ll << 63,
-                                           1 << 31,
-                                           static_cast<short>(1 << 15),
-                                           static_cast<char>(1 << 7)));
+                      TestFoo::MakeTestFoo(std::numeric_limits<TestFoo::x_t>::max(),
+                                           std::numeric_limits<TestFoo::y_t>::max(),
+                                           std::numeric_limits<TestFoo::z_t>::max(),
+                                           std::numeric_limits<TestFoo::w_t>::max()));
 
-    TestSize<TestBar>(num_items, TestBar(0, 0), TestBar(1ll << 63, 1 << 31));
+    TestSize<TestBar>(num_items, 
+                      TestBar(0, 0), 
+                      TestBar(std::numeric_limits<long long>::max(), 
+                              std::numeric_limits<int>::max()));
 
 #endif
 
     return 0;
 }
-
-
-

--- a/test/test_device_spmv.cu
+++ b/test/test_device_spmv.cu
@@ -289,10 +289,10 @@ host_csr_matrix<ValueT> make_random_csr_matrix(int num_rows,
 
       if (std::is_floating_point<ValueT>::value)
       {
-        // Keep fp numbers somewhat small, from -100 -> 100; otherwise we run
+        // Keep fp numbers somewhat small, from -50 -> 50; otherwise we run
         // into issues with nans/infs
         ValueT value =
-          (RandomValue(static_cast<ValueT>(200)) - static_cast<ValueT>(100));
+          (RandomValue(static_cast<ValueT>(100)) - static_cast<ValueT>(50));
         mat.append_value(row, col, value);
       }
       else
@@ -340,7 +340,7 @@ thrust::host_vector<ValueT> make_random_vector(int len)
     if (std::is_floating_point<ValueT>::value)
     { // Keep fp numbers somewhat small; otherwise we run into issues with
       // nans/infs
-      val = RandomValue(static_cast<ValueT>(200)) - static_cast<ValueT>(100);
+      val = RandomValue(static_cast<ValueT>(100)) - static_cast<ValueT>(50);
     }
     else
     {
@@ -568,7 +568,7 @@ void test_types()
   test_type<double>();
   test_type<signed char>();
   test_type<int>();
-  test_type<unsigned long long>();
+  test_type<long long>();
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
We currently provide `cub::Mutex` as part of our public API. The facility is using `std::mutex` internally for C++11 and forward. Since the facility is not tested and doesn't provide any extra functionality, I'm deprecating it and suggesting users to rely on `std::mutex` instead. Marking this as a breaking change not to forget to mention this in release notes. 

This PR also fixes some narrowing conversions in our tests. 