### PR TITLE
Optimize merge sort

### DIFF
--- a/cub/block/block_merge_sort.cuh
+++ b/cub/block/block_merge_sort.cuh
@@ -407,7 +407,6 @@ public:
     // each thread has sorted keys
     // merge sort keys in shared memory
     //
-    #pragma unroll
     for (int target_merged_threads_number = 2;
          target_merged_threads_number <= NUM_THREADS;
          target_merged_threads_number *= 2)


### PR DESCRIPTION
This PR addresses regression (more than 45%) of merge sort used with relatively complex comparison operators. The regression is caused by high-level unroll pragma that didn't lead to unrolling the loop before CTK 11.8. With a newer version of CTK, the pragma took effect and led to kernel size explosion. Removing this pragma has little impact on the sorting of fundamental types.