### PR TITLE
Add policy parameter to allow tuning

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -22,15 +22,17 @@
   - if
 - scan 
   - by key
+- histogram 
+  - even
+  - range
+  - multi even
+  - multi range
 
 ### TODO
 
 - adjacent difference 
   - left
   - right
-- histogram : needs policy
-  - even
-  - range
 - rle : needs policy
   - encode
   - non trivial runs

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -11,31 +11,28 @@
 - reduce
   - sum
   - max
+  - by_key
 - scan
   - sum
   - max
+  - by key
 - select
   - flagged
   - if
 - partition
   - flagged
   - if
-- scan 
-  - by key
 - histogram 
   - even
   - range
   - multi even
   - multi range
+- rle 
+  - encode
+  - non trivial runs
+- adjacent difference 
+  - left
 
 ### TODO
 
-- adjacent difference 
-  - left
-  - right
-- rle : needs policy
-  - encode
-  - non trivial runs
-- reduce : needs policy
-  - by key
 - segmented

--- a/benchmarks/bench/adjacent_difference/subtract_left.cu
+++ b/benchmarks/bench/adjacent_difference/subtract_left.cu
@@ -1,0 +1,94 @@
+#include <nvbench_helper.cuh>
+
+// %RANGE% TUNE_ITEMS_PER_THREAD ipt 7:24:1
+// %RANGE% TUNE_THREADS_PER_BLOCK tpb 128:1024:32
+
+#include <cub/device/device_adjacent_difference.cuh>
+
+#if !TUNE_BASE
+struct policy_hub_t
+{
+  struct Policy350 : cub::ChainedPolicy<350, Policy350, Policy350>
+  {
+    using AdjacentDifferencePolicy =
+      cub::AgentAdjacentDifferencePolicy<TUNE_THREADS_PER_BLOCK,
+                                         TUNE_ITEMS_PER_THREAD,
+                                         cub::BLOCK_LOAD_WARP_TRANSPOSE,
+                                         cub::LOAD_CA,
+                                         cub::BLOCK_STORE_WARP_TRANSPOSE>;
+  };
+
+  using MaxPolicy = Policy350;
+};
+#endif // !TUNE_BASE
+
+template <class T, class OffsetT>
+void adjacent_difference(nvbench::state& state, nvbench::type_list<T, OffsetT>)
+{
+  constexpr bool may_alias = false;
+  constexpr bool read_left = true;
+
+  using input_it_t = const T*;
+  using output_it_t = T*;
+  using difference_op_t = cub::Difference;
+  using offset_t = typename cub::detail::ChooseOffsetT<OffsetT>::Type;
+
+#if !TUNE_BASE
+  using dispatch_t = cub::DispatchAdjacentDifference<input_it_t,
+                                                     output_it_t,
+                                                     difference_op_t,
+                                                     offset_t,
+                                                     may_alias,
+                                                     read_left,
+                                                     policy_hub_t>;
+#else
+  using dispatch_t = cub::DispatchAdjacentDifference<input_it_t,
+                                                     output_it_t,
+                                                     difference_op_t,
+                                                     offset_t,
+                                                     may_alias,
+                                                     read_left>;
+#endif // TUNE_BASE
+
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
+  thrust::device_vector<T> in(elements);
+  thrust::device_vector<T> out(elements);
+  gen(seed_t{}, in);
+
+  input_it_t d_in   = thrust::raw_pointer_cast(in.data());
+  output_it_t d_out = thrust::raw_pointer_cast(out.data());
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  std::size_t temp_storage_bytes{};
+  dispatch_t::Dispatch(nullptr,
+                       temp_storage_bytes,
+                       d_in,
+                       d_out,
+                       static_cast<offset_t>(elements),
+                       difference_op_t{},
+                       0);
+
+  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  std::uint8_t* d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  state.exec([&](nvbench::launch &launch) {
+    dispatch_t::Dispatch(d_temp_storage,
+                         temp_storage_bytes,
+                         d_in,
+                         d_out,
+                         static_cast<offset_t>(elements),
+                         difference_op_t{},
+                         launch.get_stream());
+  });
+}
+
+
+using types = nvbench::type_list<int32_t>;
+
+NVBENCH_BENCH_TYPES(adjacent_difference, NVBENCH_TYPE_AXES(types, offset_types))
+  .set_name("cub::DeviceAdjacentDifference::SubtractLeftCopy")
+  .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4));

--- a/benchmarks/bench/adjacent_difference/subtract_left.cu
+++ b/benchmarks/bench/adjacent_difference/subtract_left.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <cub/device/device_adjacent_difference.cuh>
 
 #include <nvbench_helper.cuh>

--- a/benchmarks/bench/adjacent_difference/subtract_left.cu
+++ b/benchmarks/bench/adjacent_difference/subtract_left.cu
@@ -1,9 +1,9 @@
+#include <cub/device/device_adjacent_difference.cuh>
+
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS_PER_THREAD ipt 7:24:1
 // %RANGE% TUNE_THREADS_PER_BLOCK tpb 128:1024:32
-
-#include <cub/device/device_adjacent_difference.cuh>
 
 #if !TUNE_BASE
 struct policy_hub_t

--- a/benchmarks/bench/histogram/even.cu
+++ b/benchmarks/bench/histogram/even.cu
@@ -1,0 +1,182 @@
+#include <nvbench_helper.cuh>
+
+// %RANGE% TUNE_ITEMS ipt 7:24:1
+// %RANGE% TUNE_THREADS tpb 128:1024:32
+// %RANGE% TUNE_RLE_COMPRESS rle 0:1:1
+// %RANGE% TUNE_WORK_STEALING ws 0:1:1
+// %RANGE% TUNE_MEM_PREFERENCE mem 0:2:1
+// %RANGE% TUNE_LOAD ld 0:2:1
+
+#include <cub/device/device_histogram.cuh>
+
+#if !TUNE_BASE
+
+#if TUNE_LOAD == 0
+#define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
+#elif TUNE_LOAD == 1
+#define TUNE_LOAD_MODIFIER cub::LOAD_LDG
+#else // TUNE_LOAD == 2
+#define TUNE_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_LOAD 
+
+#if TUNE_MEM_PREFERENCE == 0
+constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::GMEM;
+#elif TUNE_MEM_PREFERENCE == 1
+constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::SMEM;
+#else // TUNE_MEM_PREFERENCE == 2
+constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::BLEND;
+#endif // TUNE_MEM_PREFERENCE
+
+
+template <typename SampleT, int NUM_ACTIVE_CHANNELS>
+struct policy_hub_t
+{
+  template <int NOMINAL_ITEMS_PER_THREAD>
+  struct TScale
+  {
+    enum
+    {
+      V_SCALE = (sizeof(SampleT) + sizeof(int) - 1) / sizeof(int),
+      VALUE   = CUB_MAX((NOMINAL_ITEMS_PER_THREAD / NUM_ACTIVE_CHANNELS / V_SCALE), 1)
+    };
+  };
+
+  struct policy_t : cub::ChainedPolicy<350, policy_t, policy_t>
+  {
+    using AgentHistogramPolicyT = cub::AgentHistogramPolicy<TUNE_THREADS,
+                                                            TScale<TUNE_ITEMS>::VALUE,
+                                                            cub::BLOCK_LOAD_DIRECT,
+                                                            TUNE_LOAD_MODIFIER,
+                                                            TUNE_RLE_COMPRESS,
+                                                            MEM_PREFERENCE,
+                                                            TUNE_WORK_STEALING>;
+  };
+
+  using MaxPolicy = policy_t;
+};
+#endif // !TUNE_BASE
+
+template <class SampleT, class OffsetT>
+SampleT get_upper_level(OffsetT bins, OffsetT elements)
+{
+  if constexpr (cuda::std::is_integral_v<SampleT>)
+  {
+    if constexpr (sizeof(SampleT) < sizeof(OffsetT))
+    {
+      const SampleT max_key = std::numeric_limits<SampleT>::max();
+      return static_cast<SampleT>(std::min(bins, static_cast<OffsetT>(max_key)));
+    }
+    else
+    {
+      return static_cast<SampleT>(bins);
+    }
+  }
+
+  return static_cast<SampleT>(elements);
+}
+
+template <typename SampleT, typename CounterT, typename OffsetT>
+static void histogram(nvbench::state &state, nvbench::type_list<SampleT, CounterT, OffsetT>)
+{
+  constexpr int num_channels        = 1;
+  constexpr int num_active_channels = 1;
+
+  using sample_iterator_t = SampleT *;
+
+#if !TUNE_BASE 
+  using policy_t   = policy_hub_t<key_t, num_active_channels>;
+  using dispatch_t = cub::DispatchHistogram<num_channels, //
+                                            num_active_channels,
+                                            sample_iterator_t,
+                                            CounterT,
+                                            SampleT,
+                                            OffsetT,
+                                            policy_t>;
+#else // TUNE_BASE
+  using dispatch_t = cub::DispatchHistogram<num_channels, //
+                                            num_active_channels,
+                                            sample_iterator_t,
+                                            CounterT,
+                                            SampleT,
+                                            OffsetT>;
+#endif // TUNE_BASE
+
+  const auto entropy   = str_to_entropy(state.get_string("Entropy"));
+  const auto elements  = state.get_int64("Elements{io}");
+  const auto num_bins  = state.get_int64("Bins");
+  const int num_levels = static_cast<int>(num_bins) + 1;
+
+  const SampleT lower_level = 0;
+  const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
+
+  thrust::device_vector<SampleT> input(elements);
+  thrust::device_vector<CounterT> hist(num_bins);
+  gen(seed_t{}, input, entropy, lower_level, upper_level);
+
+  SampleT *d_input      = thrust::raw_pointer_cast(input.data());
+  CounterT *d_histogram = thrust::raw_pointer_cast(hist.data());
+
+  CounterT *d_histogram1[1] = {d_histogram};
+  int num_levels1[1]        = {num_levels};
+  SampleT lower_level1[1]   = {lower_level};
+  SampleT upper_level1[1]   = {upper_level};
+
+  std::uint8_t *d_temp_storage = nullptr;
+  std::size_t temp_storage_bytes{};
+
+  cub::Int2Type<sizeof(SampleT) == 1> is_byte_sample;
+  OffsetT num_row_pixels     = static_cast<OffsetT>(elements);
+  OffsetT num_rows           = 1;
+  OffsetT row_stride_samples = num_row_pixels;
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<SampleT>(elements);
+  state.add_global_memory_writes<CounterT>(num_bins);
+
+  dispatch_t::DispatchEven(d_temp_storage,
+                           temp_storage_bytes,
+                           d_input,
+                           d_histogram1,
+                           num_levels1,
+                           lower_level1,
+                           upper_level1,
+                           num_row_pixels,
+                           num_rows,
+                           row_stride_samples,
+                           0,
+                           is_byte_sample);
+
+  thrust::device_vector<nvbench::uint8_t> tmp(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(tmp.data());
+
+  state.exec([&](nvbench::launch &launch) {
+    dispatch_t::DispatchEven(d_temp_storage,
+                             temp_storage_bytes,
+                             d_input,
+                             d_histogram1,
+                             num_levels1,
+                             lower_level1,
+                             upper_level1,
+                             num_row_pixels,
+                             num_rows,
+                             row_stride_samples,
+                             launch.get_stream(),
+                             is_byte_sample);
+  });
+}
+
+using bin_types         = nvbench::type_list<int32_t>;
+using some_offset_types = nvbench::type_list<int32_t>;
+
+#ifdef TUNE_SampleT
+using sample_types = nvbench::type_list<TUNE_SampleT>;
+#else // !defined(TUNE_SampleT)
+using sample_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t, float, double>;
+#endif // TUNE_SampleT
+
+NVBENCH_BENCH_TYPES(histogram, NVBENCH_TYPE_AXES(sample_types, bin_types, some_offset_types))
+  .set_name("cub::cub::DeviceHistogram::HistogramEven")
+  .set_type_axes_names({"SampleT{ct}", "BinT{ct}", "OffsetT{ct}"})
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
+  .add_int64_axis("Bins", {128, 2048, 2097152})
+  .add_string_axis("Entropy", {"1.000", "0.544", "0.000"});

--- a/benchmarks/bench/histogram/even.cu
+++ b/benchmarks/bench/histogram/even.cu
@@ -1,3 +1,5 @@
+#include <cub/device/device_histogram.cuh>
+
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
@@ -6,8 +8,6 @@
 // %RANGE% TUNE_WORK_STEALING ws 0:1:1
 // %RANGE% TUNE_MEM_PREFERENCE mem 0:2:1
 // %RANGE% TUNE_LOAD ld 0:2:1
-
-#include <cub/device/device_histogram.cuh>
 
 #if !TUNE_BASE
 

--- a/benchmarks/bench/histogram/even.cu
+++ b/benchmarks/bench/histogram/even.cu
@@ -1,5 +1,4 @@
-#include <cub/device/device_histogram.cuh>
-
+#include "histogram_common.cuh"
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
@@ -8,72 +7,6 @@
 // %RANGE% TUNE_WORK_STEALING ws 0:1:1
 // %RANGE% TUNE_MEM_PREFERENCE mem 0:2:1
 // %RANGE% TUNE_LOAD ld 0:2:1
-
-#if !TUNE_BASE
-
-#if TUNE_LOAD == 0
-#define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
-#elif TUNE_LOAD == 1
-#define TUNE_LOAD_MODIFIER cub::LOAD_LDG
-#else // TUNE_LOAD == 2
-#define TUNE_LOAD_MODIFIER cub::LOAD_CA
-#endif // TUNE_LOAD 
-
-#if TUNE_MEM_PREFERENCE == 0
-constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::GMEM;
-#elif TUNE_MEM_PREFERENCE == 1
-constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::SMEM;
-#else // TUNE_MEM_PREFERENCE == 2
-constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::BLEND;
-#endif // TUNE_MEM_PREFERENCE
-
-
-template <typename SampleT, int NUM_ACTIVE_CHANNELS>
-struct policy_hub_t
-{
-  template <int NOMINAL_ITEMS_PER_THREAD>
-  struct TScale
-  {
-    enum
-    {
-      V_SCALE = (sizeof(SampleT) + sizeof(int) - 1) / sizeof(int),
-      VALUE   = CUB_MAX((NOMINAL_ITEMS_PER_THREAD / NUM_ACTIVE_CHANNELS / V_SCALE), 1)
-    };
-  };
-
-  struct policy_t : cub::ChainedPolicy<350, policy_t, policy_t>
-  {
-    using AgentHistogramPolicyT = cub::AgentHistogramPolicy<TUNE_THREADS,
-                                                            TScale<TUNE_ITEMS>::VALUE,
-                                                            cub::BLOCK_LOAD_DIRECT,
-                                                            TUNE_LOAD_MODIFIER,
-                                                            TUNE_RLE_COMPRESS,
-                                                            MEM_PREFERENCE,
-                                                            TUNE_WORK_STEALING>;
-  };
-
-  using MaxPolicy = policy_t;
-};
-#endif // !TUNE_BASE
-
-template <class SampleT, class OffsetT>
-SampleT get_upper_level(OffsetT bins, OffsetT elements)
-{
-  if constexpr (cuda::std::is_integral_v<SampleT>)
-  {
-    if constexpr (sizeof(SampleT) < sizeof(OffsetT))
-    {
-      const SampleT max_key = std::numeric_limits<SampleT>::max();
-      return static_cast<SampleT>(std::min(bins, static_cast<OffsetT>(max_key)));
-    }
-    else
-    {
-      return static_cast<SampleT>(bins);
-    }
-  }
-
-  return static_cast<SampleT>(elements);
-}
 
 template <typename SampleT, typename CounterT, typename OffsetT>
 static void histogram(nvbench::state &state, nvbench::type_list<SampleT, CounterT, OffsetT>)

--- a/benchmarks/bench/histogram/even.cu
+++ b/benchmarks/bench/histogram/even.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include "histogram_common.cuh"
 #include <nvbench_helper.cuh>
 

--- a/benchmarks/bench/histogram/histogram_common.cuh
+++ b/benchmarks/bench/histogram/histogram_common.cuh
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #pragma once
 
 #include <cub/device/device_histogram.cuh>

--- a/benchmarks/bench/histogram/histogram_common.cuh
+++ b/benchmarks/bench/histogram/histogram_common.cuh
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cub/device/device_histogram.cuh>
+
+#if !TUNE_BASE
+
+#if TUNE_LOAD == 0
+#define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
+#elif TUNE_LOAD == 1
+#define TUNE_LOAD_MODIFIER cub::LOAD_LDG
+#else // TUNE_LOAD == 2
+#define TUNE_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_LOAD 
+
+#if TUNE_MEM_PREFERENCE == 0
+constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::GMEM;
+#elif TUNE_MEM_PREFERENCE == 1
+constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::SMEM;
+#else // TUNE_MEM_PREFERENCE == 2
+constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::BLEND;
+#endif // TUNE_MEM_PREFERENCE
+
+
+template <typename SampleT, int NUM_ACTIVE_CHANNELS>
+struct policy_hub_t
+{
+  template <int NOMINAL_ITEMS_PER_THREAD>
+  struct TScale
+  {
+    enum
+    {
+      V_SCALE = (sizeof(SampleT) + sizeof(int) - 1) / sizeof(int),
+      VALUE   = CUB_MAX((NOMINAL_ITEMS_PER_THREAD / NUM_ACTIVE_CHANNELS / V_SCALE), 1)
+    };
+  };
+
+  struct policy_t : cub::ChainedPolicy<350, policy_t, policy_t>
+  {
+    using AgentHistogramPolicyT = cub::AgentHistogramPolicy<TUNE_THREADS,
+                                                            TScale<TUNE_ITEMS>::VALUE,
+                                                            cub::BLOCK_LOAD_DIRECT,
+                                                            TUNE_LOAD_MODIFIER,
+                                                            TUNE_RLE_COMPRESS,
+                                                            MEM_PREFERENCE,
+                                                            TUNE_WORK_STEALING>;
+  };
+
+  using MaxPolicy = policy_t;
+};
+#endif // !TUNE_BASE
+
+template <class SampleT, class OffsetT>
+SampleT get_upper_level(OffsetT bins, OffsetT elements)
+{
+  if constexpr (cuda::std::is_integral_v<SampleT>)
+  {
+    if constexpr (sizeof(SampleT) < sizeof(OffsetT))
+    {
+      const SampleT max_key = std::numeric_limits<SampleT>::max();
+      return static_cast<SampleT>(std::min(bins, static_cast<OffsetT>(max_key)));
+    }
+    else
+    {
+      return static_cast<SampleT>(bins);
+    }
+  }
+
+  return static_cast<SampleT>(elements);
+}

--- a/benchmarks/bench/histogram/multi/even.cu
+++ b/benchmarks/bench/histogram/multi/even.cu
@@ -1,5 +1,4 @@
-#include <cub/device/device_histogram.cuh>
-
+#include "../histogram_common.cuh"
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
@@ -8,71 +7,6 @@
 // %RANGE% TUNE_WORK_STEALING ws 0:1:1
 // %RANGE% TUNE_MEM_PREFERENCE mem 0:2:1
 // %RANGE% TUNE_LOAD ld 0:2:1
-
-#if !TUNE_BASE
-
-#if TUNE_LOAD == 0
-#define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
-#elif TUNE_LOAD == 1
-#define TUNE_LOAD_MODIFIER cub::LOAD_LDG
-#else // TUNE_LOAD == 2
-#define TUNE_LOAD_MODIFIER cub::LOAD_CA
-#endif // TUNE_LOAD
-
-#if TUNE_MEM_PREFERENCE == 0
-constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::GMEM;
-#elif TUNE_MEM_PREFERENCE == 1
-constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::SMEM;
-#else  // TUNE_MEM_PREFERENCE == 2
-constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::BLEND;
-#endif // TUNE_MEM_PREFERENCE
-
-template <typename SampleT, int NUM_ACTIVE_CHANNELS>
-struct policy_hub_t
-{
-  template <int NOMINAL_ITEMS_PER_THREAD>
-  struct TScale
-  {
-    enum
-    {
-      V_SCALE = (sizeof(SampleT) + sizeof(int) - 1) / sizeof(int),
-      VALUE   = CUB_MAX((NOMINAL_ITEMS_PER_THREAD / NUM_ACTIVE_CHANNELS / V_SCALE), 1)
-    };
-  };
-
-  struct policy_t : cub::ChainedPolicy<350, policy_t, policy_t>
-  {
-    using AgentHistogramPolicyT = cub::AgentHistogramPolicy<TUNE_THREADS,
-                                                            TScale<TUNE_ITEMS>::VALUE,
-                                                            cub::BLOCK_LOAD_DIRECT,
-                                                            TUNE_LOAD_MODIFIER,
-                                                            TUNE_RLE_COMPRESS,
-                                                            MEM_PREFERENCE,
-                                                            TUNE_WORK_STEALING>;
-  };
-
-  using MaxPolicy = policy_t;
-};
-#endif // !TUNE_BASE
-
-template <class SampleT, class OffsetT>
-SampleT get_upper_level(OffsetT bins, OffsetT elements)
-{
-  if constexpr (cuda::std::is_integral_v<SampleT>)
-  {
-    if constexpr (sizeof(SampleT) < sizeof(OffsetT))
-    {
-      const SampleT max_key = std::numeric_limits<SampleT>::max();
-      return static_cast<SampleT>(std::min(bins, static_cast<OffsetT>(max_key)));
-    }
-    else
-    {
-      return static_cast<SampleT>(bins);
-    }
-  }
-
-  return static_cast<SampleT>(elements);
-}
 
 template <typename SampleT, typename CounterT, typename OffsetT>
 static void histogram(nvbench::state &state, nvbench::type_list<SampleT, CounterT, OffsetT>)

--- a/benchmarks/bench/histogram/multi/even.cu
+++ b/benchmarks/bench/histogram/multi/even.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include "../histogram_common.cuh"
 #include <nvbench_helper.cuh>
 

--- a/benchmarks/bench/histogram/multi/even.cu
+++ b/benchmarks/bench/histogram/multi/even.cu
@@ -1,3 +1,5 @@
+#include <cub/device/device_histogram.cuh>
+
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
@@ -6,8 +8,6 @@
 // %RANGE% TUNE_WORK_STEALING ws 0:1:1
 // %RANGE% TUNE_MEM_PREFERENCE mem 0:2:1
 // %RANGE% TUNE_LOAD ld 0:2:1
-
-#include <cub/device/device_histogram.cuh>
 
 #if !TUNE_BASE
 

--- a/benchmarks/bench/histogram/multi/even.cu
+++ b/benchmarks/bench/histogram/multi/even.cu
@@ -1,0 +1,191 @@
+#include <nvbench_helper.cuh>
+
+// %RANGE% TUNE_ITEMS ipt 7:24:1
+// %RANGE% TUNE_THREADS tpb 128:1024:32
+// %RANGE% TUNE_RLE_COMPRESS rle 0:1:1
+// %RANGE% TUNE_WORK_STEALING ws 0:1:1
+// %RANGE% TUNE_MEM_PREFERENCE mem 0:2:1
+// %RANGE% TUNE_LOAD ld 0:2:1
+
+#include <cub/device/device_histogram.cuh>
+
+#if !TUNE_BASE
+
+#if TUNE_LOAD == 0
+#define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
+#elif TUNE_LOAD == 1
+#define TUNE_LOAD_MODIFIER cub::LOAD_LDG
+#else // TUNE_LOAD == 2
+#define TUNE_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_LOAD
+
+#if TUNE_MEM_PREFERENCE == 0
+constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::GMEM;
+#elif TUNE_MEM_PREFERENCE == 1
+constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::SMEM;
+#else  // TUNE_MEM_PREFERENCE == 2
+constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::BLEND;
+#endif // TUNE_MEM_PREFERENCE
+
+template <typename SampleT, int NUM_ACTIVE_CHANNELS>
+struct policy_hub_t
+{
+  template <int NOMINAL_ITEMS_PER_THREAD>
+  struct TScale
+  {
+    enum
+    {
+      V_SCALE = (sizeof(SampleT) + sizeof(int) - 1) / sizeof(int),
+      VALUE   = CUB_MAX((NOMINAL_ITEMS_PER_THREAD / NUM_ACTIVE_CHANNELS / V_SCALE), 1)
+    };
+  };
+
+  struct policy_t : cub::ChainedPolicy<350, policy_t, policy_t>
+  {
+    using AgentHistogramPolicyT = cub::AgentHistogramPolicy<TUNE_THREADS,
+                                                            TScale<TUNE_ITEMS>::VALUE,
+                                                            cub::BLOCK_LOAD_DIRECT,
+                                                            TUNE_LOAD_MODIFIER,
+                                                            TUNE_RLE_COMPRESS,
+                                                            MEM_PREFERENCE,
+                                                            TUNE_WORK_STEALING>;
+  };
+
+  using MaxPolicy = policy_t;
+};
+#endif // !TUNE_BASE
+
+template <class SampleT, class OffsetT>
+SampleT get_upper_level(OffsetT bins, OffsetT elements)
+{
+  if constexpr (cuda::std::is_integral_v<SampleT>)
+  {
+    if constexpr (sizeof(SampleT) < sizeof(OffsetT))
+    {
+      const SampleT max_key = std::numeric_limits<SampleT>::max();
+      return static_cast<SampleT>(std::min(bins, static_cast<OffsetT>(max_key)));
+    }
+    else
+    {
+      return static_cast<SampleT>(bins);
+    }
+  }
+
+  return static_cast<SampleT>(elements);
+}
+
+template <typename SampleT, typename CounterT, typename OffsetT>
+static void histogram(nvbench::state &state, nvbench::type_list<SampleT, CounterT, OffsetT>)
+{
+  constexpr int num_channels        = 4;
+  constexpr int num_active_channels = 3;
+
+  using sample_iterator_t = SampleT *;
+
+#if !TUNE_BASE
+  using policy_t   = policy_hub_t<key_t, num_active_channels>;
+  using dispatch_t = cub::DispatchHistogram<num_channels, //
+                                            num_active_channels,
+                                            sample_iterator_t,
+                                            CounterT,
+                                            SampleT,
+                                            OffsetT,
+                                            policy_t>;
+#else  // TUNE_BASE
+  using dispatch_t = cub::DispatchHistogram<num_channels, //
+                                            num_active_channels,
+                                            sample_iterator_t,
+                                            CounterT,
+                                            SampleT,
+                                            OffsetT>;
+#endif // TUNE_BASE
+
+  const auto entropy     = str_to_entropy(state.get_string("Entropy"));
+  const auto elements    = state.get_int64("Elements{io}");
+  const auto num_bins    = state.get_int64("Bins");
+  const int num_levels_r = static_cast<int>(num_bins) + 1;
+  const int num_levels_g = num_levels_r;
+  const int num_levels_b = num_levels_g;
+
+  const SampleT lower_level_r = 0;
+  const SampleT upper_level_r = get_upper_level<SampleT>(num_bins, elements);
+  const SampleT lower_level_g = lower_level_r;
+  const SampleT upper_level_g = upper_level_r;
+  const SampleT lower_level_b = lower_level_g;
+  const SampleT upper_level_b = upper_level_g;
+
+  thrust::device_vector<SampleT> input(elements * num_channels);
+  thrust::device_vector<CounterT> hist_r(num_bins);
+  thrust::device_vector<CounterT> hist_g(num_bins);
+  thrust::device_vector<CounterT> hist_b(num_bins);
+  gen(seed_t{}, input, entropy, lower_level_r, upper_level_r);
+
+  SampleT *d_input        = thrust::raw_pointer_cast(input.data());
+  CounterT *d_histogram_r = thrust::raw_pointer_cast(hist_r.data());
+  CounterT *d_histogram_g = thrust::raw_pointer_cast(hist_g.data());
+  CounterT *d_histogram_b = thrust::raw_pointer_cast(hist_b.data());
+
+  CounterT *d_histogram[num_active_channels] = {d_histogram_r, d_histogram_g, d_histogram_b};
+  int num_levels[num_active_channels]        = {num_levels_r, num_levels_g, num_levels_b};
+  SampleT lower_level[num_active_channels]   = {lower_level_r, lower_level_g, lower_level_b};
+  SampleT upper_level[num_active_channels]   = {upper_level_r, upper_level_g, upper_level_b};
+
+  std::uint8_t *d_temp_storage = nullptr;
+  std::size_t temp_storage_bytes{};
+
+  cub::Int2Type<sizeof(SampleT) == 1> is_byte_sample;
+  OffsetT num_row_pixels     = static_cast<OffsetT>(elements);
+  OffsetT num_rows           = 1;
+  OffsetT row_stride_samples = num_row_pixels;
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<SampleT>(elements * num_active_channels);
+  state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
+
+  dispatch_t::DispatchEven(d_temp_storage,
+                           temp_storage_bytes,
+                           d_input,
+                           d_histogram,
+                           num_levels,
+                           lower_level,
+                           upper_level,
+                           num_row_pixels,
+                           num_rows,
+                           row_stride_samples,
+                           0,
+                           is_byte_sample);
+
+  thrust::device_vector<nvbench::uint8_t> tmp(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(tmp.data());
+
+  state.exec([&](nvbench::launch &launch) {
+    dispatch_t::DispatchEven(d_temp_storage,
+                             temp_storage_bytes,
+                             d_input,
+                             d_histogram,
+                             num_levels,
+                             lower_level,
+                             upper_level,
+                             num_row_pixels,
+                             num_rows,
+                             row_stride_samples,
+                             launch.get_stream(),
+                             is_byte_sample);
+  });
+}
+
+using bin_types         = nvbench::type_list<int32_t>;
+using some_offset_types = nvbench::type_list<int32_t>;
+
+#ifdef TUNE_SampleT
+using sample_types = nvbench::type_list<TUNE_SampleT>;
+#else  // !defined(TUNE_SampleT)
+using sample_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t, float, double>;
+#endif // TUNE_SampleT
+
+NVBENCH_BENCH_TYPES(histogram, NVBENCH_TYPE_AXES(sample_types, bin_types, some_offset_types))
+  .set_name("cub::DeviceHistogram::MultiHistogramEven")
+  .set_type_axes_names({"SampleT{ct}", "BinT{ct}", "OffsetT{ct}"})
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
+  .add_int64_axis("Bins", {128, 2048, 2097152})
+  .add_string_axis("Entropy", {"1.000", "0.544", "0.000"});

--- a/benchmarks/bench/histogram/multi/range.cu
+++ b/benchmarks/bench/histogram/multi/range.cu
@@ -1,7 +1,6 @@
-#include <cub/device/device_histogram.cuh>
-
 #include <thrust/sequence.h>
 
+#include "../histogram_common.cuh"
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
@@ -10,71 +9,6 @@
 // %RANGE% TUNE_WORK_STEALING ws 0:1:1
 // %RANGE% TUNE_MEM_PREFERENCE mem 0:2:1
 // %RANGE% TUNE_LOAD ld 0:2:1
-
-#if !TUNE_BASE
-
-#if TUNE_LOAD == 0
-#define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
-#elif TUNE_LOAD == 1
-#define TUNE_LOAD_MODIFIER cub::LOAD_LDG
-#else // TUNE_LOAD == 2
-#define TUNE_LOAD_MODIFIER cub::LOAD_CA
-#endif // TUNE_LOAD
-
-#if TUNE_MEM_PREFERENCE == 0
-constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::GMEM;
-#elif TUNE_MEM_PREFERENCE == 1
-constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::SMEM;
-#else  // TUNE_MEM_PREFERENCE == 2
-constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::BLEND;
-#endif // TUNE_MEM_PREFERENCE
-
-template <typename SampleT, int NUM_ACTIVE_CHANNELS>
-struct policy_hub_t
-{
-  template <int NOMINAL_ITEMS_PER_THREAD>
-  struct TScale
-  {
-    enum
-    {
-      V_SCALE = (sizeof(SampleT) + sizeof(int) - 1) / sizeof(int),
-      VALUE   = CUB_MAX((NOMINAL_ITEMS_PER_THREAD / NUM_ACTIVE_CHANNELS / V_SCALE), 1)
-    };
-  };
-
-  struct policy_t : cub::ChainedPolicy<350, policy_t, policy_t>
-  {
-    using AgentHistogramPolicyT = cub::AgentHistogramPolicy<TUNE_THREADS,
-                                                            TScale<TUNE_ITEMS>::VALUE,
-                                                            cub::BLOCK_LOAD_DIRECT,
-                                                            TUNE_LOAD_MODIFIER,
-                                                            TUNE_RLE_COMPRESS,
-                                                            MEM_PREFERENCE,
-                                                            TUNE_WORK_STEALING>;
-  };
-
-  using MaxPolicy = policy_t;
-};
-#endif // !TUNE_BASE
-
-template <class SampleT, class OffsetT>
-SampleT get_upper_level(OffsetT bins, OffsetT elements)
-{
-  if constexpr (cuda::std::is_integral_v<SampleT>)
-  {
-    if constexpr (sizeof(SampleT) < sizeof(OffsetT))
-    {
-      const SampleT max_key = std::numeric_limits<SampleT>::max();
-      return static_cast<SampleT>(std::min(bins, static_cast<OffsetT>(max_key)));
-    }
-    else
-    {
-      return static_cast<SampleT>(bins);
-    }
-  }
-
-  return static_cast<SampleT>(elements);
-}
 
 template <typename SampleT, typename CounterT, typename OffsetT>
 static void histogram(nvbench::state &state, nvbench::type_list<SampleT, CounterT, OffsetT>)

--- a/benchmarks/bench/histogram/multi/range.cu
+++ b/benchmarks/bench/histogram/multi/range.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <thrust/sequence.h>
 
 #include "../histogram_common.cuh"

--- a/benchmarks/bench/histogram/multi/range.cu
+++ b/benchmarks/bench/histogram/multi/range.cu
@@ -1,3 +1,5 @@
+#include <cub/device/device_histogram.cuh>
+
 #include <thrust/sequence.h>
 
 #include <nvbench_helper.cuh>
@@ -8,8 +10,6 @@
 // %RANGE% TUNE_WORK_STEALING ws 0:1:1
 // %RANGE% TUNE_MEM_PREFERENCE mem 0:2:1
 // %RANGE% TUNE_LOAD ld 0:2:1
-
-#include <cub/device/device_histogram.cuh>
 
 #if !TUNE_BASE
 

--- a/benchmarks/bench/histogram/multi/range.cu
+++ b/benchmarks/bench/histogram/multi/range.cu
@@ -1,0 +1,198 @@
+#include <thrust/sequence.h>
+
+#include <nvbench_helper.cuh>
+
+// %RANGE% TUNE_ITEMS ipt 7:24:1
+// %RANGE% TUNE_THREADS tpb 128:1024:32
+// %RANGE% TUNE_RLE_COMPRESS rle 0:1:1
+// %RANGE% TUNE_WORK_STEALING ws 0:1:1
+// %RANGE% TUNE_MEM_PREFERENCE mem 0:2:1
+// %RANGE% TUNE_LOAD ld 0:2:1
+
+#include <cub/device/device_histogram.cuh>
+
+#if !TUNE_BASE
+
+#if TUNE_LOAD == 0
+#define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
+#elif TUNE_LOAD == 1
+#define TUNE_LOAD_MODIFIER cub::LOAD_LDG
+#else // TUNE_LOAD == 2
+#define TUNE_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_LOAD
+
+#if TUNE_MEM_PREFERENCE == 0
+constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::GMEM;
+#elif TUNE_MEM_PREFERENCE == 1
+constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::SMEM;
+#else  // TUNE_MEM_PREFERENCE == 2
+constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::BLEND;
+#endif // TUNE_MEM_PREFERENCE
+
+template <typename SampleT, int NUM_ACTIVE_CHANNELS>
+struct policy_hub_t
+{
+  template <int NOMINAL_ITEMS_PER_THREAD>
+  struct TScale
+  {
+    enum
+    {
+      V_SCALE = (sizeof(SampleT) + sizeof(int) - 1) / sizeof(int),
+      VALUE   = CUB_MAX((NOMINAL_ITEMS_PER_THREAD / NUM_ACTIVE_CHANNELS / V_SCALE), 1)
+    };
+  };
+
+  struct policy_t : cub::ChainedPolicy<350, policy_t, policy_t>
+  {
+    using AgentHistogramPolicyT = cub::AgentHistogramPolicy<TUNE_THREADS,
+                                                            TScale<TUNE_ITEMS>::VALUE,
+                                                            cub::BLOCK_LOAD_DIRECT,
+                                                            TUNE_LOAD_MODIFIER,
+                                                            TUNE_RLE_COMPRESS,
+                                                            MEM_PREFERENCE,
+                                                            TUNE_WORK_STEALING>;
+  };
+
+  using MaxPolicy = policy_t;
+};
+#endif // !TUNE_BASE
+
+template <class SampleT, class OffsetT>
+SampleT get_upper_level(OffsetT bins, OffsetT elements)
+{
+  if constexpr (cuda::std::is_integral_v<SampleT>)
+  {
+    if constexpr (sizeof(SampleT) < sizeof(OffsetT))
+    {
+      const SampleT max_key = std::numeric_limits<SampleT>::max();
+      return static_cast<SampleT>(std::min(bins, static_cast<OffsetT>(max_key)));
+    }
+    else
+    {
+      return static_cast<SampleT>(bins);
+    }
+  }
+
+  return static_cast<SampleT>(elements);
+}
+
+template <typename SampleT, typename CounterT, typename OffsetT>
+static void histogram(nvbench::state &state, nvbench::type_list<SampleT, CounterT, OffsetT>)
+{
+  constexpr int num_channels        = 4;
+  constexpr int num_active_channels = 3;
+
+  using sample_iterator_t = SampleT *;
+
+#if !TUNE_BASE
+  using policy_t   = policy_hub_t<key_t, num_active_channels>;
+  using dispatch_t = cub::DispatchHistogram<num_channels, //
+                                            num_active_channels,
+                                            sample_iterator_t,
+                                            CounterT,
+                                            SampleT,
+                                            OffsetT,
+                                            policy_t>;
+#else  // TUNE_BASE
+  using dispatch_t = cub::DispatchHistogram<num_channels, //
+                                            num_active_channels,
+                                            sample_iterator_t,
+                                            CounterT,
+                                            SampleT,
+                                            OffsetT>;
+#endif // TUNE_BASE
+
+  const auto entropy     = str_to_entropy(state.get_string("Entropy"));
+  const auto elements    = state.get_int64("Elements{io}");
+  const auto num_bins    = state.get_int64("Bins");
+  const int num_levels_r = static_cast<int>(num_bins) + 1;
+  const int num_levels_g = num_levels_r;
+  const int num_levels_b = num_levels_g;
+
+  const SampleT lower_level = 0;
+  const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
+
+  SampleT step = (upper_level - lower_level) / num_bins;
+  thrust::device_vector<SampleT> levels_r(num_bins + 1);
+
+  // TODO Extract sequence to the helper TU
+  thrust::sequence(levels_r.begin(), levels_r.end(), lower_level, step);
+  thrust::device_vector<SampleT> levels_g = levels_r;
+  thrust::device_vector<SampleT> levels_b = levels_g;
+
+  SampleT *d_levels_r = thrust::raw_pointer_cast(levels_r.data());
+  SampleT *d_levels_g = thrust::raw_pointer_cast(levels_g.data());
+  SampleT *d_levels_b = thrust::raw_pointer_cast(levels_b.data());
+
+  thrust::device_vector<SampleT> input(elements * num_channels);
+  thrust::device_vector<CounterT> hist_r(num_bins);
+  thrust::device_vector<CounterT> hist_g(num_bins);
+  thrust::device_vector<CounterT> hist_b(num_bins);
+  gen(seed_t{}, input, entropy, lower_level, upper_level);
+
+  SampleT *d_input        = thrust::raw_pointer_cast(input.data());
+  CounterT *d_histogram_r = thrust::raw_pointer_cast(hist_r.data());
+  CounterT *d_histogram_g = thrust::raw_pointer_cast(hist_g.data());
+  CounterT *d_histogram_b = thrust::raw_pointer_cast(hist_b.data());
+
+  CounterT *d_histogram[num_active_channels] = {d_histogram_r, d_histogram_g, d_histogram_b};
+  int num_levels[num_active_channels]        = {num_levels_r, num_levels_g, num_levels_b};
+  SampleT *d_levels[num_active_channels]     = {d_levels_r, d_levels_g, d_levels_b};
+
+  std::uint8_t *d_temp_storage = nullptr;
+  std::size_t temp_storage_bytes{};
+
+  cub::Int2Type<sizeof(SampleT) == 1> is_byte_sample;
+  OffsetT num_row_pixels     = static_cast<OffsetT>(elements);
+  OffsetT num_rows           = 1;
+  OffsetT row_stride_samples = num_row_pixels;
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<SampleT>(elements * num_active_channels);
+  state.add_global_memory_writes<CounterT>(num_bins * num_active_channels);
+
+  dispatch_t::DispatchRange(d_temp_storage,
+                            temp_storage_bytes,
+                            d_input,
+                            d_histogram,
+                            num_levels,
+                            d_levels,
+                            num_row_pixels,
+                            num_rows,
+                            row_stride_samples,
+                            0,
+                            is_byte_sample);
+
+  thrust::device_vector<nvbench::uint8_t> tmp(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(tmp.data());
+
+  state.exec([&](nvbench::launch &launch) {
+    dispatch_t::DispatchRange(d_temp_storage,
+                              temp_storage_bytes,
+                              d_input,
+                              d_histogram,
+                              num_levels,
+                              d_levels,
+                              num_row_pixels,
+                              num_rows,
+                              row_stride_samples,
+                              launch.get_stream(),
+                              is_byte_sample);
+  });
+}
+
+using bin_types         = nvbench::type_list<int32_t>;
+using some_offset_types = nvbench::type_list<int32_t>;
+
+#ifdef TUNE_SampleT
+using sample_types = nvbench::type_list<TUNE_SampleT>;
+#else  // !defined(TUNE_SampleT)
+using sample_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t, float, double>;
+#endif // TUNE_SampleT
+
+NVBENCH_BENCH_TYPES(histogram, NVBENCH_TYPE_AXES(sample_types, bin_types, some_offset_types))
+  .set_name("cub::DeviceHistogram::MultiHistogramRange")
+  .set_type_axes_names({"SampleT{ct}", "BinT{ct}", "OffsetT{ct}"})
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
+  .add_int64_axis("Bins", {128, 2048, 2097152})
+  .add_string_axis("Entropy", {"1.000", "0.544", "0.000"});

--- a/benchmarks/bench/histogram/range.cu
+++ b/benchmarks/bench/histogram/range.cu
@@ -1,0 +1,187 @@
+#include <nvbench_helper.cuh>
+#include <thrust/sequence.h>
+
+// %RANGE% TUNE_ITEMS ipt 7:24:1
+// %RANGE% TUNE_THREADS tpb 128:1024:32
+// %RANGE% TUNE_RLE_COMPRESS rle 0:1:1
+// %RANGE% TUNE_WORK_STEALING ws 0:1:1
+// %RANGE% TUNE_MEM_PREFERENCE mem 0:2:1
+// %RANGE% TUNE_LOAD ld 0:2:1
+
+#include <cub/device/device_histogram.cuh>
+
+#if !TUNE_BASE
+
+#if TUNE_LOAD == 0
+#define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
+#elif TUNE_LOAD == 1
+#define TUNE_LOAD_MODIFIER cub::LOAD_LDG
+#else // TUNE_LOAD == 2
+#define TUNE_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_LOAD 
+
+#if TUNE_MEM_PREFERENCE == 0
+constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::GMEM;
+#elif TUNE_MEM_PREFERENCE == 1
+constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::SMEM;
+#else // TUNE_MEM_PREFERENCE == 2
+constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::BLEND;
+#endif // TUNE_MEM_PREFERENCE
+
+
+template <typename SampleT, int NUM_ACTIVE_CHANNELS>
+struct policy_hub_t
+{
+  template <int NOMINAL_ITEMS_PER_THREAD>
+  struct TScale
+  {
+    enum
+    {
+      V_SCALE = (sizeof(SampleT) + sizeof(int) - 1) / sizeof(int),
+      VALUE   = CUB_MAX((NOMINAL_ITEMS_PER_THREAD / NUM_ACTIVE_CHANNELS / V_SCALE), 1)
+    };
+  };
+
+  struct policy_t : cub::ChainedPolicy<350, policy_t, policy_t>
+  {
+    using AgentHistogramPolicyT = cub::AgentHistogramPolicy<TUNE_THREADS,
+                                                            TScale<TUNE_ITEMS>::VALUE,
+                                                            cub::BLOCK_LOAD_DIRECT,
+                                                            TUNE_LOAD_MODIFIER,
+                                                            TUNE_RLE_COMPRESS,
+                                                            MEM_PREFERENCE,
+                                                            TUNE_WORK_STEALING>;
+  };
+
+  using MaxPolicy = policy_t;
+};
+#endif // !TUNE_BASE
+
+template <class SampleT, class OffsetT>
+SampleT get_upper_level(OffsetT bins, OffsetT elements)
+{
+  if constexpr (cuda::std::is_integral_v<SampleT>)
+  {
+    if constexpr (sizeof(SampleT) < sizeof(OffsetT))
+    {
+      const SampleT max_key = std::numeric_limits<SampleT>::max();
+      return static_cast<SampleT>(std::min(bins, static_cast<OffsetT>(max_key)));
+    }
+    else
+    {
+      return static_cast<SampleT>(bins);
+    }
+  }
+
+  return static_cast<SampleT>(elements);
+}
+
+template <typename SampleT, typename CounterT, typename OffsetT>
+static void histogram(nvbench::state &state, nvbench::type_list<SampleT, CounterT, OffsetT>)
+{
+  constexpr int num_channels        = 1;
+  constexpr int num_active_channels = 1;
+
+  using sample_iterator_t = SampleT *;
+
+#if !TUNE_BASE 
+  using policy_t   = policy_hub_t<key_t, num_active_channels>;
+  using dispatch_t = cub::DispatchHistogram<num_channels, //
+                                            num_active_channels,
+                                            sample_iterator_t,
+                                            CounterT,
+                                            SampleT,
+                                            OffsetT,
+                                            policy_t>;
+#else // TUNE_BASE
+  using dispatch_t = cub::DispatchHistogram<num_channels, //
+                                            num_active_channels,
+                                            sample_iterator_t,
+                                            CounterT,
+                                            SampleT,
+                                            OffsetT>;
+#endif // TUNE_BASE
+
+  const auto entropy   = str_to_entropy(state.get_string("Entropy"));
+  const auto elements  = state.get_int64("Elements{io}");
+  const auto num_bins  = state.get_int64("Bins");
+  const int num_levels = static_cast<int>(num_bins) + 1;
+
+  const SampleT lower_level = 0;
+  const SampleT upper_level = get_upper_level<SampleT>(num_bins, elements);
+
+  SampleT step = (upper_level - lower_level) / num_bins;
+  thrust::device_vector<SampleT> levels(num_bins + 1);
+
+  // TODO Extract sequence to the helper TU
+  thrust::sequence(levels.begin(), levels.end(), lower_level, step);
+  SampleT* d_levels = thrust::raw_pointer_cast(levels.data());
+
+  thrust::device_vector<SampleT> input(elements);
+  thrust::device_vector<CounterT> hist(num_bins);
+  gen(seed_t{}, input, entropy, lower_level, upper_level);
+
+  SampleT *d_input      = thrust::raw_pointer_cast(input.data());
+  CounterT *d_histogram = thrust::raw_pointer_cast(hist.data());
+
+  CounterT *d_histogram1[1] = {d_histogram};
+  int num_levels1[1]        = {num_levels};
+  SampleT *d_levels1[1]     = {d_levels};
+
+  std::uint8_t *d_temp_storage = nullptr;
+  std::size_t temp_storage_bytes{};
+
+  cub::Int2Type<sizeof(SampleT) == 1> is_byte_sample;
+  OffsetT num_row_pixels     = static_cast<OffsetT>(elements);
+  OffsetT num_rows           = 1;
+  OffsetT row_stride_samples = num_row_pixels;
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<SampleT>(elements);
+  state.add_global_memory_writes<CounterT>(num_bins);
+
+  dispatch_t::DispatchRange(d_temp_storage,
+                            temp_storage_bytes,
+                            d_input,
+                            d_histogram1,
+                            num_levels1,
+                            d_levels1,
+                            num_row_pixels,
+                            num_rows,
+                            row_stride_samples,
+                            0,
+                            is_byte_sample);
+
+  thrust::device_vector<nvbench::uint8_t> tmp(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(tmp.data());
+
+  state.exec([&](nvbench::launch &launch) {
+    dispatch_t::DispatchRange(d_temp_storage,
+                              temp_storage_bytes,
+                              d_input,
+                              d_histogram1,
+                              num_levels1,
+                              d_levels1,
+                              num_row_pixels,
+                              num_rows,
+                              row_stride_samples,
+                              launch.get_stream(),
+                              is_byte_sample);
+  });
+}
+
+using bin_types         = nvbench::type_list<int32_t>;
+using some_offset_types = nvbench::type_list<int32_t>;
+
+#ifdef TUNE_SampleT
+using sample_types = nvbench::type_list<TUNE_SampleT>;
+#else // !defined(TUNE_SampleT)
+using sample_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t, float, double>;
+#endif // TUNE_SampleT
+
+NVBENCH_BENCH_TYPES(histogram, NVBENCH_TYPE_AXES(sample_types, bin_types, some_offset_types))
+  .set_name("cub::cub::DeviceHistogram::HistogramRange")
+  .set_type_axes_names({"SampleT{ct}", "BinT{ct}", "OffsetT{ct}"})
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
+  .add_int64_axis("Bins", {128, 2048, 2097152})
+  .add_string_axis("Entropy", {"1.000", "0.544", "0.000"});

--- a/benchmarks/bench/histogram/range.cu
+++ b/benchmarks/bench/histogram/range.cu
@@ -1,5 +1,8 @@
-#include <nvbench_helper.cuh>
+#include <cub/device/device_histogram.cuh>
+
 #include <thrust/sequence.h>
+
+#include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
 // %RANGE% TUNE_THREADS tpb 128:1024:32
@@ -7,8 +10,6 @@
 // %RANGE% TUNE_WORK_STEALING ws 0:1:1
 // %RANGE% TUNE_MEM_PREFERENCE mem 0:2:1
 // %RANGE% TUNE_LOAD ld 0:2:1
-
-#include <cub/device/device_histogram.cuh>
 
 #if !TUNE_BASE
 

--- a/benchmarks/bench/histogram/range.cu
+++ b/benchmarks/bench/histogram/range.cu
@@ -1,7 +1,5 @@
-#include <cub/device/device_histogram.cuh>
-
+#include "histogram_common.cuh"
 #include <thrust/sequence.h>
-
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
@@ -10,72 +8,6 @@
 // %RANGE% TUNE_WORK_STEALING ws 0:1:1
 // %RANGE% TUNE_MEM_PREFERENCE mem 0:2:1
 // %RANGE% TUNE_LOAD ld 0:2:1
-
-#if !TUNE_BASE
-
-#if TUNE_LOAD == 0
-#define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
-#elif TUNE_LOAD == 1
-#define TUNE_LOAD_MODIFIER cub::LOAD_LDG
-#else // TUNE_LOAD == 2
-#define TUNE_LOAD_MODIFIER cub::LOAD_CA
-#endif // TUNE_LOAD 
-
-#if TUNE_MEM_PREFERENCE == 0
-constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::GMEM;
-#elif TUNE_MEM_PREFERENCE == 1
-constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::SMEM;
-#else // TUNE_MEM_PREFERENCE == 2
-constexpr cub::BlockHistogramMemoryPreference MEM_PREFERENCE = cub::BLEND;
-#endif // TUNE_MEM_PREFERENCE
-
-
-template <typename SampleT, int NUM_ACTIVE_CHANNELS>
-struct policy_hub_t
-{
-  template <int NOMINAL_ITEMS_PER_THREAD>
-  struct TScale
-  {
-    enum
-    {
-      V_SCALE = (sizeof(SampleT) + sizeof(int) - 1) / sizeof(int),
-      VALUE   = CUB_MAX((NOMINAL_ITEMS_PER_THREAD / NUM_ACTIVE_CHANNELS / V_SCALE), 1)
-    };
-  };
-
-  struct policy_t : cub::ChainedPolicy<350, policy_t, policy_t>
-  {
-    using AgentHistogramPolicyT = cub::AgentHistogramPolicy<TUNE_THREADS,
-                                                            TScale<TUNE_ITEMS>::VALUE,
-                                                            cub::BLOCK_LOAD_DIRECT,
-                                                            TUNE_LOAD_MODIFIER,
-                                                            TUNE_RLE_COMPRESS,
-                                                            MEM_PREFERENCE,
-                                                            TUNE_WORK_STEALING>;
-  };
-
-  using MaxPolicy = policy_t;
-};
-#endif // !TUNE_BASE
-
-template <class SampleT, class OffsetT>
-SampleT get_upper_level(OffsetT bins, OffsetT elements)
-{
-  if constexpr (cuda::std::is_integral_v<SampleT>)
-  {
-    if constexpr (sizeof(SampleT) < sizeof(OffsetT))
-    {
-      const SampleT max_key = std::numeric_limits<SampleT>::max();
-      return static_cast<SampleT>(std::min(bins, static_cast<OffsetT>(max_key)));
-    }
-    else
-    {
-      return static_cast<SampleT>(bins);
-    }
-  }
-
-  return static_cast<SampleT>(elements);
-}
 
 template <typename SampleT, typename CounterT, typename OffsetT>
 static void histogram(nvbench::state &state, nvbench::type_list<SampleT, CounterT, OffsetT>)

--- a/benchmarks/bench/histogram/range.cu
+++ b/benchmarks/bench/histogram/range.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include "histogram_common.cuh"
 #include <thrust/sequence.h>
 #include <nvbench_helper.cuh>

--- a/benchmarks/bench/merge_sort/keys.cu
+++ b/benchmarks/bench/merge_sort/keys.cu
@@ -121,9 +121,7 @@ void merge_sort_keys(nvbench::state &state, nvbench::type_list<T, OffsetT>)
   });
 }
 
-using key_types = push_back_t<complex, all_types>;
-
-NVBENCH_BENCH_TYPES(merge_sort_keys, NVBENCH_TYPE_AXES(key_types, offset_types))
+NVBENCH_BENCH_TYPES(merge_sort_keys, NVBENCH_TYPE_AXES(all_types, offset_types))
   .set_name("cub::DeviceMergeSort::SortKeys")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))

--- a/benchmarks/bench/merge_sort/keys.cu
+++ b/benchmarks/bench/merge_sort/keys.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <cub/device/device_merge_sort.cuh>
 
 #include <nvbench_helper.cuh>

--- a/benchmarks/bench/merge_sort/pairs.cu
+++ b/benchmarks/bench/merge_sort/pairs.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <cub/device/device_merge_sort.cuh>
 
 #include <nvbench_helper.cuh>

--- a/benchmarks/bench/partition/flagged.cu
+++ b/benchmarks/bench/partition/flagged.cu
@@ -138,4 +138,4 @@ NVBENCH_BENCH_TYPES(partition, NVBENCH_TYPE_AXES(fundamental_types, offset_types
   .set_name("cub::DevicePartition::Flagged")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.811", "0.544", "0.337", "0.201", "0.000"});
+  .add_string_axis("Entropy", {"1.000", "0.544", "0.000"});

--- a/benchmarks/bench/partition/flagged.cu
+++ b/benchmarks/bench/partition/flagged.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <nvbench_helper.cuh>
 #include <cub/device/device_partition.cuh>
 

--- a/benchmarks/bench/partition/if.cu
+++ b/benchmarks/bench/partition/if.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <nvbench_helper.cuh>
 #include <cub/device/device_partition.cuh>
 

--- a/benchmarks/bench/partition/if.cu
+++ b/benchmarks/bench/partition/if.cu
@@ -162,4 +162,4 @@ NVBENCH_BENCH_TYPES(partition, NVBENCH_TYPE_AXES(fundamental_types, offset_types
   .set_name("cub::DevicePartition::If")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.811", "0.544", "0.337", "0.201", "0.000"});
+  .add_string_axis("Entropy", {"1.000", "0.544", "0.000"});

--- a/benchmarks/bench/radix_sort/keys.cu
+++ b/benchmarks/bench/radix_sort/keys.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <cub/device/device_radix_sort.cuh>
 
 #include <nvbench_helper.cuh>

--- a/benchmarks/bench/radix_sort/pairs.cu
+++ b/benchmarks/bench/radix_sort/pairs.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <cub/device/device_radix_sort.cuh>
 
 #include <nvbench_helper.cuh>

--- a/benchmarks/bench/reduce/base.cuh
+++ b/benchmarks/bench/reduce/base.cuh
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <cub/device/device_reduce.cuh>
 
 #ifndef TUNE_BASE

--- a/benchmarks/bench/reduce/by_key.cu
+++ b/benchmarks/bench/reduce/by_key.cu
@@ -1,0 +1,167 @@
+#include "thrust/device_vector.h"
+#include <nvbench_helper.cuh>
+
+// %RANGE% TUNE_ITEMS ipt 7:24:1
+// %RANGE% TUNE_THREADS tpb 128:1024:32
+// %RANGE% TUNE_TRANSPOSE trp 0:1:1
+// %RANGE% TUNE_LOAD ld 0:1:1
+// %RANGE% CUB_DETAIL_L2_BACKOFF_NS l2b 0:1200:5
+// %RANGE% CUB_DETAIL_L2_WRITE_LATENCY_NS l2w 0:1200:5
+
+#if !TUNE_BASE
+#if TUNE_TRANSPOSE == 0
+#define TUNE_LOAD_ALGORITHM cub::BLOCK_LOAD_DIRECT
+#else // TUNE_TRANSPOSE == 1
+#define TUNE_LOAD_ALGORITHM cub::BLOCK_LOAD_WARP_TRANSPOSE
+#endif // TUNE_TRANSPOSE
+
+#if TUNE_LOAD == 0
+#define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
+#else // TUNE_LOAD == 1
+#define TUNE_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_LOAD
+
+struct device_reduce_by_key_policy_hub
+{
+  struct Policy350 : cub::ChainedPolicy<350, Policy350, Policy350>
+  {
+    using ReduceByKeyPolicyT = cub::AgentReduceByKeyPolicy<TUNE_THREADS,
+                                                           TUNE_ITEMS,
+                                                           TUNE_LOAD_ALGORITHM,
+                                                           TUNE_LOAD_MODIFIER,
+                                                           cub::BLOCK_SCAN_WARP_SCANS>;
+  };
+
+  using MaxPolicy = Policy350;
+};
+#endif // !TUNE_BASE
+
+#include <cub/device/device_reduce.cuh>
+
+template <class KeyT, class ValueT, class OffsetT>
+static void reduce(nvbench::state &state, nvbench::type_list<KeyT, ValueT, OffsetT>)
+{
+  using keys_input_it_t = const KeyT*;
+  using unique_output_it_t = KeyT*;
+  using vals_input_it_t = const ValueT*;
+  using aggregate_output_it_t = ValueT*;
+  using num_runs_output_iterator_t = OffsetT*;
+  using equality_op_t = cub::Equality;
+  using reduction_op_t = cub::Sum;
+  using accum_t = ValueT;
+  using offset_t = OffsetT;
+
+  #if !TUNE_BASE
+  using dispatch_t = cub::DispatchReduceByKey<keys_input_it_t,
+                                              unique_output_it_t,
+                                              vals_input_it_t,
+                                              aggregate_output_it_t,
+                                              num_runs_output_iterator_t,
+                                              equality_op_t,
+                                              reduction_op_t,
+                                              offset_t,
+                                              accum_t,
+                                              device_reduce_by_key_policy_hub>;
+  #else
+  using dispatch_t = cub::DispatchReduceByKey<keys_input_it_t,
+                                              unique_output_it_t,
+                                              vals_input_it_t,
+                                              aggregate_output_it_t,
+                                              num_runs_output_iterator_t,
+                                              equality_op_t,
+                                              reduction_op_t,
+                                              offset_t,
+                                              accum_t>;
+  #endif
+
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
+  const std::size_t min_segment_size = 1;
+  const std::size_t max_segment_size = static_cast<std::size_t>(state.get_int64("MaxSegSize"));
+
+  thrust::device_vector<OffsetT> num_runs_out(1);
+  thrust::device_vector<ValueT> in_vals(elements);
+  thrust::device_vector<ValueT> out_vals(elements);
+  thrust::device_vector<KeyT> out_keys(elements);
+  thrust::device_vector<KeyT> in_keys =
+    gen_uniform_key_segments<KeyT>(seed_t{}, elements, min_segment_size, max_segment_size);
+
+  KeyT *d_in_keys         = thrust::raw_pointer_cast(in_keys.data());
+  KeyT *d_out_keys        = thrust::raw_pointer_cast(out_keys.data());
+  ValueT *d_in_vals       = thrust::raw_pointer_cast(in_vals.data());
+  ValueT *d_out_vals      = thrust::raw_pointer_cast(out_vals.data());
+  OffsetT *d_num_runs_out = thrust::raw_pointer_cast(num_runs_out.data());
+
+  std::uint8_t *d_temp_storage{};
+  std::size_t temp_storage_bytes{};
+
+  dispatch_t::Dispatch(d_temp_storage,
+                       temp_storage_bytes,
+                       d_in_keys,
+                       d_out_keys,
+                       d_in_vals,
+                       d_out_vals,
+                       d_num_runs_out,
+                       equality_op_t{},
+                       reduction_op_t{},
+                       elements,
+                       0);
+
+  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  dispatch_t::Dispatch(d_temp_storage,
+                       temp_storage_bytes,
+                       d_in_keys,
+                       d_out_keys,
+                       d_in_vals,
+                       d_out_vals,
+                       d_num_runs_out,
+                       equality_op_t{},
+                       reduction_op_t{},
+                       elements,
+                       0);
+  cudaDeviceSynchronize();
+  const OffsetT num_runs = num_runs_out[0];
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<KeyT>(elements);
+  state.add_global_memory_reads<ValueT>(elements);
+  state.add_global_memory_writes<ValueT>(num_runs);
+  state.add_global_memory_writes<OffsetT>(1);
+
+  std::cout << "runs: " << num_runs << std::endl;
+
+  state.exec([&](nvbench::launch &launch) {
+    dispatch_t::Dispatch(d_temp_storage,
+                         temp_storage_bytes,
+                         d_in_keys,
+                         d_out_keys,
+                         d_in_vals,
+                         d_out_vals,
+                         d_num_runs_out,
+                         equality_op_t{},
+                         reduction_op_t{},
+                         elements,
+                         launch.get_stream());
+  });
+}
+
+using some_offset_types = nvbench::type_list<nvbench::int32_t>;
+
+#ifdef TUNE_KeyT
+using key_types = nvbench::type_list<TUNE_KeyT>;
+#else // !defined(TUNE_KeyT)
+using key_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t, int128_t>;
+#endif // TUNE_KeyT
+
+#ifdef TUNE_ValueT
+using value_types = nvbench::type_list<TUNE_ValueT>;
+#else // !defined(TUNE_ValueT)
+using value_types = all_types;
+#endif // TUNE_ValueT
+
+NVBENCH_BENCH_TYPES(reduce, NVBENCH_TYPE_AXES(key_types, value_types, some_offset_types))
+  .set_name("cub::DeviceReduce::ReduceByKey")
+  .set_type_axes_names({"KeyT{ct}", "ValueT{ct}", "OffsetT{ct}"})
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
+  .add_int64_power_of_two_axis("MaxSegSize", {1, 4, 8});

--- a/benchmarks/bench/reduce/by_key.cu
+++ b/benchmarks/bench/reduce/by_key.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1

--- a/benchmarks/bench/reduce/max.cu
+++ b/benchmarks/bench/reduce/max.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS_PER_THREAD ipt 7:24:1

--- a/benchmarks/bench/reduce/sum.cu
+++ b/benchmarks/bench/reduce/sum.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS_PER_THREAD ipt 7:24:1

--- a/benchmarks/bench/run_length_encode/encode.cu
+++ b/benchmarks/bench/run_length_encode/encode.cu
@@ -1,3 +1,5 @@
+#include <cub/device/device_run_length_encode.cuh>
+
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
@@ -34,8 +36,6 @@ struct device_reduce_by_key_policy_hub
   using MaxPolicy = Policy350;
 };
 #endif // !TUNE_BASE
-
-#include <cub/device/device_run_length_encode.cuh>
 
 template <class T, class OffsetT>
 static void rle(nvbench::state &state, nvbench::type_list<T, OffsetT>)

--- a/benchmarks/bench/run_length_encode/encode.cu
+++ b/benchmarks/bench/run_length_encode/encode.cu
@@ -35,20 +35,20 @@ struct device_reduce_by_key_policy_hub
 };
 #endif // !TUNE_BASE
 
-#include <cub/device/device_reduce.cuh>
+#include <cub/device/device_run_length_encode.cuh>
 
-template <class KeyT, class ValueT, class OffsetT>
-static void reduce(nvbench::state &state, nvbench::type_list<KeyT, ValueT, OffsetT>)
+template <class T, class OffsetT>
+static void rle(nvbench::state &state, nvbench::type_list<T, OffsetT>)
 {
-  using keys_input_it_t = const KeyT*;
-  using unique_output_it_t = KeyT*;
-  using vals_input_it_t = const ValueT*;
-  using aggregate_output_it_t = ValueT*;
-  using num_runs_output_iterator_t = OffsetT*;
+  using offset_t = OffsetT;
+  using keys_input_it_t = const T*;
+  using unique_output_it_t = T*;
+  using vals_input_it_t = cub::ConstantInputIterator<offset_t, OffsetT>;
+  using aggregate_output_it_t = offset_t*;
+  using num_runs_output_iterator_t = offset_t*;
   using equality_op_t = cub::Equality;
   using reduction_op_t = cub::Sum;
-  using accum_t = ValueT;
-  using offset_t = OffsetT;
+  using accum_t = offset_t;
 
   #if !TUNE_BASE
   using dispatch_t = cub::DispatchReduceByKey<keys_input_it_t,
@@ -77,18 +77,17 @@ static void reduce(nvbench::state &state, nvbench::type_list<KeyT, ValueT, Offse
   const std::size_t min_segment_size = 1;
   const std::size_t max_segment_size = static_cast<std::size_t>(state.get_int64("MaxSegSize"));
 
-  thrust::device_vector<OffsetT> num_runs_out(1);
-  thrust::device_vector<ValueT> in_vals(elements);
-  thrust::device_vector<ValueT> out_vals(elements);
-  thrust::device_vector<KeyT> out_keys(elements);
-  thrust::device_vector<KeyT> in_keys =
-    gen_uniform_key_segments<KeyT>(seed_t{}, elements, min_segment_size, max_segment_size);
+  thrust::device_vector<offset_t> num_runs_out(1);
+  thrust::device_vector<offset_t> out_vals(elements);
+  thrust::device_vector<T> out_keys(elements);
+  thrust::device_vector<T> in_keys =
+    gen_uniform_key_segments<T>(seed_t{}, elements, min_segment_size, max_segment_size);
 
-  KeyT *d_in_keys         = thrust::raw_pointer_cast(in_keys.data());
-  KeyT *d_out_keys        = thrust::raw_pointer_cast(out_keys.data());
-  ValueT *d_in_vals       = thrust::raw_pointer_cast(in_vals.data());
-  ValueT *d_out_vals      = thrust::raw_pointer_cast(out_vals.data());
-  OffsetT *d_num_runs_out = thrust::raw_pointer_cast(num_runs_out.data());
+  T *d_in_keys             = thrust::raw_pointer_cast(in_keys.data());
+  T *d_out_keys            = thrust::raw_pointer_cast(out_keys.data());
+  offset_t *d_out_vals     = thrust::raw_pointer_cast(out_vals.data());
+  offset_t *d_num_runs_out = thrust::raw_pointer_cast(num_runs_out.data());
+  vals_input_it_t d_in_vals(offset_t{1});
 
   std::uint8_t *d_temp_storage{};
   std::size_t temp_storage_bytes{};
@@ -123,10 +122,9 @@ static void reduce(nvbench::state &state, nvbench::type_list<KeyT, ValueT, Offse
   const OffsetT num_runs = num_runs_out[0];
 
   state.add_element_count(elements);
-  state.add_global_memory_reads<KeyT>(elements);
-  state.add_global_memory_reads<ValueT>(elements);
-  state.add_global_memory_writes<ValueT>(num_runs);
-  state.add_global_memory_writes<KeyT>(num_runs);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(num_runs);
+  state.add_global_memory_writes<OffsetT>(num_runs);
   state.add_global_memory_writes<OffsetT>(1);
 
   state.exec([&](nvbench::launch &launch) {
@@ -146,20 +144,8 @@ static void reduce(nvbench::state &state, nvbench::type_list<KeyT, ValueT, Offse
 
 using some_offset_types = nvbench::type_list<nvbench::int32_t>;
 
-#ifdef TUNE_KeyT
-using key_types = nvbench::type_list<TUNE_KeyT>;
-#else // !defined(TUNE_KeyT)
-using key_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t, int128_t>;
-#endif // TUNE_KeyT
-
-#ifdef TUNE_ValueT
-using value_types = nvbench::type_list<TUNE_ValueT>;
-#else // !defined(TUNE_ValueT)
-using value_types = all_types;
-#endif // TUNE_ValueT
-
-NVBENCH_BENCH_TYPES(reduce, NVBENCH_TYPE_AXES(key_types, value_types, some_offset_types))
-  .set_name("cub::DeviceReduce::ReduceByKey")
-  .set_type_axes_names({"KeyT{ct}", "ValueT{ct}", "OffsetT{ct}"})
+NVBENCH_BENCH_TYPES(rle, NVBENCH_TYPE_AXES(all_types, some_offset_types))
+  .set_name("cub::DeviceRunLengthEncode::Encode")
+  .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
   .add_int64_power_of_two_axis("MaxSegSize", {1, 4, 8});

--- a/benchmarks/bench/run_length_encode/encode.cu
+++ b/benchmarks/bench/run_length_encode/encode.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <cub/device/device_run_length_encode.cuh>
 
 #include <nvbench_helper.cuh>

--- a/benchmarks/bench/run_length_encode/non_trivial_runs.cu
+++ b/benchmarks/bench/run_length_encode/non_trivial_runs.cu
@@ -1,3 +1,5 @@
+#include <cub/device/device_run_length_encode.cuh>
+
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
@@ -7,8 +9,6 @@
 // %RANGE% TUNE_LOAD ld 0:1:1
 // %RANGE% CUB_DETAIL_L2_BACKOFF_NS l2b 0:1200:5
 // %RANGE% CUB_DETAIL_L2_WRITE_LATENCY_NS l2w 0:1200:5
-
-#include <cub/device/device_run_length_encode.cuh>
 
 #if !TUNE_BASE
 #if TUNE_TRANSPOSE == 0

--- a/benchmarks/bench/run_length_encode/non_trivial_runs.cu
+++ b/benchmarks/bench/run_length_encode/non_trivial_runs.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <cub/device/device_run_length_encode.cuh>
 
 #include <nvbench_helper.cuh>

--- a/benchmarks/bench/run_length_encode/non_trivial_runs.cu
+++ b/benchmarks/bench/run_length_encode/non_trivial_runs.cu
@@ -1,0 +1,138 @@
+#include <nvbench_helper.cuh>
+
+// %RANGE% TUNE_ITEMS ipt 7:24:1
+// %RANGE% TUNE_THREADS tpb 128:1024:32
+// %RANGE% TUNE_TRANSPOSE trp 0:1:1
+// %RANGE% TUNE_TIME_SLICING ts 0:1:1
+// %RANGE% TUNE_LOAD ld 0:1:1
+// %RANGE% CUB_DETAIL_L2_BACKOFF_NS l2b 0:1200:5
+// %RANGE% CUB_DETAIL_L2_WRITE_LATENCY_NS l2w 0:1200:5
+
+#include <cub/device/device_run_length_encode.cuh>
+
+#if !TUNE_BASE
+#if TUNE_TRANSPOSE == 0
+#define TUNE_LOAD_ALGORITHM cub::BLOCK_LOAD_DIRECT
+#else // TUNE_TRANSPOSE == 1
+#define TUNE_LOAD_ALGORITHM cub::BLOCK_LOAD_WARP_TRANSPOSE
+#endif // TUNE_TRANSPOSE
+
+#if TUNE_LOAD == 0
+#define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
+#else // TUNE_LOAD == 1
+#define TUNE_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_LOAD
+
+struct device_rle_policy_hub
+{
+  struct Policy350 : cub::ChainedPolicy<350, Policy350, Policy350>
+  {
+    using RleSweepPolicyT = cub::AgentRlePolicy<TUNE_THREADS,
+                                                TUNE_ITEMS,
+                                                TUNE_LOAD_ALGORITHM,
+                                                TUNE_LOAD_MODIFIER,
+                                                TUNE_TIME_SLICING,
+                                                cub::BLOCK_SCAN_WARP_SCANS>;
+  };
+
+  using MaxPolicy = Policy350;
+};
+#endif // !TUNE_BASE
+
+template <class T, class OffsetT>
+static void rle(nvbench::state &state, nvbench::type_list<T, OffsetT>)
+{
+  using offset_t = OffsetT;
+  using keys_input_it_t = const T*;
+  using offset_output_it_t = offset_t*;
+  using length_output_it_t = offset_t*;
+  using num_runs_output_iterator_t = offset_t*;
+  using equality_op_t = cub::Equality;
+  using accum_t = offset_t;
+
+  #if !TUNE_BASE
+  using dispatch_t = cub::DeviceRleDispatch<keys_input_it_t,
+                                            offset_output_it_t,
+                                            length_output_it_t,
+                                            num_runs_output_iterator_t,
+                                            equality_op_t,
+                                            offset_t,
+                                            device_rle_policy_hub>;
+  #else
+  using dispatch_t = cub::DeviceRleDispatch<keys_input_it_t,
+                                            offset_output_it_t,
+                                            length_output_it_t,
+                                            num_runs_output_iterator_t,
+                                            equality_op_t,
+                                            offset_t>;
+  #endif
+
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
+  const std::size_t min_segment_size = 1;
+  const std::size_t max_segment_size = static_cast<std::size_t>(state.get_int64("MaxSegSize"));
+
+  thrust::device_vector<offset_t> num_runs_out(1);
+  thrust::device_vector<offset_t> out_offsets(elements);
+  thrust::device_vector<offset_t> out_lengths(elements);
+  thrust::device_vector<T> in_keys =
+    gen_uniform_key_segments<T>(seed_t{}, elements, min_segment_size, max_segment_size);
+
+  T *d_in_keys             = thrust::raw_pointer_cast(in_keys.data());
+  offset_t *d_out_offsets  = thrust::raw_pointer_cast(out_offsets.data());
+  offset_t *d_out_lengths  = thrust::raw_pointer_cast(out_lengths.data());
+  offset_t *d_num_runs_out = thrust::raw_pointer_cast(num_runs_out.data());
+
+  std::uint8_t *d_temp_storage{};
+  std::size_t temp_storage_bytes{};
+
+  dispatch_t::Dispatch(d_temp_storage,
+                       temp_storage_bytes,
+                       d_in_keys,
+                       d_out_offsets,
+                       d_out_lengths,
+                       d_num_runs_out,
+                       equality_op_t{},
+                       elements,
+                       0);
+
+  thrust::device_vector<std::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  dispatch_t::Dispatch(d_temp_storage,
+                       temp_storage_bytes,
+                       d_in_keys,
+                       d_out_offsets,
+                       d_out_lengths,
+                       d_num_runs_out,
+                       equality_op_t{},
+                       elements,
+                       0);
+  cudaDeviceSynchronize();
+  const OffsetT num_runs = num_runs_out[0];
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<OffsetT>(num_runs);
+  state.add_global_memory_writes<OffsetT>(num_runs);
+  state.add_global_memory_writes<OffsetT>(1);
+
+  state.exec([&](nvbench::launch &launch) {
+    dispatch_t::Dispatch(d_temp_storage,
+                         temp_storage_bytes,
+                         d_in_keys,
+                         d_out_offsets,
+                         d_out_lengths,
+                         d_num_runs_out,
+                         equality_op_t{},
+                         elements,
+                         launch.get_stream());
+  });
+}
+
+using some_offset_types = nvbench::type_list<nvbench::int32_t>;
+
+NVBENCH_BENCH_TYPES(rle, NVBENCH_TYPE_AXES(all_types, some_offset_types))
+  .set_name("cub::DeviceRunLengthEncode::Encode")
+  .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
+  .add_int64_power_of_two_axis("MaxSegSize", {1, 4, 8});

--- a/benchmarks/bench/scan/exclusive/base.cuh
+++ b/benchmarks/bench/scan/exclusive/base.cuh
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <cub/device/device_scan.cuh>
 
 #include <type_traits>

--- a/benchmarks/bench/scan/exclusive/by_key.cu
+++ b/benchmarks/bench/scan/exclusive/by_key.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <cub/device/device_scan.cuh>
 
 #include <type_traits>

--- a/benchmarks/bench/scan/exclusive/by_key.cu
+++ b/benchmarks/bench/scan/exclusive/by_key.cu
@@ -62,11 +62,10 @@ static void scan(nvbench::state &state, nvbench::type_list<KeyT, ValueT, OffsetT
   #endif // TUNE_BASE
 
   const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
-  const auto segments = 2 * elements / 100; // 2% of elements
 
   thrust::device_vector<ValueT> in_vals(elements);
   thrust::device_vector<ValueT> out_vals(elements);
-  thrust::device_vector<KeyT> keys = gen_power_law_key_segments<KeyT>(seed_t{}, elements, segments);
+  thrust::device_vector<KeyT> keys = gen_uniform_key_segments<KeyT>(seed_t{}, elements, 0, 5200);
 
   KeyT *d_keys       = thrust::raw_pointer_cast(keys.data());
   ValueT *d_in_vals  = thrust::raw_pointer_cast(in_vals.data());

--- a/benchmarks/bench/scan/exclusive/by_key.cu
+++ b/benchmarks/bench/scan/exclusive/by_key.cu
@@ -1,13 +1,13 @@
+#include <cub/device/device_scan.cuh>
+
+#include <type_traits>
+
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1
 // %RANGE% TUNE_THREADS tpb 128:1024:32
 // %RANGE% CUB_DETAIL_L2_BACKOFF_NS l2b 0:1200:5
 // %RANGE% CUB_DETAIL_L2_WRITE_LATENCY_NS l2w 0:1200:5
-
-#include <cub/device/device_scan.cuh>
-
-#include <type_traits>
 
 #if !TUNE_BASE
 struct policy_hub_t

--- a/benchmarks/bench/scan/exclusive/max.cu
+++ b/benchmarks/bench/scan/exclusive/max.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_ITEMS ipt 7:24:1

--- a/benchmarks/bench/scan/exclusive/sum.cu
+++ b/benchmarks/bench/scan/exclusive/sum.cu
@@ -1,9 +1,36 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include <nvbench_helper.cuh>
+
 // %RANGE% TUNE_ITEMS ipt 7:24:1
 // %RANGE% TUNE_THREADS tpb 128:1024:32
 // %RANGE% CUB_DETAIL_L2_BACKOFF_NS l2b 0:1200:5
 // %RANGE% CUB_DETAIL_L2_WRITE_LATENCY_NS l2w 0:1200:5
-
-#include <nvbench_helper.cuh>
 
 using op_t = cub::Sum;
 #include "base.cuh"

--- a/benchmarks/bench/segmented_sort/large/keys.cu
+++ b/benchmarks/bench/segmented_sort/large/keys.cu
@@ -1,0 +1,240 @@
+#include <nvbench_helper.cuh>
+
+// %RANGE% TUNE_L_ITEMS ipt 7:24:1
+// %RANGE% TUNE_M_ITEMS ipmw 1:17:1
+// %RANGE% TUNE_S_ITEMS ipsw 1:17:1
+// %RANGE% TUNE_THREADS tpb 128:1024:32
+// %RANGE% TUNE_SW_THREADS_POW2 tpsw 1:4:1
+// %RANGE% TUNE_MW_THREADS_POW2 tpmw 1:5:1
+// %RANGE% TUNE_RADIX_BITS bits 4:8:1
+// %RANGE% TUNE_PARTITIONING_THRESHOLD pt 100:800:50
+// %RANGE% TUNE_RANK_ALGORITHM ra 0:4:1
+// %RANGE% TUNE_LOAD ld 0:2:1
+// %RANGE% TUNE_TRANSPOSE trp 0:1:1
+// %RANGE% TUNE_S_LOAD sld 0:2:1
+// %RANGE% TUNE_S_TRANSPOSE strp 0:1:1
+// %RANGE% TUNE_M_LOAD mld 0:2:1
+// %RANGE% TUNE_M_TRANSPOSE mtrp 0:1:1
+
+#include <cub/device/device_segmented_sort.cuh>
+
+#if !TUNE_BASE
+
+#define TUNE_SW_THREADS (1 << TUNE_SW_THREADS_POW2)
+#define TUNE_MW_THREADS (1 << TUNE_MW_THREADS_POW2)
+
+#define SMALL_SEGMENT_SIZE TUNE_S_ITEMS * TUNE_SW_THREADS
+#define MEDIUM_SEGMENT_SIZE TUNE_M_ITEMS * TUNE_MW_THREADS
+#define LARGE_SEGMENT_SIZE TUNE_L_ITEMS * TUNE_THREADS
+
+#if (LARGE_SEGMENT_SIZE <= SMALL_SEGMENT_SIZE) || (LARGE_SEGMENT_SIZE <= MEDIUM_SEGMENT_SIZE)
+#error Large segment size must be larger than small and medium segment sizes
+#endif
+
+#if (MEDIUM_SEGMENT_SIZE <= SMALL_SEGMENT_SIZE)
+#error Medium segment size must be larger than small one
+#endif
+
+#if TUNE_LOAD == 0
+#define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
+#elif TUNE_LOAD == 1
+#define TUNE_LOAD_MODIFIER cub::LOAD_LDG
+#else // TUNE_LOAD == 2
+#define TUNE_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_LOAD 
+
+#if TUNE_S_LOAD == 0
+#define TUNE_S_LOAD_MODIFIER cub::LOAD_DEFAULT
+#elif TUNE_S_LOAD == 1
+#define TUNE_S_LOAD_MODIFIER cub::LOAD_LDG
+#else // TUNE_S_LOAD == 2
+#define TUNE_S_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_S_LOAD 
+
+#if TUNE_M_LOAD == 0
+#define TUNE_M_LOAD_MODIFIER cub::LOAD_DEFAULT
+#elif TUNE_M_LOAD == 1
+#define TUNE_M_LOAD_MODIFIER cub::LOAD_LDG
+#else // TUNE_M_LOAD == 2
+#define TUNE_M_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_M_LOAD 
+
+#if TUNE_TRANSPOSE == 0
+#define TUNE_LOAD_ALGORITHM cub::BLOCK_LOAD_DIRECT
+#else // TUNE_TRANSPOSE == 1
+#define TUNE_LOAD_ALGORITHM cub::BLOCK_LOAD_WARP_TRANSPOSE
+#endif // TUNE_TRANSPOSE
+
+#if TUNE_S_TRANSPOSE == 0
+#define TUNE_S_LOAD_ALGORITHM cub::WarpLoadAlgorithm::WARP_LOAD_DIRECT
+#else // TUNE_S_TRANSPOSE == 1
+#define TUNE_S_LOAD_ALGORITHM cub::WarpLoadAlgorithm::WARP_LOAD_TRANSPOSE
+#endif // TUNE_S_TRANSPOSE
+
+#if TUNE_M_TRANSPOSE == 0
+#define TUNE_M_LOAD_ALGORITHM cub::WarpLoadAlgorithm::WARP_LOAD_DIRECT
+#else // TUNE_M_TRANSPOSE == 1
+#define TUNE_M_LOAD_ALGORITHM cub::WarpLoadAlgorithm::WARP_LOAD_TRANSPOSE
+#endif // TUNE_M_TRANSPOSE
+
+template <class KeyT>
+struct device_seg_sort_policy_hub
+{
+  using DominantT = KeyT;
+
+  struct Policy350 : cub::ChainedPolicy<350, Policy350, Policy350>
+  {
+    constexpr static int BLOCK_THREADS          = TUNE_THREADS;
+    constexpr static int RADIX_BITS             = TUNE_RADIX_BITS ;
+    constexpr static int PARTITIONING_THRESHOLD = TUNE_PARTITIONING_THRESHOLD;
+
+    using LargeSegmentPolicy =
+      cub::AgentRadixSortDownsweepPolicy<BLOCK_THREADS,
+                                         TUNE_L_ITEMS,
+                                         DominantT,
+                                         TUNE_LOAD_ALGORITHM,
+                                         TUNE_LOAD_MODIFIER,
+                                         static_cast<cub::RadixRankAlgorithm>(TUNE_RANK_ALGORITHM),
+                                         cub::BLOCK_SCAN_WARP_SCANS,
+                                         RADIX_BITS>;
+
+    constexpr static int ITEMS_PER_SMALL_THREAD = TUNE_S_ITEMS;
+    constexpr static int ITEMS_PER_MEDIUM_THREAD = TUNE_M_ITEMS;
+
+    using SmallAndMediumSegmentedSortPolicyT = cub::AgentSmallAndMediumSegmentedSortPolicy<
+
+      BLOCK_THREADS,
+
+      // Small policy
+      cub::AgentSubWarpMergeSortPolicy<TUNE_SW_THREADS,
+                                       ITEMS_PER_SMALL_THREAD,
+                                       TUNE_S_LOAD_ALGORITHM,
+                                       TUNE_S_LOAD_MODIFIER>,
+
+      // Medium policy
+      cub::AgentSubWarpMergeSortPolicy<TUNE_MW_THREADS,
+                                       ITEMS_PER_MEDIUM_THREAD,
+                                       TUNE_M_LOAD_ALGORITHM,
+                                       TUNE_M_LOAD_MODIFIER>>;
+  };
+
+  using MaxPolicy = Policy350;
+};
+#endif // !TUNE_BASE
+
+#include <fstream>
+#include <thrust/host_vector.h>
+
+template <class T, typename OffsetT>
+void seg_sort(nvbench::state &state, nvbench::type_list<T, OffsetT>)
+{
+  constexpr bool is_descending   = false;
+  constexpr bool is_overwrite_ok = false;
+
+  using offset_t          = OffsetT;
+  using begin_offset_it_t = const offset_t *;
+  using end_offset_it_t   = const offset_t *;
+  using key_t             = T;
+  using value_t           = cub::NullType;
+
+#if !TUNE_BASE
+  using policy_t = device_seg_sort_policy_hub<key_t>;
+  using dispatch_t = //
+    cub::DispatchSegmentedSort<is_descending,
+                               key_t,
+                               value_t,
+                               offset_t,
+                               begin_offset_it_t,
+                               end_offset_it_t,
+                               policy_t>;
+#else
+  using dispatch_t = //
+    cub::DispatchSegmentedSort<is_descending,
+                               key_t,
+                               value_t,
+                               offset_t,
+                               begin_offset_it_t,
+                               end_offset_it_t>;
+#endif
+
+  const auto elements         = static_cast<std::size_t>(state.get_int64("Elements{io}"));
+  const auto max_segment_size = static_cast<std::size_t>(state.get_int64("MaxSegmentSize"));
+
+  const auto max_segment_size_log = static_cast<offset_t>(std::log2(max_segment_size));
+  const auto min_segment_size = 1 << (max_segment_size_log - 1);
+
+  thrust::device_vector<key_t> buffer_1(elements);
+  thrust::device_vector<key_t> buffer_2(elements);
+
+  gen(seed_t{}, buffer_1);
+
+  key_t *d_buffer_1 = thrust::raw_pointer_cast(buffer_1.data());
+  key_t *d_buffer_2 = thrust::raw_pointer_cast(buffer_2.data());
+
+  cub::DoubleBuffer<key_t> d_keys(d_buffer_1, d_buffer_2);
+  cub::DoubleBuffer<value_t> d_values;
+
+  thrust::device_vector<offset_t> offsets =
+    gen_uniform_offsets<offset_t>(seed_t{}, elements, min_segment_size, max_segment_size);
+  const std::size_t segments = offsets.size() - 1;
+
+  thrust::host_vector<offset_t> h_offsets = offsets;
+
+  for (std::size_t i = 0; i < segments; i++)
+  {
+    if (h_offsets[i + 1] < h_offsets[i])
+    {
+      std::cerr << "Invalid segment size: " << h_offsets[i] << " > " << h_offsets[i + 1]
+                << std::endl;
+      std::exit(1);
+    }
+  }
+
+  begin_offset_it_t d_begin_offsets = thrust::raw_pointer_cast(offsets.data());
+  end_offset_it_t d_end_offsets     = d_begin_offsets + 1;
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<key_t>(elements);
+  state.add_global_memory_writes<key_t>(elements);
+  state.add_global_memory_reads<offset_t>(segments + 1);
+
+  std::size_t temp_storage_bytes{};
+  std::uint8_t *d_temp_storage{};
+  dispatch_t::Dispatch(d_temp_storage,
+                       temp_storage_bytes,
+                       d_keys,
+                       d_values,
+                       elements,
+                       segments,
+                       d_begin_offsets,
+                       d_end_offsets,
+                       is_overwrite_ok,
+                       0);
+
+  thrust::device_vector<nvbench::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    cub::DoubleBuffer<key_t> keys     = d_keys;
+    cub::DoubleBuffer<value_t> values = d_values;
+
+    dispatch_t::Dispatch(d_temp_storage,
+                         temp_storage_bytes,
+                         keys,
+                         values,
+                         elements,
+                         segments,
+                         d_begin_offsets,
+                         d_end_offsets,
+                         is_overwrite_ok,
+                         launch.get_stream());
+  });
+}
+
+using some_offset_types = nvbench::type_list<uint32_t>;
+
+NVBENCH_BENCH_TYPES(seg_sort, NVBENCH_TYPE_AXES(fundamental_types, some_offset_types))
+  .set_name("cub::DeviceSegmentedSort::SortKeys")
+  .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(22, 30, 4))
+  .add_int64_power_of_two_axis("MaxSegmentSize", nvbench::range(10, 18, 2));

--- a/benchmarks/bench/segmented_sort/large/keys.cu
+++ b/benchmarks/bench/segmented_sort/large/keys.cu
@@ -1,3 +1,5 @@
+#include <cub/device/device_segmented_sort.cuh>
+
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_L_ITEMS ipt 7:24:1
@@ -15,8 +17,6 @@
 // %RANGE% TUNE_S_TRANSPOSE strp 0:1:1
 // %RANGE% TUNE_M_LOAD mld 0:2:1
 // %RANGE% TUNE_M_TRANSPOSE mtrp 0:1:1
-
-#include <cub/device/device_segmented_sort.cuh>
 
 #if !TUNE_BASE
 

--- a/benchmarks/bench/segmented_sort/large/keys.cu
+++ b/benchmarks/bench/segmented_sort/large/keys.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <cub/device/device_segmented_sort.cuh>
 
 #include <nvbench_helper.cuh>

--- a/benchmarks/bench/segmented_sort/power_law/keys.cu
+++ b/benchmarks/bench/segmented_sort/power_law/keys.cu
@@ -1,3 +1,5 @@
+#include <cub/device/device_segmented_sort.cuh>
+
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_L_ITEMS ipt 7:24:1
@@ -15,8 +17,6 @@
 // %RANGE% TUNE_S_TRANSPOSE strp 0:1:1
 // %RANGE% TUNE_M_LOAD mld 0:2:1
 // %RANGE% TUNE_M_TRANSPOSE mtrp 0:1:1
-
-#include <cub/device/device_segmented_sort.cuh>
 
 #if !TUNE_BASE
 

--- a/benchmarks/bench/segmented_sort/power_law/keys.cu
+++ b/benchmarks/bench/segmented_sort/power_law/keys.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <cub/device/device_segmented_sort.cuh>
 
 #include <nvbench_helper.cuh>

--- a/benchmarks/bench/segmented_sort/power_law/keys.cu
+++ b/benchmarks/bench/segmented_sort/power_law/keys.cu
@@ -1,0 +1,223 @@
+#include <nvbench_helper.cuh>
+
+// %RANGE% TUNE_L_ITEMS ipt 7:24:1
+// %RANGE% TUNE_M_ITEMS ipmw 1:17:1
+// %RANGE% TUNE_S_ITEMS ipsw 1:17:1
+// %RANGE% TUNE_THREADS tpb 128:1024:32
+// %RANGE% TUNE_SW_THREADS_POW2 tpsw 1:4:1
+// %RANGE% TUNE_MW_THREADS_POW2 tpmw 1:5:1
+// %RANGE% TUNE_RADIX_BITS bits 4:8:1
+// %RANGE% TUNE_PARTITIONING_THRESHOLD pt 100:800:50
+// %RANGE% TUNE_RANK_ALGORITHM ra 0:4:1
+// %RANGE% TUNE_LOAD ld 0:2:1
+// %RANGE% TUNE_TRANSPOSE trp 0:1:1
+// %RANGE% TUNE_S_LOAD sld 0:2:1
+// %RANGE% TUNE_S_TRANSPOSE strp 0:1:1
+// %RANGE% TUNE_M_LOAD mld 0:2:1
+// %RANGE% TUNE_M_TRANSPOSE mtrp 0:1:1
+
+#include <cub/device/device_segmented_sort.cuh>
+
+#if !TUNE_BASE
+
+#define TUNE_SW_THREADS (1 << TUNE_SW_THREADS_POW2)
+#define TUNE_MW_THREADS (1 << TUNE_MW_THREADS_POW2)
+
+#define SMALL_SEGMENT_SIZE TUNE_S_ITEMS * TUNE_SW_THREADS
+#define MEDIUM_SEGMENT_SIZE TUNE_M_ITEMS * TUNE_MW_THREADS
+#define LARGE_SEGMENT_SIZE TUNE_L_ITEMS * TUNE_THREADS
+
+#if (LARGE_SEGMENT_SIZE <= SMALL_SEGMENT_SIZE) || (LARGE_SEGMENT_SIZE <= MEDIUM_SEGMENT_SIZE)
+#error Large segment size must be larger than small and medium segment sizes
+#endif
+
+#if (MEDIUM_SEGMENT_SIZE <= SMALL_SEGMENT_SIZE)
+#error Medium segment size must be larger than small one
+#endif
+
+#if TUNE_LOAD == 0
+#define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
+#elif TUNE_LOAD == 1
+#define TUNE_LOAD_MODIFIER cub::LOAD_LDG
+#else // TUNE_LOAD == 2
+#define TUNE_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_LOAD 
+
+#if TUNE_S_LOAD == 0
+#define TUNE_S_LOAD_MODIFIER cub::LOAD_DEFAULT
+#elif TUNE_S_LOAD == 1
+#define TUNE_S_LOAD_MODIFIER cub::LOAD_LDG
+#else // TUNE_S_LOAD == 2
+#define TUNE_S_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_S_LOAD 
+
+#if TUNE_M_LOAD == 0
+#define TUNE_M_LOAD_MODIFIER cub::LOAD_DEFAULT
+#elif TUNE_M_LOAD == 1
+#define TUNE_M_LOAD_MODIFIER cub::LOAD_LDG
+#else // TUNE_M_LOAD == 2
+#define TUNE_M_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_M_LOAD 
+
+#if TUNE_TRANSPOSE == 0
+#define TUNE_LOAD_ALGORITHM cub::BLOCK_LOAD_DIRECT
+#else // TUNE_TRANSPOSE == 1
+#define TUNE_LOAD_ALGORITHM cub::BLOCK_LOAD_WARP_TRANSPOSE
+#endif // TUNE_TRANSPOSE
+
+#if TUNE_S_TRANSPOSE == 0
+#define TUNE_S_LOAD_ALGORITHM cub::WarpLoadAlgorithm::WARP_LOAD_DIRECT
+#else // TUNE_S_TRANSPOSE == 1
+#define TUNE_S_LOAD_ALGORITHM cub::WarpLoadAlgorithm::WARP_LOAD_TRANSPOSE
+#endif // TUNE_S_TRANSPOSE
+
+#if TUNE_M_TRANSPOSE == 0
+#define TUNE_M_LOAD_ALGORITHM cub::WarpLoadAlgorithm::WARP_LOAD_DIRECT
+#else // TUNE_M_TRANSPOSE == 1
+#define TUNE_M_LOAD_ALGORITHM cub::WarpLoadAlgorithm::WARP_LOAD_TRANSPOSE
+#endif // TUNE_M_TRANSPOSE
+
+template <class KeyT>
+struct device_seg_sort_policy_hub
+{
+  using DominantT = KeyT;
+
+  struct Policy350 : cub::ChainedPolicy<350, Policy350, Policy350>
+  {
+    constexpr static int BLOCK_THREADS          = TUNE_THREADS;
+    constexpr static int RADIX_BITS             = TUNE_RADIX_BITS ;
+    constexpr static int PARTITIONING_THRESHOLD = TUNE_PARTITIONING_THRESHOLD;
+
+    using LargeSegmentPolicy =
+      cub::AgentRadixSortDownsweepPolicy<BLOCK_THREADS,
+                                         TUNE_L_ITEMS,
+                                         DominantT,
+                                         TUNE_LOAD_ALGORITHM,
+                                         TUNE_LOAD_MODIFIER,
+                                         static_cast<cub::RadixRankAlgorithm>(TUNE_RANK_ALGORITHM),
+                                         cub::BLOCK_SCAN_WARP_SCANS,
+                                         RADIX_BITS>;
+
+    constexpr static int ITEMS_PER_SMALL_THREAD = TUNE_S_ITEMS;
+    constexpr static int ITEMS_PER_MEDIUM_THREAD = TUNE_M_ITEMS;
+
+    using SmallAndMediumSegmentedSortPolicyT = cub::AgentSmallAndMediumSegmentedSortPolicy<
+
+      BLOCK_THREADS,
+
+      // Small policy
+      cub::AgentSubWarpMergeSortPolicy<TUNE_SW_THREADS,
+                                       ITEMS_PER_SMALL_THREAD,
+                                       TUNE_S_LOAD_ALGORITHM,
+                                       TUNE_S_LOAD_MODIFIER>,
+
+      // Medium policy
+      cub::AgentSubWarpMergeSortPolicy<TUNE_MW_THREADS,
+                                       ITEMS_PER_MEDIUM_THREAD,
+                                       TUNE_M_LOAD_ALGORITHM,
+                                       TUNE_M_LOAD_MODIFIER>>;
+  };
+
+  using MaxPolicy = Policy350;
+};
+#endif // !TUNE_BASE
+
+template <class T, typename OffsetT>
+void seg_sort(nvbench::state &state, nvbench::type_list<T, OffsetT>)
+{
+  constexpr bool is_descending   = false;
+  constexpr bool is_overwrite_ok = false;
+
+  using offset_t          = OffsetT;
+  using begin_offset_it_t = const offset_t *;
+  using end_offset_it_t   = const offset_t *;
+  using key_t             = T;
+  using value_t           = cub::NullType;
+
+#if !TUNE_BASE
+  using policy_t = device_seg_sort_policy_hub<key_t>;
+  using dispatch_t = //
+    cub::DispatchSegmentedSort<is_descending,
+                               key_t,
+                               value_t,
+                               offset_t,
+                               begin_offset_it_t,
+                               end_offset_it_t,
+                               policy_t>;
+#else
+  using dispatch_t = //
+    cub::DispatchSegmentedSort<is_descending,
+                               key_t,
+                               value_t,
+                               offset_t,
+                               begin_offset_it_t,
+                               end_offset_it_t>;
+#endif
+
+  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements{io}"));
+  const auto segments       = static_cast<std::size_t>(state.get_int64("Segments{io}"));
+  const bit_entropy entropy = str_to_entropy(state.get_string("Entropy"));
+
+  thrust::device_vector<key_t> buffer_1(elements);
+  thrust::device_vector<key_t> buffer_2(elements);
+
+  gen(seed_t{}, buffer_1, entropy);
+
+  key_t *d_buffer_1 = thrust::raw_pointer_cast(buffer_1.data());
+  key_t *d_buffer_2 = thrust::raw_pointer_cast(buffer_2.data());
+
+  cub::DoubleBuffer<key_t> d_keys(d_buffer_1, d_buffer_2);
+  cub::DoubleBuffer<value_t> d_values;
+
+  thrust::device_vector<offset_t> offsets =
+    gen_power_law_offsets<offset_t>(seed_t{}, elements, segments);
+
+  begin_offset_it_t d_begin_offsets = thrust::raw_pointer_cast(offsets.data());
+  end_offset_it_t d_end_offsets     = d_begin_offsets + 1;
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<key_t>(elements);
+  state.add_global_memory_writes<key_t>(elements);
+  state.add_global_memory_reads<offset_t>(segments + 1);
+
+  std::size_t temp_storage_bytes{};
+  std::uint8_t *d_temp_storage{};
+  dispatch_t::Dispatch(d_temp_storage,
+                       temp_storage_bytes,
+                       d_keys,
+                       d_values,
+                       elements,
+                       segments,
+                       d_begin_offsets,
+                       d_end_offsets,
+                       is_overwrite_ok,
+                       0);
+
+  thrust::device_vector<nvbench::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    cub::DoubleBuffer<key_t> keys     = d_keys;
+    cub::DoubleBuffer<value_t> values = d_values;
+
+    dispatch_t::Dispatch(d_temp_storage,
+                         temp_storage_bytes,
+                         keys,
+                         values,
+                         elements,
+                         segments,
+                         d_begin_offsets,
+                         d_end_offsets,
+                         is_overwrite_ok,
+                         launch.get_stream());
+  });
+}
+
+using some_offset_types = nvbench::type_list<uint32_t>;
+
+NVBENCH_BENCH_TYPES(seg_sort, NVBENCH_TYPE_AXES(fundamental_types, some_offset_types))
+  .set_name("cub::DeviceSegmentedSort::SortKeys")
+  .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(22, 30, 4))
+  .add_int64_power_of_two_axis("Segments{io}", nvbench::range(12, 20, 4))
+  .add_string_axis("Entropy", {"1.000", "0.544", "0.201"});

--- a/benchmarks/bench/segmented_sort/small/keys.cu
+++ b/benchmarks/bench/segmented_sort/small/keys.cu
@@ -1,0 +1,240 @@
+#include <nvbench_helper.cuh>
+
+// %RANGE% TUNE_L_ITEMS ipt 7:24:1
+// %RANGE% TUNE_M_ITEMS ipmw 1:17:1
+// %RANGE% TUNE_S_ITEMS ipsw 1:17:1
+// %RANGE% TUNE_THREADS tpb 128:1024:32
+// %RANGE% TUNE_SW_THREADS_POW2 tpsw 1:4:1
+// %RANGE% TUNE_MW_THREADS_POW2 tpmw 1:5:1
+// %RANGE% TUNE_RADIX_BITS bits 4:8:1
+// %RANGE% TUNE_PARTITIONING_THRESHOLD pt 100:800:50
+// %RANGE% TUNE_RANK_ALGORITHM ra 0:4:1
+// %RANGE% TUNE_LOAD ld 0:2:1
+// %RANGE% TUNE_TRANSPOSE trp 0:1:1
+// %RANGE% TUNE_S_LOAD sld 0:2:1
+// %RANGE% TUNE_S_TRANSPOSE strp 0:1:1
+// %RANGE% TUNE_M_LOAD mld 0:2:1
+// %RANGE% TUNE_M_TRANSPOSE mtrp 0:1:1
+
+#include <cub/device/device_segmented_sort.cuh>
+
+#if !TUNE_BASE
+
+#define TUNE_SW_THREADS (1 << TUNE_SW_THREADS_POW2)
+#define TUNE_MW_THREADS (1 << TUNE_MW_THREADS_POW2)
+
+#define SMALL_SEGMENT_SIZE TUNE_S_ITEMS * TUNE_SW_THREADS
+#define MEDIUM_SEGMENT_SIZE TUNE_M_ITEMS * TUNE_MW_THREADS
+#define LARGE_SEGMENT_SIZE TUNE_L_ITEMS * TUNE_THREADS
+
+#if (LARGE_SEGMENT_SIZE <= SMALL_SEGMENT_SIZE) || (LARGE_SEGMENT_SIZE <= MEDIUM_SEGMENT_SIZE)
+#error Large segment size must be larger than small and medium segment sizes
+#endif
+
+#if (MEDIUM_SEGMENT_SIZE <= SMALL_SEGMENT_SIZE)
+#error Medium segment size must be larger than small one
+#endif
+
+#if TUNE_LOAD == 0
+#define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
+#elif TUNE_LOAD == 1
+#define TUNE_LOAD_MODIFIER cub::LOAD_LDG
+#else // TUNE_LOAD == 2
+#define TUNE_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_LOAD 
+
+#if TUNE_S_LOAD == 0
+#define TUNE_S_LOAD_MODIFIER cub::LOAD_DEFAULT
+#elif TUNE_S_LOAD == 1
+#define TUNE_S_LOAD_MODIFIER cub::LOAD_LDG
+#else // TUNE_S_LOAD == 2
+#define TUNE_S_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_S_LOAD 
+
+#if TUNE_M_LOAD == 0
+#define TUNE_M_LOAD_MODIFIER cub::LOAD_DEFAULT
+#elif TUNE_M_LOAD == 1
+#define TUNE_M_LOAD_MODIFIER cub::LOAD_LDG
+#else // TUNE_M_LOAD == 2
+#define TUNE_M_LOAD_MODIFIER cub::LOAD_CA
+#endif // TUNE_M_LOAD 
+
+#if TUNE_TRANSPOSE == 0
+#define TUNE_LOAD_ALGORITHM cub::BLOCK_LOAD_DIRECT
+#else // TUNE_TRANSPOSE == 1
+#define TUNE_LOAD_ALGORITHM cub::BLOCK_LOAD_WARP_TRANSPOSE
+#endif // TUNE_TRANSPOSE
+
+#if TUNE_S_TRANSPOSE == 0
+#define TUNE_S_LOAD_ALGORITHM cub::WarpLoadAlgorithm::WARP_LOAD_DIRECT
+#else // TUNE_S_TRANSPOSE == 1
+#define TUNE_S_LOAD_ALGORITHM cub::WarpLoadAlgorithm::WARP_LOAD_TRANSPOSE
+#endif // TUNE_S_TRANSPOSE
+
+#if TUNE_M_TRANSPOSE == 0
+#define TUNE_M_LOAD_ALGORITHM cub::WarpLoadAlgorithm::WARP_LOAD_DIRECT
+#else // TUNE_M_TRANSPOSE == 1
+#define TUNE_M_LOAD_ALGORITHM cub::WarpLoadAlgorithm::WARP_LOAD_TRANSPOSE
+#endif // TUNE_M_TRANSPOSE
+
+template <class KeyT>
+struct device_seg_sort_policy_hub
+{
+  using DominantT = KeyT;
+
+  struct Policy350 : cub::ChainedPolicy<350, Policy350, Policy350>
+  {
+    constexpr static int BLOCK_THREADS          = TUNE_THREADS;
+    constexpr static int RADIX_BITS             = TUNE_RADIX_BITS ;
+    constexpr static int PARTITIONING_THRESHOLD = TUNE_PARTITIONING_THRESHOLD;
+
+    using LargeSegmentPolicy =
+      cub::AgentRadixSortDownsweepPolicy<BLOCK_THREADS,
+                                         TUNE_L_ITEMS,
+                                         DominantT,
+                                         TUNE_LOAD_ALGORITHM,
+                                         TUNE_LOAD_MODIFIER,
+                                         static_cast<cub::RadixRankAlgorithm>(TUNE_RANK_ALGORITHM),
+                                         cub::BLOCK_SCAN_WARP_SCANS,
+                                         RADIX_BITS>;
+
+    constexpr static int ITEMS_PER_SMALL_THREAD = TUNE_S_ITEMS;
+    constexpr static int ITEMS_PER_MEDIUM_THREAD = TUNE_M_ITEMS;
+
+    using SmallAndMediumSegmentedSortPolicyT = cub::AgentSmallAndMediumSegmentedSortPolicy<
+
+      BLOCK_THREADS,
+
+      // Small policy
+      cub::AgentSubWarpMergeSortPolicy<TUNE_SW_THREADS,
+                                       ITEMS_PER_SMALL_THREAD,
+                                       TUNE_S_LOAD_ALGORITHM,
+                                       TUNE_S_LOAD_MODIFIER>,
+
+      // Medium policy
+      cub::AgentSubWarpMergeSortPolicy<TUNE_MW_THREADS,
+                                       ITEMS_PER_MEDIUM_THREAD,
+                                       TUNE_M_LOAD_ALGORITHM,
+                                       TUNE_M_LOAD_MODIFIER>>;
+  };
+
+  using MaxPolicy = Policy350;
+};
+#endif // !TUNE_BASE
+
+#include <fstream>
+#include <thrust/host_vector.h>
+
+template <class T, typename OffsetT>
+void seg_sort(nvbench::state &state, nvbench::type_list<T, OffsetT>)
+{
+  constexpr bool is_descending   = false;
+  constexpr bool is_overwrite_ok = false;
+
+  using offset_t          = OffsetT;
+  using begin_offset_it_t = const offset_t *;
+  using end_offset_it_t   = const offset_t *;
+  using key_t             = T;
+  using value_t           = cub::NullType;
+
+#if !TUNE_BASE
+  using policy_t = device_seg_sort_policy_hub<key_t>;
+  using dispatch_t = //
+    cub::DispatchSegmentedSort<is_descending,
+                               key_t,
+                               value_t,
+                               offset_t,
+                               begin_offset_it_t,
+                               end_offset_it_t,
+                               policy_t>;
+#else
+  using dispatch_t = //
+    cub::DispatchSegmentedSort<is_descending,
+                               key_t,
+                               value_t,
+                               offset_t,
+                               begin_offset_it_t,
+                               end_offset_it_t>;
+#endif
+
+  const auto elements         = static_cast<std::size_t>(state.get_int64("Elements{io}"));
+  const auto max_segment_size = static_cast<std::size_t>(state.get_int64("MaxSegmentSize"));
+
+  const auto max_segment_size_log = static_cast<offset_t>(std::log2(max_segment_size));
+  const auto min_segment_size = 1 << (max_segment_size_log - 1);
+
+  thrust::device_vector<key_t> buffer_1(elements);
+  thrust::device_vector<key_t> buffer_2(elements);
+
+  gen(seed_t{}, buffer_1);
+
+  key_t *d_buffer_1 = thrust::raw_pointer_cast(buffer_1.data());
+  key_t *d_buffer_2 = thrust::raw_pointer_cast(buffer_2.data());
+
+  cub::DoubleBuffer<key_t> d_keys(d_buffer_1, d_buffer_2);
+  cub::DoubleBuffer<value_t> d_values;
+
+  thrust::device_vector<offset_t> offsets =
+    gen_uniform_offsets<offset_t>(seed_t{}, elements, min_segment_size, max_segment_size);
+  const std::size_t segments = offsets.size() - 1;
+
+  thrust::host_vector<offset_t> h_offsets = offsets;
+
+  for (std::size_t i = 0; i < segments; i++)
+  {
+    if (h_offsets[i + 1] < h_offsets[i])
+    {
+      std::cerr << "Invalid segment size: " << h_offsets[i] << " > " << h_offsets[i + 1]
+                << std::endl;
+      std::exit(1);
+    }
+  }
+
+  begin_offset_it_t d_begin_offsets = thrust::raw_pointer_cast(offsets.data());
+  end_offset_it_t d_end_offsets     = d_begin_offsets + 1;
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<key_t>(elements);
+  state.add_global_memory_writes<key_t>(elements);
+  state.add_global_memory_reads<offset_t>(segments + 1);
+
+  std::size_t temp_storage_bytes{};
+  std::uint8_t *d_temp_storage{};
+  dispatch_t::Dispatch(d_temp_storage,
+                       temp_storage_bytes,
+                       d_keys,
+                       d_values,
+                       elements,
+                       segments,
+                       d_begin_offsets,
+                       d_end_offsets,
+                       is_overwrite_ok,
+                       0);
+
+  thrust::device_vector<nvbench::uint8_t> temp_storage(temp_storage_bytes);
+  d_temp_storage = thrust::raw_pointer_cast(temp_storage.data());
+
+  state.exec(nvbench::exec_tag::sync, [&](nvbench::launch &launch) {
+    cub::DoubleBuffer<key_t> keys     = d_keys;
+    cub::DoubleBuffer<value_t> values = d_values;
+
+    dispatch_t::Dispatch(d_temp_storage,
+                         temp_storage_bytes,
+                         keys,
+                         values,
+                         elements,
+                         segments,
+                         d_begin_offsets,
+                         d_end_offsets,
+                         is_overwrite_ok,
+                         launch.get_stream());
+  });
+}
+
+using some_offset_types = nvbench::type_list<uint32_t>;
+
+NVBENCH_BENCH_TYPES(seg_sort, NVBENCH_TYPE_AXES(fundamental_types, some_offset_types))
+  .set_name("cub::DeviceSegmentedSort::SortKeys")
+  .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(22, 30, 4))
+  .add_int64_power_of_two_axis("MaxSegmentSize", nvbench::range(1, 8, 1));

--- a/benchmarks/bench/segmented_sort/small/keys.cu
+++ b/benchmarks/bench/segmented_sort/small/keys.cu
@@ -1,3 +1,5 @@
+#include <cub/device/device_segmented_sort.cuh>
+
 #include <nvbench_helper.cuh>
 
 // %RANGE% TUNE_L_ITEMS ipt 7:24:1
@@ -15,8 +17,6 @@
 // %RANGE% TUNE_S_TRANSPOSE strp 0:1:1
 // %RANGE% TUNE_M_LOAD mld 0:2:1
 // %RANGE% TUNE_M_TRANSPOSE mtrp 0:1:1
-
-#include <cub/device/device_segmented_sort.cuh>
 
 #if !TUNE_BASE
 

--- a/benchmarks/bench/segmented_sort/small/keys.cu
+++ b/benchmarks/bench/segmented_sort/small/keys.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <cub/device/device_segmented_sort.cuh>
 
 #include <nvbench_helper.cuh>

--- a/benchmarks/bench/select/flagged.cu
+++ b/benchmarks/bench/select/flagged.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <nvbench_helper.cuh>
 #include <cub/device/device_select.cuh>
 #include <thrust/count.h>

--- a/benchmarks/bench/select/flagged.cu
+++ b/benchmarks/bench/select/flagged.cu
@@ -141,4 +141,4 @@ NVBENCH_BENCH_TYPES(select, NVBENCH_TYPE_AXES(fundamental_types, offset_types))
   .set_name("cub::DeviceSelect::Flagged")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.811", "0.544", "0.337", "0.201", "0.000"});
+  .add_string_axis("Entropy", {"1.000", "0.544", "0.000"});

--- a/benchmarks/bench/select/if.cu
+++ b/benchmarks/bench/select/if.cu
@@ -1,3 +1,30 @@
+/******************************************************************************
+ * Copyright (c) 2011-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
 #include <nvbench_helper.cuh>
 #include <cub/device/device_select.cuh>
 #include <thrust/count.h>

--- a/benchmarks/bench/select/if.cu
+++ b/benchmarks/bench/select/if.cu
@@ -166,4 +166,4 @@ NVBENCH_BENCH_TYPES(select, NVBENCH_TYPE_AXES(fundamental_types, offset_types))
   .set_name("cub::DeviceSelect::If")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
-  .add_string_axis("Entropy", {"1.000", "0.811", "0.544", "0.337", "0.201", "0.000"});
+  .add_string_axis("Entropy", {"1.000", "0.544", "0.000"});

--- a/benchmarks/nvbench_helper/nvbench_helper.cu
+++ b/benchmarks/nvbench_helper/nvbench_helper.cu
@@ -424,14 +424,12 @@ thrust::device_vector<T> gen_power_law_offsets(seed_t seed,
   return generator_t{}.power_law_segment_offsets<T>(seed, total_elements, total_segments);
 }
 
-#define INSTANTIATE_RND(TYPE)                                                                      \
+#define INSTANTIATE(TYPE)                                                                          \
   template thrust::device_vector<TYPE> gen_power_law_offsets<TYPE>(seed_t, std::size_t, std::size_t)
-
-#define INSTANTIATE(TYPE) INSTANTIATE_RND(TYPE);
-
 
 INSTANTIATE(int32_t);
 INSTANTIATE(int64_t);
+#undef INSTANTIATE
 
 
 template <class T>
@@ -449,7 +447,7 @@ struct offset_to_iterator_t
 template <class T>
 struct repeat_index_t
 {
-  __host__ __device__ __forceinline__ thrust::constant_iterator<std::size_t> operator()(std::size_t i)
+  __host__ __device__ __forceinline__ thrust::constant_iterator<T> operator()(std::size_t i)
   {
     return thrust::constant_iterator<T>(static_cast<T>(i));
   }
@@ -502,4 +500,29 @@ thrust::device_vector<T> gen_power_law_key_segments(seed_t seed,
                            d_range_sizes,
                            total_segments);
   cudaDeviceSynchronize();
+
+  return out;
 }
+
+#define INSTANTIATE(TYPE)                                                                          \
+  template thrust::device_vector<TYPE> gen_power_law_key_segments<TYPE>(seed_t,                    \
+                                                                        std::size_t,               \
+                                                                        std::size_t)
+
+INSTANTIATE(bool);
+
+INSTANTIATE(uint8_t);
+INSTANTIATE(uint16_t);
+INSTANTIATE(uint32_t);
+INSTANTIATE(uint64_t);
+INSTANTIATE(uint128_t);
+
+INSTANTIATE(int8_t);
+INSTANTIATE(int16_t);
+INSTANTIATE(int32_t);
+INSTANTIATE(int64_t);
+INSTANTIATE(int128_t);
+
+INSTANTIATE(float);
+INSTANTIATE(double);
+INSTANTIATE(complex);

--- a/benchmarks/nvbench_helper/nvbench_helper.cuh
+++ b/benchmarks/nvbench_helper/nvbench_helper.cuh
@@ -155,6 +155,8 @@ void gen(seed_t seed,
          T min = std::numeric_limits<T>::min(),
          T max = std::numeric_limits<T>::max());
 
+template <typename T>
+void gen_power_law_offsets(seed_t seed, std::size_t total_elements, std::size_t total_segments);
 
 // #define DBG_ENTROPY
 

--- a/benchmarks/nvbench_helper/nvbench_helper.cuh
+++ b/benchmarks/nvbench_helper/nvbench_helper.cuh
@@ -156,7 +156,14 @@ void gen(seed_t seed,
          T max = std::numeric_limits<T>::max());
 
 template <typename T>
-void gen_power_law_offsets(seed_t seed, std::size_t total_elements, std::size_t total_segments);
+thrust::device_vector<T> gen_power_law_offsets(seed_t seed,
+                                               std::size_t total_elements,
+                                               std::size_t total_segments);
+
+template <typename T>
+thrust::device_vector<T> gen_power_law_key_segments(seed_t seed,
+                                                    std::size_t total_elements,
+                                                    std::size_t total_segments);
 
 // #define DBG_ENTROPY
 

--- a/benchmarks/nvbench_helper/nvbench_helper.cuh
+++ b/benchmarks/nvbench_helper/nvbench_helper.cuh
@@ -165,6 +165,13 @@ thrust::device_vector<T> gen_power_law_key_segments(seed_t seed,
                                                     std::size_t total_elements,
                                                     std::size_t total_segments);
 
+
+template <typename T>
+thrust::device_vector<T> gen_uniform_key_segments(seed_t seed,
+                                                  std::size_t total_elements,
+                                                  std::size_t min_segment_size,
+                                                  std::size_t max_segment_size);
+
 // #define DBG_ENTROPY
 
 // This is very slow to compile, do not enable by default

--- a/benchmarks/nvbench_helper/nvbench_helper.cuh
+++ b/benchmarks/nvbench_helper/nvbench_helper.cuh
@@ -165,6 +165,11 @@ thrust::device_vector<T> gen_power_law_key_segments(seed_t seed,
                                                     std::size_t total_elements,
                                                     std::size_t total_segments);
 
+template <typename T>
+thrust::device_vector<T> gen_uniform_offsets(seed_t seed,
+                                             T total_elements,
+                                             T min_segment_size,
+                                             T max_segment_size);
 
 template <typename T>
 thrust::device_vector<T> gen_uniform_key_segments(seed_t seed,

--- a/cub/device/device_run_length_encode.cuh
+++ b/cub/device/device_run_length_encode.cuh
@@ -205,8 +205,6 @@ struct DeviceRunLengthEncode
          cudaStream_t stream = 0)
   {
     using OffsetT      = int;        // Signed integer type for global offsets
-    using FlagIterator = NullType *; // FlagT iterator type (not used)
-    using SelectOp     = NullType;   // Selection op (not used)
     using EqualityOp   = Equality;   // Default == operator
     using ReductionOp  = cub::Sum;   // Value reduction operator
 

--- a/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/device/dispatch/dispatch_histogram.cuh
@@ -28,8 +28,9 @@
  ******************************************************************************/
 
 /**
- * \file
- * cub::DeviceHistogram provides device-wide parallel operations for constructing histogram(s) from a sequence of samples data residing within device-accessible memory.
+ * @file
+ *   cub::DeviceHistogram provides device-wide parallel operations for constructing histogram(s)
+ *   from a sequence of samples data residing within device-accessible memory.
  */
 
 #pragma once
@@ -50,15 +51,13 @@
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
-#include <nv/target>
-
 #include <cstdio>
 #include <iterator>
 #include <limits>
 
+#include <nv/target>
+
 CUB_NAMESPACE_BEGIN
-
-
 
 /******************************************************************************
  * Histogram kernel entry points
@@ -66,104 +65,174 @@ CUB_NAMESPACE_BEGIN
 
 /**
  * Histogram initialization kernel entry point
+ *
+ * @tparam NUM_ACTIVE_CHANNELS
+ *   Number of channels actively being histogrammed
+ *
+ * @tparam CounterT
+ *   Integer type for counting sample occurrences per histogram bin
+ *
+ * @tparam OffsetT
+ *   Signed integer type for global offsets
+ *
+ * @param num_output_bins_wrapper
+ *   Number of output histogram bins per channel
+ *
+ * @param d_output_histograms_wrapper
+ *   Histogram counter data having logical dimensions
+ *   `CounterT[NUM_ACTIVE_CHANNELS][num_bins.array[CHANNEL]]`
+ *
+ * @param tile_queue
+ *   Drain queue descriptor for dynamically mapping tile data onto thread blocks
  */
-template <
-    int                                             NUM_ACTIVE_CHANNELS,            ///< Number of channels actively being histogrammed
-    typename                                        CounterT,                       ///< Integer type for counting sample occurrences per histogram bin
-    typename                                        OffsetT>                        ///< Signed integer type for global offsets
-__global__ void DeviceHistogramInitKernel(
-    ArrayWrapper<int, NUM_ACTIVE_CHANNELS>          num_output_bins_wrapper,        ///< Number of output histogram bins per channel
-    ArrayWrapper<CounterT*, NUM_ACTIVE_CHANNELS>    d_output_histograms_wrapper,    ///< Histogram counter data having logical dimensions <tt>CounterT[NUM_ACTIVE_CHANNELS][num_bins.array[CHANNEL]]</tt>
-    GridQueue<int>                                  tile_queue)                     ///< Drain queue descriptor for dynamically mapping tile data onto thread blocks
+template <int NUM_ACTIVE_CHANNELS, typename CounterT, typename OffsetT>
+__global__ void
+DeviceHistogramInitKernel(ArrayWrapper<int, NUM_ACTIVE_CHANNELS> num_output_bins_wrapper,
+                          ArrayWrapper<CounterT *, NUM_ACTIVE_CHANNELS> d_output_histograms_wrapper,
+                          GridQueue<int> tile_queue)
 {
-    if ((threadIdx.x == 0) && (blockIdx.x == 0))
-        tile_queue.ResetDrain();
+  if ((threadIdx.x == 0) && (blockIdx.x == 0))
+    tile_queue.ResetDrain();
 
-    int output_bin = (blockIdx.x * blockDim.x) + threadIdx.x;
+  int output_bin = (blockIdx.x * blockDim.x) + threadIdx.x;
 
-    #pragma unroll
-    for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
-    {
-        if (output_bin < num_output_bins_wrapper.array[CHANNEL])
-            d_output_histograms_wrapper.array[CHANNEL][output_bin] = 0;
-    }
+#pragma unroll
+  for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
+  {
+    if (output_bin < num_output_bins_wrapper.array[CHANNEL])
+      d_output_histograms_wrapper.array[CHANNEL][output_bin] = 0;
+  }
 }
-
 
 /**
- * Histogram privatized sweep kernel entry point (multi-block).  Computes privatized histograms, one per thread block.
+ * Histogram privatized sweep kernel entry point (multi-block).
+ * Computes privatized histograms, one per thread block.
+ *
+ *
+ * @tparam AgentHistogramPolicyT
+ *   Parameterized AgentHistogramPolicy tuning policy type
+ *
+ * @tparam PRIVATIZED_SMEM_BINS
+ *   Maximum number of histogram bins per channel (e.g., up to 256)
+ *
+ * @tparam NUM_CHANNELS
+ *   Number of channels interleaved in the input data (may be greater than the number of channels
+ *   being actively histogrammed)
+ *
+ * @tparam NUM_ACTIVE_CHANNELS
+ *   Number of channels actively being histogrammed
+ *
+ * @tparam SampleIteratorT
+ *   The input iterator type. \iterator.
+ *
+ * @tparam CounterT
+ *   Integer type for counting sample occurrences per histogram bin
+ *
+ * @tparam PrivatizedDecodeOpT
+ *   The transform operator type for determining privatized counter indices from samples,
+ *   one for each channel
+ *
+ * @tparam OutputDecodeOpT
+ *   The transform operator type for determining output bin-ids from privatized counter indices,
+ *   one for each channel
+ *
+ * @tparam OffsetT
+ *   integer type for global offsets
+ *
+ * @param d_samples
+ *   Input data to reduce
+ *
+ * @param num_output_bins_wrapper
+ *   The number bins per final output histogram
+ *
+ * @param num_privatized_bins_wrapper
+ *   The number bins per privatized histogram
+ *
+ * @param d_output_histograms_wrapper
+ *   Reference to final output histograms
+ *
+ * @param d_privatized_histograms_wrapper
+ *   Reference to privatized histograms
+ *
+ * @param output_decode_op_wrapper
+ *   The transform operator for determining output bin-ids from privatized counter indices,
+ *   one for each channel
+ *
+ * @param privatized_decode_op_wrapper
+ *   The transform operator for determining privatized counter indices from samples,
+ *   one for each channel
+ *
+ * @param num_row_pixels
+ *   The number of multi-channel pixels per row in the region of interest
+ *
+ * @param num_rows
+ *   The number of rows in the region of interest
+ *
+ * @param row_stride_samples
+ *   The number of samples between starts of consecutive rows in the region of interest
+ *
+ * @param tiles_per_row
+ *   Number of image tiles per row
+ *
+ * @param tile_queue
+ *   Drain queue descriptor for dynamically mapping tile data onto thread blocks
  */
-template <
-    typename                                            AgentHistogramPolicyT,     ///< Parameterized AgentHistogramPolicy tuning policy type
-    int                                                 PRIVATIZED_SMEM_BINS,           ///< Maximum number of histogram bins per channel (e.g., up to 256)
-    int                                                 NUM_CHANNELS,                   ///< Number of channels interleaved in the input data (may be greater than the number of channels being actively histogrammed)
-    int                                                 NUM_ACTIVE_CHANNELS,            ///< Number of channels actively being histogrammed
-    typename                                            SampleIteratorT,                ///< The input iterator type. \iterator.
-    typename                                            CounterT,                       ///< Integer type for counting sample occurrences per histogram bin
-    typename                                            PrivatizedDecodeOpT,            ///< The transform operator type for determining privatized counter indices from samples, one for each channel
-    typename                                            OutputDecodeOpT,                ///< The transform operator type for determining output bin-ids from privatized counter indices, one for each channel
-    typename                                            OffsetT>                        ///< Signed integer type for global offsets
-__launch_bounds__ (int(AgentHistogramPolicyT::BLOCK_THREADS))
-__global__ void DeviceHistogramSweepKernel(
-    SampleIteratorT                                         d_samples,                          ///< Input data to reduce
-    ArrayWrapper<int, NUM_ACTIVE_CHANNELS>                  num_output_bins_wrapper,            ///< The number bins per final output histogram
-    ArrayWrapper<int, NUM_ACTIVE_CHANNELS>                  num_privatized_bins_wrapper,        ///< The number bins per privatized histogram
-    ArrayWrapper<CounterT*, NUM_ACTIVE_CHANNELS>            d_output_histograms_wrapper,        ///< Reference to final output histograms
-    ArrayWrapper<CounterT*, NUM_ACTIVE_CHANNELS>            d_privatized_histograms_wrapper,    ///< Reference to privatized histograms
-    ArrayWrapper<OutputDecodeOpT, NUM_ACTIVE_CHANNELS>      output_decode_op_wrapper,           ///< The transform operator for determining output bin-ids from privatized counter indices, one for each channel
-    ArrayWrapper<PrivatizedDecodeOpT, NUM_ACTIVE_CHANNELS>  privatized_decode_op_wrapper,       ///< The transform operator for determining privatized counter indices from samples, one for each channel
-    OffsetT                                                 num_row_pixels,                     ///< The number of multi-channel pixels per row in the region of interest
-    OffsetT                                                 num_rows,                           ///< The number of rows in the region of interest
-    OffsetT                                                 row_stride_samples,                 ///< The number of samples between starts of consecutive rows in the region of interest
-    int                                                     tiles_per_row,                      ///< Number of image tiles per row
-    GridQueue<int>                                          tile_queue)                         ///< Drain queue descriptor for dynamically mapping tile data onto thread blocks
+template <typename AgentHistogramPolicyT,
+          int PRIVATIZED_SMEM_BINS,
+          int NUM_CHANNELS,
+          int NUM_ACTIVE_CHANNELS,
+          typename SampleIteratorT,
+          typename CounterT,
+          typename PrivatizedDecodeOpT,
+          typename OutputDecodeOpT,
+          typename OffsetT>
+__launch_bounds__(int(AgentHistogramPolicyT::BLOCK_THREADS)) __global__
+  void DeviceHistogramSweepKernel(
+    SampleIteratorT d_samples,
+    ArrayWrapper<int, NUM_ACTIVE_CHANNELS> num_output_bins_wrapper,
+    ArrayWrapper<int, NUM_ACTIVE_CHANNELS> num_privatized_bins_wrapper,
+    ArrayWrapper<CounterT *, NUM_ACTIVE_CHANNELS> d_output_histograms_wrapper,
+    ArrayWrapper<CounterT *, NUM_ACTIVE_CHANNELS> d_privatized_histograms_wrapper,
+    ArrayWrapper<OutputDecodeOpT, NUM_ACTIVE_CHANNELS> output_decode_op_wrapper,
+    ArrayWrapper<PrivatizedDecodeOpT, NUM_ACTIVE_CHANNELS> privatized_decode_op_wrapper,
+    OffsetT num_row_pixels,
+    OffsetT num_rows,
+    OffsetT row_stride_samples,
+    int tiles_per_row,
+    GridQueue<int> tile_queue)
 {
-    // Thread block type for compositing input tiles
-    typedef AgentHistogram<
-            AgentHistogramPolicyT,
-            PRIVATIZED_SMEM_BINS,
-            NUM_CHANNELS,
-            NUM_ACTIVE_CHANNELS,
-            SampleIteratorT,
-            CounterT,
-            PrivatizedDecodeOpT,
-            OutputDecodeOpT,
-            OffsetT>
-        AgentHistogramT;
+  // Thread block type for compositing input tiles
+  using AgentHistogramT = AgentHistogram<AgentHistogramPolicyT,
+                                         PRIVATIZED_SMEM_BINS,
+                                         NUM_CHANNELS,
+                                         NUM_ACTIVE_CHANNELS,
+                                         SampleIteratorT,
+                                         CounterT,
+                                         PrivatizedDecodeOpT,
+                                         OutputDecodeOpT,
+                                         OffsetT>;
 
-    // Shared memory for AgentHistogram
-    __shared__ typename AgentHistogramT::TempStorage temp_storage;
+  // Shared memory for AgentHistogram
+  __shared__ typename AgentHistogramT::TempStorage temp_storage;
 
-    AgentHistogramT agent(
-        temp_storage,
-        d_samples,
-        num_output_bins_wrapper.array,
-        num_privatized_bins_wrapper.array,
-        d_output_histograms_wrapper.array,
-        d_privatized_histograms_wrapper.array,
-        output_decode_op_wrapper.array,
-        privatized_decode_op_wrapper.array);
+  AgentHistogramT agent(temp_storage,
+                        d_samples,
+                        num_output_bins_wrapper.array,
+                        num_privatized_bins_wrapper.array,
+                        d_output_histograms_wrapper.array,
+                        d_privatized_histograms_wrapper.array,
+                        output_decode_op_wrapper.array,
+                        privatized_decode_op_wrapper.array);
 
-    // Initialize counters
-    agent.InitBinCounters();
+  // Initialize counters
+  agent.InitBinCounters();
 
-    // Consume input tiles
-    agent.ConsumeTiles(
-        num_row_pixels,
-        num_rows,
-        row_stride_samples,
-        tiles_per_row,
-        tile_queue);
+  // Consume input tiles
+  agent.ConsumeTiles(num_row_pixels, num_rows, row_stride_samples, tiles_per_row, tile_queue);
 
-    // Store output to global (if necessary)
-    agent.StoreOutput();
-
+  // Store output to global (if necessary)
+  agent.StoreOutput();
 }
-
-
-
-
-
 
 /******************************************************************************
  * Dispatch
@@ -171,1191 +240,1547 @@ __global__ void DeviceHistogramSweepKernel(
 
 /**
  * Utility class for dispatching the appropriately-tuned kernels for DeviceHistogram
+ *
+ * @tparam NUM_CHANNELS
+ *   Number of channels interleaved in the input data (may be greater than the number of channels
+ *   being actively histogrammed)
+ *
+ * @tparam NUM_ACTIVE_CHANNELS
+ *   Number of channels actively being histogrammed
+ *
+ * @tparam SampleIteratorT
+ *   Random-access input iterator type for reading input items \iterator
+ *
+ * @tparam CounterT
+ *   Integer type for counting sample occurrences per histogram bin
+ *
+ * @tparam LevelT
+ *   Type for specifying bin level boundaries
+ *
+ * @tparam OffsetT
+ *   Signed integer type for global offsets
  */
-template <
-    int         NUM_CHANNELS,               ///< Number of channels interleaved in the input data (may be greater than the number of channels being actively histogrammed)
-    int         NUM_ACTIVE_CHANNELS,        ///< Number of channels actively being histogrammed
-    typename    SampleIteratorT,            ///< Random-access input iterator type for reading input items \iterator
-    typename    CounterT,                   ///< Integer type for counting sample occurrences per histogram bin
-    typename    LevelT,                     ///< Type for specifying bin level boundaries
-    typename    OffsetT>                    ///< Signed integer type for global offsets
+template <int NUM_CHANNELS,
+          int NUM_ACTIVE_CHANNELS,
+          typename SampleIteratorT,
+          typename CounterT,
+          typename LevelT,
+          typename OffsetT>
 struct DispatchHistogram
 {
 public:
-    //---------------------------------------------------------------------
-    // Types and constants
-    //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  // Types and constants
+  //---------------------------------------------------------------------
 
-    /// The sample value type of the input iterator
-    using SampleT = cub::detail::value_t<SampleIteratorT>;
+  /// The sample value type of the input iterator
+  using SampleT = cub::detail::value_t<SampleIteratorT>;
 
-    enum
-    {
-        // Maximum number of bins per channel for which we will use a privatized smem strategy
-        MAX_PRIVATIZED_SMEM_BINS = 256
-    };
+  enum
+  {
+    // Maximum number of bins per channel for which we will use a privatized smem strategy
+    MAX_PRIVATIZED_SMEM_BINS = 256
+  };
 
+  //---------------------------------------------------------------------
+  // Transform functors for converting samples to bin-ids
+  //---------------------------------------------------------------------
 
-    //---------------------------------------------------------------------
-    // Transform functors for converting samples to bin-ids
-    //---------------------------------------------------------------------
-
-    // Searches for bin given a list of bin-boundary levels
-    template <typename LevelIteratorT>
-    struct SearchTransform
-    {
-        LevelIteratorT  d_levels;                   // Pointer to levels array
-        int             num_output_levels;          // Number of levels in array
-
-        // Initializer
-        __host__ __device__ __forceinline__ void Init(
-            LevelIteratorT  d_levels_,               // Pointer to levels array
-            int             num_output_levels_)      // Number of levels in array
-        {
-            this->d_levels          = d_levels_;
-            this->num_output_levels = num_output_levels_;
-        }
-
-        // Method for converting samples to bin-ids
-        template <CacheLoadModifier LOAD_MODIFIER, typename _SampleT>
-        __host__ __device__ __forceinline__ void BinSelect(_SampleT sample, int &bin, bool valid)
-        {
-            /// Level iterator wrapper type
-            // Wrap the native input pointer with CacheModifiedInputIterator
-            // or Directly use the supplied input iterator type
-            using WrappedLevelIteratorT = cub::detail::conditional_t<
-              std::is_pointer<LevelIteratorT>::value,
-              CacheModifiedInputIterator<LOAD_MODIFIER, LevelT, OffsetT>,
-              LevelIteratorT>;
-
-            WrappedLevelIteratorT wrapped_levels(d_levels);
-
-            int num_bins = num_output_levels - 1;
-            if (valid)
-            {
-                bin = UpperBound(wrapped_levels, num_output_levels, (LevelT) sample) - 1;
-                if (bin >= num_bins)
-                    bin = -1;
-            }
-        }
-    };
-
-    // Scales samples to evenly-spaced bins
-    struct ScaleTransform
-    {
-    private:
-      using CommonT = typename ::cuda::std::common_type<LevelT, SampleT>::type;
-      static_assert(::cuda::std::is_convertible<CommonT, int>::value,
-                    "The common type of `LevelT` and `SampleT` must be "
-                    "convertible to `int`.");
-      static_assert(::cuda::std::is_trivially_copyable<CommonT>::value,
-                    "The common type of `LevelT` and `SampleT` must be "
-                    "trivially copyable.");
-
-      // An arithmetic type that's used for bin computation of integral types, guaranteed to not
-      // overflow for (max_level - min_level) * scale.fraction.bins. Since we drop invalid samples
-      // of less than min_level, (sample - min_level) is guaranteed to be non-negative. We use the
-      // rule: 2^l * 2^r = 2^(l + r) to determine a sufficiently large type to hold the
-      // multiplication result.
-      // If CommonT used to be a 128-bit wide integral type already, we use CommonT's arithmetic
-      using IntArithmeticT = cub::detail::conditional_t<       //
-        sizeof(SampleT) + sizeof(CommonT) <= sizeof(uint32_t), //
-        uint32_t,                                              //
-#if CUB_IS_INT128_ENABLED
-        cub::detail::conditional_t<                            //
-          (::cuda::std::is_same<CommonT, __int128_t>::value || //
-           ::cuda::std::is_same<CommonT, __uint128_t>::value), //
-          CommonT,                                             //
-          uint64_t>                                            //
-#else
-        uint64_t
-#endif
-        >;
-
-      // Alias template that excludes __[u]int128 from the integral types
-      template <typename T>
-      using is_integral_excl_int128 =
-#if CUB_IS_INT128_ENABLED
-        cub::detail::conditional_t<
-          ::cuda::std::is_same<T, __int128_t>::value && ::cuda::std::is_same<T, __uint128_t>::value,
-          ::cuda::std::false_type,
-          ::cuda::std::is_integral<T>>;
-#else
-        ::cuda::std::is_integral<T>;
-#endif
-
-      union ScaleT
-      {
-        // Used when CommonT is not floating-point to avoid intermediate
-        // rounding errors (see NVIDIA/cub#489).
-        struct FractionT
-        {
-          CommonT bins;
-          CommonT range;
-        } fraction;
-
-        // Used when CommonT is floating-point as an optimization.
-        CommonT reciprocal;
-      };
-
-      CommonT m_max;   // Max sample level (exclusive)
-      CommonT m_min;   // Min sample level (inclusive)
-      ScaleT  m_scale; // Bin scaling
-
-      template <typename T>
-      __host__ __device__ __forceinline__
-      ScaleT ComputeScale(int num_levels,
-                          T   max_level,
-                          T   min_level,
-                          ::cuda::std::true_type /* is_fp */)
-      {
-        ScaleT result;
-        result.reciprocal =
-          static_cast<T>(static_cast<T>(num_levels - 1) /
-                         static_cast<T>(max_level - min_level));
-        return result;
-      }
-
-      template <typename T>
-      __host__ __device__ __forceinline__
-      ScaleT ComputeScale(int num_levels,
-                          T   max_level,
-                          T   min_level,
-                          ::cuda::std::false_type /* is_fp */)
-      {
-        ScaleT result;
-        result.fraction.bins  = static_cast<T>(num_levels - 1);
-        result.fraction.range = static_cast<T>(max_level - min_level);
-        return result;
-      }
-
-      template <typename T>
-      __host__ __device__ __forceinline__
-      ScaleT ComputeScale(int num_levels,
-                          T   max_level,
-                          T   min_level)
-      {
-        return this->ComputeScale(num_levels,
-                                  max_level,
-                                  min_level,
-                                  ::cuda::std::is_floating_point<T>{});
-      }
-
-#ifdef __CUDA_FP16_TYPES_EXIST__
-      __host__ __device__ __forceinline__
-      ScaleT ComputeScale(int    num_levels,
-                          __half max_level,
-                          __half min_level)
-      {
-        NV_IF_TARGET(NV_PROVIDES_SM_53,
-                     (return this->ComputeScale(num_levels,
-                                                max_level,
-                                                min_level,
-                                                ::cuda::std::true_type{});),
-                     (return this->ComputeScale(num_levels,
-                                                __half2float(max_level),
-                                                __half2float(min_level),
-                                                ::cuda::std::true_type{});));
-      }
-#endif
-
-      // All types but __half:
-      template <typename T>
-      __host__ __device__ __forceinline__
-      int SampleIsValid(T sample, T max_level, T min_level)
-      {
-        return sample >= min_level && sample < max_level;
-      }
-
-#ifdef __CUDA_FP16_TYPES_EXIST__
-      __host__ __device__ __forceinline__
-      int SampleIsValid(__half sample, __half max_level, __half min_level)
-      {
-        NV_IF_TARGET(NV_PROVIDES_SM_53,
-                     (return sample >= min_level && sample < max_level;),
-                     (return this->SampleIsValid(__half2float(sample),
-                                                 __half2float(max_level),
-                                                 __half2float(min_level));));
-      }
-#endif
-
-      /**
-       * @brief Bin computation for floating point (and extended floating point) types
-       */
-      template <typename T>
-      __host__ __device__ __forceinline__ int
-      ComputeBin(T sample, T min_level, ScaleT scale, ::cuda::std::true_type /* is_fp */)
-      {
-        return static_cast<int>((sample - min_level) * scale.reciprocal);
-      }
-
-      /**
-       * @brief Bin computation for custom types and __[u]int128
-       */
-      template <typename T>
-      __host__ __device__ __forceinline__ int
-      ComputeBin(T sample, T min_level, ScaleT scale, ::cuda::std::false_type /* is_fp */)
-      {
-        return static_cast<int>(((sample - min_level) * scale.fraction.bins) /
-                                scale.fraction.range);
-      }
-
-      /**
-       * @brief Bin computation for integral types of up to 64-bit types
-       */
-      template <typename T,
-                typename ::cuda::std::enable_if<is_integral_excl_int128<T>::value, int>::type = 0>
-      __host__ __device__ __forceinline__ int ComputeBin(T sample, T min_level, ScaleT scale)
-      {
-        return static_cast<int>((static_cast<IntArithmeticT>(sample - min_level) *
-                                 static_cast<IntArithmeticT>(scale.fraction.bins)) /
-                                static_cast<IntArithmeticT>(scale.fraction.range));
-      }
-
-      template <typename T,
-                typename ::cuda::std::enable_if<!is_integral_excl_int128<T>::value, int>::type = 0>
-      __host__ __device__ __forceinline__ int ComputeBin(T sample, T min_level, ScaleT scale)
-      {
-        return this->ComputeBin(sample, min_level, scale, ::cuda::std::is_floating_point<T>{});
-      }
-
-#ifdef __CUDA_FP16_TYPES_EXIST__
-      __host__ __device__ __forceinline__ int ComputeBin(__half sample,
-                                                         __half min_level,
-                                                         ScaleT scale)
-      {
-        NV_IF_TARGET(NV_PROVIDES_SM_53,
-                     (return this->ComputeBin(sample, min_level, scale, ::cuda::std::true_type{});),
-                     (return static_cast<int>((__half2float(sample) - __half2float(min_level)) *
-                                              __half2float(scale.reciprocal));));
-      }
-#endif
-
-      __host__ __device__ __forceinline__ bool MayOverflow(CommonT /* num_bins */,
-                                                           ::cuda::std::false_type /* is_integral */)
-      {
-        return false;
-      }
-
-      /**
-       * @brief Returns true if the bin computation for a given combination of range `(max_level -
-       * min_level)` and number of bins may overflow.
-       */
-      __host__ __device__ __forceinline__ bool MayOverflow(CommonT num_bins,
-                                                           ::cuda::std::true_type /* is_integral */)
-      {
-        return static_cast<IntArithmeticT>(m_max - m_min) >
-               (::cuda::std::numeric_limits<IntArithmeticT>::max() /
-                static_cast<IntArithmeticT>(num_bins));
-      }
-
-    public:
-      /**
-       * @brief Initializes the ScaleTransform for the given parameters
-       * @return cudaErrorInvalidValue if the ScaleTransform for the given values may overflow,
-       * cudaSuccess otherwise
-       */
-      __host__ __device__ __forceinline__ cudaError_t Init(int num_levels,
-                                                           LevelT max_level,
-                                                           LevelT min_level)
-      {
-        m_max = static_cast<CommonT>(max_level);
-        m_min = static_cast<CommonT>(min_level);
-
-        // Check whether accurate bin computation for an integral sample type may overflow
-        if (MayOverflow(static_cast<CommonT>(num_levels - 1), ::cuda::std::is_integral<CommonT>{}))
-        {
-          return cudaErrorInvalidValue;
-        }
-
-        m_scale = this->ComputeScale(num_levels, m_max, m_min);
-        return cudaSuccess;
-      }
-
-      // Method for converting samples to bin-ids
-      template <CacheLoadModifier LOAD_MODIFIER>
-      __host__ __device__ __forceinline__ void BinSelect(SampleT sample, int &bin, bool valid)
-      {
-        const CommonT common_sample = static_cast<CommonT>(sample);
-
-        if (valid && this->SampleIsValid(common_sample, m_max, m_min))
-        {
-          bin = this->ComputeBin(common_sample, m_min, m_scale);
-        }
-      }
-    };
-
-    // Pass-through bin transform operator
-    struct PassThruTransform
-    {
-        // Method for converting samples to bin-ids
-        template <CacheLoadModifier LOAD_MODIFIER, typename _SampleT>
-        __host__ __device__ __forceinline__ void BinSelect(_SampleT sample, int &bin, bool valid)
-        {
-            if (valid)
-                bin = (int) sample;
-        }
-    };
-
-    //---------------------------------------------------------------------
-    // Tuning policies
-    //---------------------------------------------------------------------
-
-    template <int NOMINAL_ITEMS_PER_THREAD>
-    struct TScale
-    {
-        enum
-        {
-            V_SCALE = (sizeof(SampleT) + sizeof(int) - 1) / sizeof(int),
-            VALUE   = CUB_MAX((NOMINAL_ITEMS_PER_THREAD / NUM_ACTIVE_CHANNELS / V_SCALE), 1)
-        };
-    };
-
-    /// SM35
-    struct Policy350
-    {
-        // HistogramSweepPolicy
-        typedef AgentHistogramPolicy<
-                128,
-                TScale<8>::VALUE,
-                BLOCK_LOAD_DIRECT,
-                LOAD_LDG,
-                true,
-                BLEND,
-                true>
-            HistogramSweepPolicy;
-    };
-
-    /// SM50
-    struct Policy500
-    {
-        // HistogramSweepPolicy
-        typedef AgentHistogramPolicy<
-                384,
-                TScale<16>::VALUE,
-                BLOCK_LOAD_DIRECT,
-                LOAD_LDG,
-                true,
-                SMEM,
-                false>
-            HistogramSweepPolicy;
-    };
-
-
-
-    //---------------------------------------------------------------------
-    // Tuning policies of current PTX compiler pass
-    //---------------------------------------------------------------------
-
-#if (CUB_PTX_ARCH >= 500)
-    typedef Policy500 PtxPolicy;
-
-#else
-    typedef Policy350 PtxPolicy;
-
-#endif
-
-    // "Opaque" policies (whose parameterizations aren't reflected in the type signature)
-    struct PtxHistogramSweepPolicy : PtxPolicy::HistogramSweepPolicy {};
-
-
-    //---------------------------------------------------------------------
-    // Utilities
-    //---------------------------------------------------------------------
+  // Searches for bin given a list of bin-boundary levels
+  template <typename LevelIteratorT>
+  struct SearchTransform
+  {
+    LevelIteratorT d_levels; // Pointer to levels array
+    int num_output_levels;   // Number of levels in array
 
     /**
-     * Initialize kernel dispatch configurations with the policies corresponding to the PTX assembly we will use
+     * @brief Initializer
+     *
+     * @param d_levels_ Pointer to levels array
+     * @param num_output_levels_ Number of levels in array
      */
-    template <typename KernelConfig>
-    CUB_RUNTIME_FUNCTION __forceinline__
-    static cudaError_t InitConfigs(
-        int             ptx_version,
-        KernelConfig    &histogram_sweep_config)
+    __host__ __device__ __forceinline__ void Init(LevelIteratorT d_levels_, int num_output_levels_)
     {
-      cudaError_t result = cudaErrorNotSupported;
-      NV_IF_TARGET(
-        NV_IS_DEVICE,
-        (
-          // We're on the device, so initialize the kernel dispatch
-          // configurations with the current PTX policy
-          result = histogram_sweep_config.template Init<PtxHistogramSweepPolicy>();
-        ),
-        ( // NV_IS_HOST:
-          // We're on the host, so lookup and initialize the kernel dispatch
-          // configurations with the policies that match the device's PTX
-          // version
-          if (ptx_version >= 500)
-          {
-            result = histogram_sweep_config.template Init<typename Policy500::HistogramSweepPolicy>();
-          }
-          else
-          {
-            result = histogram_sweep_config.template Init<typename Policy350::HistogramSweepPolicy>();
-          }
-        ));
+      this->d_levels          = d_levels_;
+      this->num_output_levels = num_output_levels_;
+    }
 
+    // Method for converting samples to bin-ids
+    template <CacheLoadModifier LOAD_MODIFIER, typename _SampleT>
+    __host__ __device__ __forceinline__ void BinSelect(_SampleT sample, int &bin, bool valid)
+    {
+      /// Level iterator wrapper type
+      // Wrap the native input pointer with CacheModifiedInputIterator
+      // or Directly use the supplied input iterator type
+      using WrappedLevelIteratorT =
+        cub::detail::conditional_t<std::is_pointer<LevelIteratorT>::value,
+                                   CacheModifiedInputIterator<LOAD_MODIFIER, LevelT, OffsetT>,
+                                   LevelIteratorT>;
+
+      WrappedLevelIteratorT wrapped_levels(d_levels);
+
+      int num_bins = num_output_levels - 1;
+      if (valid)
+      {
+        bin = UpperBound(wrapped_levels, num_output_levels, (LevelT)sample) - 1;
+        if (bin >= num_bins)
+          bin = -1;
+      }
+    }
+  };
+
+  // Scales samples to evenly-spaced bins
+  struct ScaleTransform
+  {
+  private:
+    using CommonT = typename ::cuda::std::common_type<LevelT, SampleT>::type;
+    static_assert(::cuda::std::is_convertible<CommonT, int>::value,
+                  "The common type of `LevelT` and `SampleT` must be "
+                  "convertible to `int`.");
+    static_assert(::cuda::std::is_trivially_copyable<CommonT>::value,
+                  "The common type of `LevelT` and `SampleT` must be "
+                  "trivially copyable.");
+
+    // An arithmetic type that's used for bin computation of integral types, guaranteed to not
+    // overflow for (max_level - min_level) * scale.fraction.bins. Since we drop invalid samples
+    // of less than min_level, (sample - min_level) is guaranteed to be non-negative. We use the
+    // rule: 2^l * 2^r = 2^(l + r) to determine a sufficiently large type to hold the
+    // multiplication result.
+    // If CommonT used to be a 128-bit wide integral type already, we use CommonT's arithmetic
+    using IntArithmeticT = cub::detail::conditional_t<       //
+      sizeof(SampleT) + sizeof(CommonT) <= sizeof(uint32_t), //
+      uint32_t,                                              //
+#if CUB_IS_INT128_ENABLED
+      cub::detail::conditional_t<                            //
+        (::cuda::std::is_same<CommonT, __int128_t>::value || //
+         ::cuda::std::is_same<CommonT, __uint128_t>::value), //
+        CommonT,                                             //
+        uint64_t>                                            //
+#else
+      uint64_t
+#endif
+      >;
+
+    // Alias template that excludes __[u]int128 from the integral types
+    template <typename T>
+    using is_integral_excl_int128 =
+#if CUB_IS_INT128_ENABLED
+      cub::detail::conditional_t<
+        ::cuda::std::is_same<T, __int128_t>::value && ::cuda::std::is_same<T, __uint128_t>::value,
+        ::cuda::std::false_type,
+        ::cuda::std::is_integral<T>>;
+#else
+      ::cuda::std::is_integral<T>;
+#endif
+
+    union ScaleT
+    {
+      // Used when CommonT is not floating-point to avoid intermediate
+      // rounding errors (see NVIDIA/cub#489).
+      struct FractionT
+      {
+        CommonT bins;
+        CommonT range;
+      } fraction;
+
+      // Used when CommonT is floating-point as an optimization.
+      CommonT reciprocal;
+    };
+
+    CommonT m_max;  // Max sample level (exclusive)
+    CommonT m_min;  // Min sample level (inclusive)
+    ScaleT m_scale; // Bin scaling
+
+    template <typename T>
+    __host__ __device__ __forceinline__ ScaleT
+    ComputeScale(int num_levels, T max_level, T min_level, ::cuda::std::true_type /* is_fp */)
+    {
+      ScaleT result;
+      result.reciprocal =
+        static_cast<T>(static_cast<T>(num_levels - 1) / static_cast<T>(max_level - min_level));
       return result;
     }
 
-    /**
-     * Kernel kernel dispatch configuration
-     */
-    struct KernelConfig
+    template <typename T>
+    __host__ __device__ __forceinline__ ScaleT
+    ComputeScale(int num_levels, T max_level, T min_level, ::cuda::std::false_type /* is_fp */)
     {
-        int                             block_threads;
-        int                             pixels_per_thread;
+      ScaleT result;
+      result.fraction.bins  = static_cast<T>(num_levels - 1);
+      result.fraction.range = static_cast<T>(max_level - min_level);
+      return result;
+    }
 
-        template <typename BlockPolicy>
-        CUB_RUNTIME_FUNCTION __forceinline__
-        cudaError_t Init()
-        {
-            block_threads               = BlockPolicy::BLOCK_THREADS;
-            pixels_per_thread           = BlockPolicy::PIXELS_PER_THREAD;
+    template <typename T>
+    __host__ __device__ __forceinline__ ScaleT ComputeScale(int num_levels,
+                                                            T max_level,
+                                                            T min_level)
+    {
+      return this->ComputeScale(num_levels,
+                                max_level,
+                                min_level,
+                                ::cuda::std::is_floating_point<T>{});
+    }
 
-            return cudaSuccess;
-        }
+#ifdef __CUDA_FP16_TYPES_EXIST__
+    __host__ __device__ __forceinline__ ScaleT ComputeScale(int num_levels,
+                                                            __half max_level,
+                                                            __half min_level)
+    {
+      NV_IF_TARGET(
+        NV_PROVIDES_SM_53,
+        (return this->ComputeScale(num_levels, max_level, min_level, ::cuda::std::true_type{});),
+        (return this->ComputeScale(num_levels,
+                                   __half2float(max_level),
+                                   __half2float(min_level),
+                                   ::cuda::std::true_type{});));
+    }
+#endif
+
+    // All types but __half:
+    template <typename T>
+    __host__ __device__ __forceinline__ int SampleIsValid(T sample, T max_level, T min_level)
+    {
+      return sample >= min_level && sample < max_level;
+    }
+
+#ifdef __CUDA_FP16_TYPES_EXIST__
+    __host__ __device__ __forceinline__ int SampleIsValid(__half sample,
+                                                          __half max_level,
+                                                          __half min_level)
+    {
+      NV_IF_TARGET(NV_PROVIDES_SM_53,
+                   (return sample >= min_level && sample < max_level;),
+                   (return this->SampleIsValid(__half2float(sample),
+                                               __half2float(max_level),
+                                               __half2float(min_level));));
+    }
+#endif
+
+    /**
+     * @brief Bin computation for floating point (and extended floating point) types
+     */
+    template <typename T>
+    __host__ __device__ __forceinline__ int
+    ComputeBin(T sample, T min_level, ScaleT scale, ::cuda::std::true_type /* is_fp */)
+    {
+      return static_cast<int>((sample - min_level) * scale.reciprocal);
+    }
+
+    /**
+     * @brief Bin computation for custom types and __[u]int128
+     */
+    template <typename T>
+    __host__ __device__ __forceinline__ int
+    ComputeBin(T sample, T min_level, ScaleT scale, ::cuda::std::false_type /* is_fp */)
+    {
+      return static_cast<int>(((sample - min_level) * scale.fraction.bins) / scale.fraction.range);
+    }
+
+    /**
+     * @brief Bin computation for integral types of up to 64-bit types
+     */
+    template <typename T,
+              typename ::cuda::std::enable_if<is_integral_excl_int128<T>::value, int>::type = 0>
+    __host__ __device__ __forceinline__ int ComputeBin(T sample, T min_level, ScaleT scale)
+    {
+      return static_cast<int>((static_cast<IntArithmeticT>(sample - min_level) *
+                               static_cast<IntArithmeticT>(scale.fraction.bins)) /
+                              static_cast<IntArithmeticT>(scale.fraction.range));
+    }
+
+    template <typename T,
+              typename ::cuda::std::enable_if<!is_integral_excl_int128<T>::value, int>::type = 0>
+    __host__ __device__ __forceinline__ int ComputeBin(T sample, T min_level, ScaleT scale)
+    {
+      return this->ComputeBin(sample, min_level, scale, ::cuda::std::is_floating_point<T>{});
+    }
+
+#ifdef __CUDA_FP16_TYPES_EXIST__
+    __host__ __device__ __forceinline__ int ComputeBin(__half sample,
+                                                       __half min_level,
+                                                       ScaleT scale)
+    {
+      NV_IF_TARGET(NV_PROVIDES_SM_53,
+                   (return this->ComputeBin(sample, min_level, scale, ::cuda::std::true_type{});),
+                   (return static_cast<int>((__half2float(sample) - __half2float(min_level)) *
+                                            __half2float(scale.reciprocal));));
+    }
+#endif
+
+    __host__ __device__ __forceinline__ bool MayOverflow(CommonT /* num_bins */,
+                                                         ::cuda::std::false_type /* is_integral */)
+    {
+      return false;
+    }
+
+    /**
+     * @brief Returns true if the bin computation for a given combination of range `(max_level -
+     * min_level)` and number of bins may overflow.
+     */
+    __host__ __device__ __forceinline__ bool MayOverflow(CommonT num_bins,
+                                                         ::cuda::std::true_type /* is_integral */)
+    {
+      return static_cast<IntArithmeticT>(m_max - m_min) >
+             (::cuda::std::numeric_limits<IntArithmeticT>::max() /
+              static_cast<IntArithmeticT>(num_bins));
+    }
+
+  public:
+    /**
+     * @brief Initializes the ScaleTransform for the given parameters
+     * @return cudaErrorInvalidValue if the ScaleTransform for the given values may overflow,
+     * cudaSuccess otherwise
+     */
+    __host__ __device__ __forceinline__ cudaError_t Init(int num_levels,
+                                                         LevelT max_level,
+                                                         LevelT min_level)
+    {
+      m_max = static_cast<CommonT>(max_level);
+      m_min = static_cast<CommonT>(min_level);
+
+      // Check whether accurate bin computation for an integral sample type may overflow
+      if (MayOverflow(static_cast<CommonT>(num_levels - 1), ::cuda::std::is_integral<CommonT>{}))
+      {
+        return cudaErrorInvalidValue;
+      }
+
+      m_scale = this->ComputeScale(num_levels, m_max, m_min);
+      return cudaSuccess;
+    }
+
+    // Method for converting samples to bin-ids
+    template <CacheLoadModifier LOAD_MODIFIER>
+    __host__ __device__ __forceinline__ void BinSelect(SampleT sample, int &bin, bool valid)
+    {
+      const CommonT common_sample = static_cast<CommonT>(sample);
+
+      if (valid && this->SampleIsValid(common_sample, m_max, m_min))
+      {
+        bin = this->ComputeBin(common_sample, m_min, m_scale);
+      }
+    }
+  };
+
+  // Pass-through bin transform operator
+  struct PassThruTransform
+  {
+    // Method for converting samples to bin-ids
+    template <CacheLoadModifier LOAD_MODIFIER, typename _SampleT>
+    __host__ __device__ __forceinline__ void BinSelect(_SampleT sample, int &bin, bool valid)
+    {
+      if (valid)
+        bin = (int)sample;
+    }
+  };
+
+  //---------------------------------------------------------------------
+  // Tuning policies
+  //---------------------------------------------------------------------
+
+  template <int NOMINAL_ITEMS_PER_THREAD>
+  struct TScale
+  {
+    enum
+    {
+      V_SCALE = (sizeof(SampleT) + sizeof(int) - 1) / sizeof(int),
+      VALUE   = CUB_MAX((NOMINAL_ITEMS_PER_THREAD / NUM_ACTIVE_CHANNELS / V_SCALE), 1)
     };
+  };
 
+  /// SM35
+  struct Policy350
+  {
+    // HistogramSweepPolicy
+    using HistogramSweepPolicy =
+      AgentHistogramPolicy<128, TScale<8>::VALUE, BLOCK_LOAD_DIRECT, LOAD_LDG, true, BLEND, true>;
+  };
 
-    //---------------------------------------------------------------------
-    // Dispatch entrypoints
-    //---------------------------------------------------------------------
+  /// SM50
+  struct Policy500
+  {
+    using HistogramSweepPolicy =
+      AgentHistogramPolicy<384, TScale<16>::VALUE, BLOCK_LOAD_DIRECT, LOAD_LDG, true, SMEM, false>;
+  };
 
-    /**
-     * Privatization-based dispatch routine
-     */
-    template <
-        typename                            PrivatizedDecodeOpT,                            ///< The transform operator type for determining privatized counter indices from samples, one for each channel
-        typename                            OutputDecodeOpT,                                ///< The transform operator type for determining output bin-ids from privatized counter indices, one for each channel
-        typename                            DeviceHistogramInitKernelT,                     ///< Function type of cub::DeviceHistogramInitKernel
-        typename                            DeviceHistogramSweepKernelT>                    ///< Function type of cub::DeviceHistogramSweepKernel
-    CUB_RUNTIME_FUNCTION __forceinline__
-    static cudaError_t PrivatizedDispatch(
-        void*                               d_temp_storage,                                 ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
-        size_t&                             temp_storage_bytes,                             ///< [in,out] Reference to size in bytes of \p d_temp_storage allocation
-        SampleIteratorT                     d_samples,                                      ///< [in] The pointer to the input sequence of sample items. The samples from different channels are assumed to be interleaved (e.g., an array of 32-bit pixels where each pixel consists of four RGBA 8-bit samples).
-        CounterT*                           d_output_histograms[NUM_ACTIVE_CHANNELS],       ///< [out] The pointers to the histogram counter output arrays, one for each active channel.  For channel<sub><em>i</em></sub>, the allocation length of <tt>d_histograms[i]</tt> should be <tt>num_output_levels[i]</tt> - 1.
-        int                                 num_privatized_levels[NUM_ACTIVE_CHANNELS],     ///< [in] The number of bin level boundaries for delineating histogram samples in each active channel.  Implies that the number of bins for channel<sub><em>i</em></sub> is <tt>num_output_levels[i]</tt> - 1.
-        PrivatizedDecodeOpT                 privatized_decode_op[NUM_ACTIVE_CHANNELS],      ///< [in] Transform operators for determining bin-ids from samples, one for each channel
-        int                                 num_output_levels[NUM_ACTIVE_CHANNELS],         ///< [in] The number of bin level boundaries for delineating histogram samples in each active channel.  Implies that the number of bins for channel<sub><em>i</em></sub> is <tt>num_output_levels[i]</tt> - 1.
-        OutputDecodeOpT                     output_decode_op[NUM_ACTIVE_CHANNELS],          ///< [in] Transform operators for determining bin-ids from samples, one for each channel
-        int                                 max_num_output_bins,                            ///< [in] Maximum number of output bins in any channel
-        OffsetT                             num_row_pixels,                                 ///< [in] The number of multi-channel pixels per row in the region of interest
-        OffsetT                             num_rows,                                       ///< [in] The number of rows in the region of interest
-        OffsetT                             row_stride_samples,                             ///< [in] The number of samples between starts of consecutive rows in the region of interest
-        DeviceHistogramInitKernelT          histogram_init_kernel,                          ///< [in] Kernel function pointer to parameterization of cub::DeviceHistogramInitKernel
-        DeviceHistogramSweepKernelT         histogram_sweep_kernel,                         ///< [in] Kernel function pointer to parameterization of cub::DeviceHistogramSweepKernel
-        KernelConfig                        histogram_sweep_config,                         ///< [in] Dispatch parameters that match the policy that \p histogram_sweep_kernel was compiled for
-        cudaStream_t                        stream)                                         ///< [in] CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
+  //---------------------------------------------------------------------
+  // Tuning policies of current PTX compiler pass
+  //---------------------------------------------------------------------
+
+#if (CUB_PTX_ARCH >= 500)
+  using PtxPolicy = Policy500;
+
+#else
+  using PtxPolicy = Policy350;
+#endif
+
+  // "Opaque" policies (whose parameterizations aren't reflected in the type signature)
+  struct PtxHistogramSweepPolicy : PtxPolicy::HistogramSweepPolicy
+  {};
+
+  //---------------------------------------------------------------------
+  // Utilities
+  //---------------------------------------------------------------------
+
+  /**
+   * Initialize kernel dispatch configurations with the policies corresponding to the PTX assembly
+   * we will use
+   */
+  template <typename KernelConfig>
+  CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
+  InitConfigs(int ptx_version, KernelConfig &histogram_sweep_config)
+  {
+    cudaError_t result = cudaErrorNotSupported;
+    NV_IF_TARGET(
+      NV_IS_DEVICE,
+      (
+        // We're on the device, so initialize the kernel dispatch
+        // configurations with the current PTX policy
+        result = histogram_sweep_config.template Init<PtxHistogramSweepPolicy>();),
+      ( // NV_IS_HOST:
+        // We're on the host, so lookup and initialize the kernel dispatch
+        // configurations with the policies that match the device's PTX
+        // version
+        if (ptx_version >= 500) {
+          result = histogram_sweep_config.template Init<typename Policy500::HistogramSweepPolicy>();
+        } else {
+          result = histogram_sweep_config.template Init<typename Policy350::HistogramSweepPolicy>();
+        }));
+
+    return result;
+  }
+
+  /**
+   * Kernel kernel dispatch configuration
+   */
+  struct KernelConfig
+  {
+    int block_threads;
+    int pixels_per_thread;
+
+    template <typename BlockPolicy>
+    CUB_RUNTIME_FUNCTION __forceinline__ cudaError_t Init()
     {
-        cudaError error = cudaSuccess;
-        do
+      block_threads     = BlockPolicy::BLOCK_THREADS;
+      pixels_per_thread = BlockPolicy::PIXELS_PER_THREAD;
+
+      return cudaSuccess;
+    }
+  };
+
+  //---------------------------------------------------------------------
+  // Dispatch entrypoints
+  //---------------------------------------------------------------------
+
+  /**
+   * Privatization-based dispatch routine
+   *
+   * @tparam PrivatizedDecodeOpT
+   *   The transform operator type for determining privatized counter indices from samples,
+   *   one for each channel
+   *
+   * @tparam OutputDecodeOpT
+   *   The transform operator type for determining output bin-ids from privatized counter indices,
+   *   one for each channel
+   *
+   * @tparam DeviceHistogramInitKernelT
+   *   Function type of cub::DeviceHistogramInitKernel
+   *
+   * @tparam DeviceHistogramSweepKernelT
+   *   Function type of cub::DeviceHistogramSweepKernel
+   *
+   * @param d_temp_storage
+   *   Device-accessible allocation of temporary storage.
+   *   When NULL, the required allocation size is written to
+   *   `temp_storage_bytes` and no work is done.
+   *
+   * @param temp_storage_bytes
+   *   Reference to size in bytes of `d_temp_storage` allocation
+   *
+   * @param d_samples
+   *   The pointer to the input sequence of sample items.
+   *   The samples from different channels are assumed to be interleaved
+   *   (e.g., an array of 32-bit pixels where each pixel consists of four RGBA 8-bit samples).
+   *
+   * @param d_output_histograms
+   *   The pointers to the histogram counter output arrays, one for each active channel.
+   *   For channel<sub><em>i</em></sub>, the allocation length of `d_histograms[i]` should be
+   *   `num_output_levels[i] - 1`.
+   *
+   * @param num_privatized_levels
+   *   The number of bin level boundaries for delineating histogram samples in each active channel.
+   *   Implies that the number of bins for channel<sub><em>i</em></sub> is
+   *   `num_output_levels[i] - 1`.
+   *
+   * @param privatized_decode_op
+   *   Transform operators for determining bin-ids from samples, one for each channel
+   *
+   * @param num_output_levels
+   *   The number of bin level boundaries for delineating histogram samples in each active channel.
+   *   Implies that the number of bins for channel<sub><em>i</em></sub> is
+   *   `num_output_levels[i] - 1`.
+   *
+   * @param output_decode_op
+   *   Transform operators for determining bin-ids from samples, one for each channel
+   *
+   * @param max_num_output_bins
+   *   Maximum number of output bins in any channel
+   *
+   * @param num_row_pixels
+   *   The number of multi-channel pixels per row in the region of interest
+   *
+   * @param num_rows
+   *   The number of rows in the region of interest
+   *
+   * @param row_stride_samples
+   *   The number of samples between starts of consecutive rows in the region of interest
+   *
+   * @param histogram_init_kernel
+   *   Kernel function pointer to parameterization of cub::DeviceHistogramInitKernel
+   *
+   * @param histogram_sweep_kernel
+   *   Kernel function pointer to parameterization of cub::DeviceHistogramSweepKernel
+   *
+   * @param histogram_sweep_config
+   *   Dispatch parameters that match the policy that `histogram_sweep_kernel` was compiled for
+   *
+   * @param stream
+   *   CUDA stream to launch kernels within. Default is stream<sub>0</sub>.
+   */
+  template <typename PrivatizedDecodeOpT,
+            typename OutputDecodeOpT,
+            typename DeviceHistogramInitKernelT,
+            typename DeviceHistogramSweepKernelT>
+  CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
+  PrivatizedDispatch(void *d_temp_storage,
+                     size_t &temp_storage_bytes,
+                     SampleIteratorT d_samples,
+                     CounterT *d_output_histograms[NUM_ACTIVE_CHANNELS],
+                     int num_privatized_levels[NUM_ACTIVE_CHANNELS],
+                     PrivatizedDecodeOpT privatized_decode_op[NUM_ACTIVE_CHANNELS],
+                     int num_output_levels[NUM_ACTIVE_CHANNELS],
+                     OutputDecodeOpT output_decode_op[NUM_ACTIVE_CHANNELS],
+                     int max_num_output_bins,
+                     OffsetT num_row_pixels,
+                     OffsetT num_rows,
+                     OffsetT row_stride_samples,
+                     DeviceHistogramInitKernelT histogram_init_kernel,
+                     DeviceHistogramSweepKernelT histogram_sweep_kernel,
+                     KernelConfig histogram_sweep_config,
+                     cudaStream_t stream)
+  {
+    cudaError error = cudaSuccess;
+    do
+    {
+      // Get device ordinal
+      int device_ordinal;
+      if (CubDebug(error = cudaGetDevice(&device_ordinal)))
+      {
+        break;
+      }
+
+      // Get SM count
+      int sm_count;
+      if (CubDebug(error = cudaDeviceGetAttribute(&sm_count,
+                                                  cudaDevAttrMultiProcessorCount,
+                                                  device_ordinal)))
+      {
+        break;
+      }
+
+      // Get SM occupancy for histogram_sweep_kernel
+      int histogram_sweep_sm_occupancy;
+      if (CubDebug(error = MaxSmOccupancy(histogram_sweep_sm_occupancy,
+                                          histogram_sweep_kernel,
+                                          histogram_sweep_config.block_threads)))
+      {
+        break;
+      }
+
+      // Get device occupancy for histogram_sweep_kernel
+      int histogram_sweep_occupancy = histogram_sweep_sm_occupancy * sm_count;
+
+      if (num_row_pixels * NUM_CHANNELS == row_stride_samples)
+      {
+        // Treat as a single linear array of samples
+        num_row_pixels *= num_rows;
+        num_rows           = 1;
+        row_stride_samples = num_row_pixels * NUM_CHANNELS;
+      }
+
+      // Get grid dimensions, trying to keep total blocks ~histogram_sweep_occupancy
+      int pixels_per_tile = histogram_sweep_config.block_threads *
+                            histogram_sweep_config.pixels_per_thread;
+      int tiles_per_row  = static_cast<int>(cub::DivideAndRoundUp(num_row_pixels, pixels_per_tile));
+      int blocks_per_row = CUB_MIN(histogram_sweep_occupancy, tiles_per_row);
+      int blocks_per_col = (blocks_per_row > 0)
+                             ? int(CUB_MIN(histogram_sweep_occupancy / blocks_per_row, num_rows))
+                             : 0;
+      int num_thread_blocks = blocks_per_row * blocks_per_col;
+
+      dim3 sweep_grid_dims;
+      sweep_grid_dims.x = (unsigned int)blocks_per_row;
+      sweep_grid_dims.y = (unsigned int)blocks_per_col;
+      sweep_grid_dims.z = 1;
+
+      // Temporary storage allocation requirements
+      const int NUM_ALLOCATIONS          = NUM_ACTIVE_CHANNELS + 1;
+      void *allocations[NUM_ALLOCATIONS] = {};
+      size_t allocation_sizes[NUM_ALLOCATIONS];
+
+      for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
+      {
+        allocation_sizes[CHANNEL] = size_t(num_thread_blocks) *
+                                    (num_privatized_levels[CHANNEL] - 1) * sizeof(CounterT);
+      }
+
+      allocation_sizes[NUM_ALLOCATIONS - 1] = GridQueue<int>::AllocationSize();
+
+      // Alias the temporary allocations from the single storage blob (or compute the
+      // necessary size of the blob)
+      if (CubDebug(
+            error =
+              AliasTemporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
+      {
+        break;
+      }
+
+      if (d_temp_storage == nullptr)
+      {
+        // Return if the caller is simply requesting the size of the storage allocation
+        break;
+      }
+
+      // Construct the grid queue descriptor
+      GridQueue<int> tile_queue(allocations[NUM_ALLOCATIONS - 1]);
+
+      // Setup array wrapper for histogram channel output (because we can't pass static arrays
+      // as kernel parameters)
+      ArrayWrapper<CounterT *, NUM_ACTIVE_CHANNELS> d_output_histograms_wrapper;
+      for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
+      {
+        d_output_histograms_wrapper.array[CHANNEL] = d_output_histograms[CHANNEL];
+      }
+
+      // Setup array wrapper for privatized per-block histogram channel output (because we
+      // can't pass static arrays as kernel parameters)
+      ArrayWrapper<CounterT *, NUM_ACTIVE_CHANNELS> d_privatized_histograms_wrapper;
+      for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
+      {
+        d_privatized_histograms_wrapper.array[CHANNEL] = (CounterT *)allocations[CHANNEL];
+      }
+
+      // Setup array wrapper for sweep bin transforms (because we can't pass static arrays as
+      // kernel parameters)
+      ArrayWrapper<PrivatizedDecodeOpT, NUM_ACTIVE_CHANNELS> privatized_decode_op_wrapper;
+      for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
+      {
+        privatized_decode_op_wrapper.array[CHANNEL] = privatized_decode_op[CHANNEL];
+      }
+
+      // Setup array wrapper for aggregation bin transforms (because we can't pass static
+      // arrays as kernel parameters)
+      ArrayWrapper<OutputDecodeOpT, NUM_ACTIVE_CHANNELS> output_decode_op_wrapper;
+      for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
+      {
+        output_decode_op_wrapper.array[CHANNEL] = output_decode_op[CHANNEL];
+      }
+
+      // Setup array wrapper for num privatized bins (because we can't pass static arrays as
+      // kernel parameters)
+      ArrayWrapper<int, NUM_ACTIVE_CHANNELS> num_privatized_bins_wrapper;
+      for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
+      {
+        num_privatized_bins_wrapper.array[CHANNEL] = num_privatized_levels[CHANNEL] - 1;
+      }
+
+      // Setup array wrapper for num output bins (because we can't pass static arrays as
+      // kernel parameters)
+      ArrayWrapper<int, NUM_ACTIVE_CHANNELS> num_output_bins_wrapper;
+      for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
+      {
+        num_output_bins_wrapper.array[CHANNEL] = num_output_levels[CHANNEL] - 1;
+      }
+
+      int histogram_init_block_threads = 256;
+
+      int histogram_init_grid_dims = (max_num_output_bins + histogram_init_block_threads - 1) /
+                                     histogram_init_block_threads;
+
+// Log DeviceHistogramInitKernel configuration
+#ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
+      _CubLog("Invoking DeviceHistogramInitKernel<<<%d, %d, 0, %lld>>>()\n",
+              histogram_init_grid_dims,
+              histogram_init_block_threads,
+              (long long)stream);
+#endif
+
+      // Invoke histogram_init_kernel
+      THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(histogram_init_grid_dims,
+                                                              histogram_init_block_threads,
+                                                              0,
+                                                              stream)
+        .doit(histogram_init_kernel,
+              num_output_bins_wrapper,
+              d_output_histograms_wrapper,
+              tile_queue);
+
+      // Return if empty problem
+      if ((blocks_per_row == 0) || (blocks_per_col == 0))
+      {
+        break;
+      }
+
+// Log histogram_sweep_kernel configuration
+#ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
+      _CubLog("Invoking histogram_sweep_kernel<<<{%d, %d, %d}, %d, 0, %lld>>>(), %d pixels "
+              "per thread, %d SM occupancy\n",
+              sweep_grid_dims.x,
+              sweep_grid_dims.y,
+              sweep_grid_dims.z,
+              histogram_sweep_config.block_threads,
+              (long long)stream,
+              histogram_sweep_config.pixels_per_thread,
+              histogram_sweep_sm_occupancy);
+#endif
+
+      // Invoke histogram_sweep_kernel
+      THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(sweep_grid_dims,
+                                                              histogram_sweep_config.block_threads,
+                                                              0,
+                                                              stream)
+        .doit(histogram_sweep_kernel,
+              d_samples,
+              num_output_bins_wrapper,
+              num_privatized_bins_wrapper,
+              d_output_histograms_wrapper,
+              d_privatized_histograms_wrapper,
+              output_decode_op_wrapper,
+              privatized_decode_op_wrapper,
+              num_row_pixels,
+              num_rows,
+              row_stride_samples,
+              tiles_per_row,
+              tile_queue);
+
+      // Check for failure to launch
+      if (CubDebug(error = cudaPeekAtLastError()))
+      {
+        break;
+      }
+
+      // Sync the stream if specified to flush runtime errors
+      error = detail::DebugSyncStream(stream);
+      if (CubDebug(error))
+      {
+        break;
+      }
+    } while (0);
+
+    return error;
+  }
+
+  template <typename PrivatizedDecodeOpT,
+            typename OutputDecodeOpT,
+            typename DeviceHistogramInitKernelT,
+            typename DeviceHistogramSweepKernelT>
+  CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
+    CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
+    PrivatizedDispatch(void *d_temp_storage,
+                       size_t &temp_storage_bytes,
+                       SampleIteratorT d_samples,
+                       CounterT *d_output_histograms[NUM_ACTIVE_CHANNELS],
+                       int num_privatized_levels[NUM_ACTIVE_CHANNELS],
+                       PrivatizedDecodeOpT privatized_decode_op[NUM_ACTIVE_CHANNELS],
+                       int num_output_levels[NUM_ACTIVE_CHANNELS],
+                       OutputDecodeOpT output_decode_op[NUM_ACTIVE_CHANNELS],
+                       int max_num_output_bins,
+                       OffsetT num_row_pixels,
+                       OffsetT num_rows,
+                       OffsetT row_stride_samples,
+                       DeviceHistogramInitKernelT histogram_init_kernel,
+                       DeviceHistogramSweepKernelT histogram_sweep_kernel,
+                       KernelConfig histogram_sweep_config,
+                       cudaStream_t stream,
+                       bool debug_synchronous)
+  {
+    CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
+
+    return PrivatizedDispatch<PrivatizedDecodeOpT,
+                              OutputDecodeOpT,
+                              DeviceHistogramInitKernelT,
+                              DeviceHistogramSweepKernelT>(d_temp_storage,
+                                                           temp_storage_bytes,
+                                                           d_samples,
+                                                           d_output_histograms,
+                                                           num_privatized_levels,
+                                                           privatized_decode_op,
+                                                           num_output_levels,
+                                                           output_decode_op,
+                                                           max_num_output_bins,
+                                                           num_row_pixels,
+                                                           num_rows,
+                                                           row_stride_samples,
+                                                           histogram_init_kernel,
+                                                           histogram_sweep_kernel,
+                                                           histogram_sweep_config,
+                                                           stream);
+  }
+
+  /**
+   * Dispatch routine for HistogramRange, specialized for sample types larger than 8bit
+   *
+   * @param d_temp_storage
+   *   Device-accessible allocation of temporary storage.
+   *   When NULL, the required allocation size is written to `temp_storage_bytes` and
+   *   no work is done.
+   *
+   * @param temp_storage_bytes
+   *   Reference to size in bytes of `d_temp_storage` allocation
+   *
+   * @param d_samples
+   *   The pointer to the multi-channel input sequence of data samples.
+   *   The samples from different channels are assumed to be interleaved
+   *   (e.g., an array of 32-bit pixels where each pixel consists of four RGBA 8-bit samples).
+   *
+   * @param d_output_histograms
+   *   The pointers to the histogram counter output arrays, one for each active channel.
+   *   For channel<sub><em>i</em></sub>, the allocation length of `d_histograms[i]` should be
+   *   `num_output_levels[i] - 1`.
+   *
+   * @param num_output_levels
+   *   The number of boundaries (levels) for delineating histogram samples in each active channel.
+   *   Implies that the number of bins for channel<sub><em>i</em></sub> is
+   *   `num_output_levels[i] - 1`.
+   *
+   * @param d_levels
+   *   The pointers to the arrays of boundaries (levels), one for each active channel.
+   *   Bin ranges are defined by consecutive boundary pairings: lower sample value boundaries are
+   *   inclusive and upper sample value boundaries are exclusive.
+   *
+   * @param num_row_pixels
+   *   The number of multi-channel pixels per row in the region of interest
+   *
+   * @param num_rows
+   *   The number of rows in the region of interest
+   *
+   * @param row_stride_samples
+   *   The number of samples between starts of consecutive rows in the region of interest
+   *
+   * @param stream
+   *   CUDA stream to launch kernels within. Default is stream<sub>0</sub>.
+   *
+   * @param is_byte_sample
+   *   type indicating whether or not SampleT is a 8b type
+   */
+  CUB_RUNTIME_FUNCTION
+  static cudaError_t DispatchRange(void *d_temp_storage,
+                                   size_t &temp_storage_bytes,
+                                   SampleIteratorT d_samples,
+                                   CounterT *d_output_histograms[NUM_ACTIVE_CHANNELS],
+                                   int num_output_levels[NUM_ACTIVE_CHANNELS],
+                                   LevelT *d_levels[NUM_ACTIVE_CHANNELS],
+                                   OffsetT num_row_pixels,
+                                   OffsetT num_rows,
+                                   OffsetT row_stride_samples,
+                                   cudaStream_t stream,
+                                   Int2Type<false> /*is_byte_sample*/)
+  {
+    cudaError error = cudaSuccess;
+    do
+    {
+      // Get PTX version
+      int ptx_version = 0;
+      if (CubDebug(error = PtxVersion(ptx_version)))
+      {
+        break;
+      }
+
+      // Get kernel dispatch configurations
+      KernelConfig histogram_sweep_config;
+      if (CubDebug(error = InitConfigs(ptx_version, histogram_sweep_config)))
+      {
+        break;
+      }
+
+      // Use the search transform op for converting samples to privatized bins
+      typedef SearchTransform<LevelT *> PrivatizedDecodeOpT;
+
+      // Use the pass-thru transform op for converting privatized bins to output bins
+      typedef PassThruTransform OutputDecodeOpT;
+
+      PrivatizedDecodeOpT privatized_decode_op[NUM_ACTIVE_CHANNELS];
+      OutputDecodeOpT output_decode_op[NUM_ACTIVE_CHANNELS];
+      int max_levels = num_output_levels[0];
+
+      for (int channel = 0; channel < NUM_ACTIVE_CHANNELS; ++channel)
+      {
+        privatized_decode_op[channel].Init(d_levels[channel], num_output_levels[channel]);
+        if (num_output_levels[channel] > max_levels)
         {
-            // Get device ordinal
-            int device_ordinal;
-            if (CubDebug(error = cudaGetDevice(&device_ordinal))) break;
-
-            // Get SM count
-            int sm_count;
-            if (CubDebug(error = cudaDeviceGetAttribute (&sm_count, cudaDevAttrMultiProcessorCount, device_ordinal))) break;
-
-            // Get SM occupancy for histogram_sweep_kernel
-            int histogram_sweep_sm_occupancy;
-            if (CubDebug(error = MaxSmOccupancy(
-                histogram_sweep_sm_occupancy,
-                histogram_sweep_kernel,
-                histogram_sweep_config.block_threads))) break;
-
-            // Get device occupancy for histogram_sweep_kernel
-            int histogram_sweep_occupancy = histogram_sweep_sm_occupancy * sm_count;
-
-            if (num_row_pixels * NUM_CHANNELS == row_stride_samples)
-            {
-                // Treat as a single linear array of samples
-                num_row_pixels      *= num_rows;
-                num_rows            = 1;
-                row_stride_samples  = num_row_pixels * NUM_CHANNELS;
-            }
-
-            // Get grid dimensions, trying to keep total blocks ~histogram_sweep_occupancy
-            int pixels_per_tile     = histogram_sweep_config.block_threads * histogram_sweep_config.pixels_per_thread;
-            int tiles_per_row       = static_cast<int>(cub::DivideAndRoundUp(num_row_pixels, pixels_per_tile));
-            int blocks_per_row      = CUB_MIN(histogram_sweep_occupancy, tiles_per_row);
-            int blocks_per_col      = (blocks_per_row > 0) ?
-                                        int(CUB_MIN(histogram_sweep_occupancy / blocks_per_row, num_rows)) :
-                                        0;
-            int num_thread_blocks   = blocks_per_row * blocks_per_col;
-
-            dim3 sweep_grid_dims;
-            sweep_grid_dims.x = (unsigned int) blocks_per_row;
-            sweep_grid_dims.y = (unsigned int) blocks_per_col;
-            sweep_grid_dims.z = 1;
-
-            // Temporary storage allocation requirements
-            const int   NUM_ALLOCATIONS = NUM_ACTIVE_CHANNELS + 1;
-            void*       allocations[NUM_ALLOCATIONS] = {};
-            size_t      allocation_sizes[NUM_ALLOCATIONS];
-
-            for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
-                allocation_sizes[CHANNEL] = size_t(num_thread_blocks) * (num_privatized_levels[CHANNEL] - 1) * sizeof(CounterT);
-
-            allocation_sizes[NUM_ALLOCATIONS - 1] = GridQueue<int>::AllocationSize();
-
-            // Alias the temporary allocations from the single storage blob (or compute the necessary size of the blob)
-            if (CubDebug(error = AliasTemporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes))) break;
-            if (d_temp_storage == NULL)
-            {
-                // Return if the caller is simply requesting the size of the storage allocation
-                break;
-            }
-
-            // Construct the grid queue descriptor
-            GridQueue<int> tile_queue(allocations[NUM_ALLOCATIONS - 1]);
-
-            // Setup array wrapper for histogram channel output (because we can't pass static arrays as kernel parameters)
-            ArrayWrapper<CounterT*, NUM_ACTIVE_CHANNELS> d_output_histograms_wrapper;
-            for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
-                d_output_histograms_wrapper.array[CHANNEL] = d_output_histograms[CHANNEL];
-
-            // Setup array wrapper for privatized per-block histogram channel output (because we can't pass static arrays as kernel parameters)
-            ArrayWrapper<CounterT*, NUM_ACTIVE_CHANNELS> d_privatized_histograms_wrapper;
-            for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
-                d_privatized_histograms_wrapper.array[CHANNEL] = (CounterT*) allocations[CHANNEL];
-
-            // Setup array wrapper for sweep bin transforms (because we can't pass static arrays as kernel parameters)
-            ArrayWrapper<PrivatizedDecodeOpT, NUM_ACTIVE_CHANNELS> privatized_decode_op_wrapper;
-            for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
-                privatized_decode_op_wrapper.array[CHANNEL] = privatized_decode_op[CHANNEL];
-
-            // Setup array wrapper for aggregation bin transforms (because we can't pass static arrays as kernel parameters)
-            ArrayWrapper<OutputDecodeOpT, NUM_ACTIVE_CHANNELS> output_decode_op_wrapper;
-            for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
-                output_decode_op_wrapper.array[CHANNEL] = output_decode_op[CHANNEL];
-
-            // Setup array wrapper for num privatized bins (because we can't pass static arrays as kernel parameters)
-            ArrayWrapper<int, NUM_ACTIVE_CHANNELS> num_privatized_bins_wrapper;
-            for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
-                num_privatized_bins_wrapper.array[CHANNEL] = num_privatized_levels[CHANNEL] - 1;
-
-            // Setup array wrapper for num output bins (because we can't pass static arrays as kernel parameters)
-            ArrayWrapper<int, NUM_ACTIVE_CHANNELS> num_output_bins_wrapper;
-            for (int CHANNEL = 0; CHANNEL < NUM_ACTIVE_CHANNELS; ++CHANNEL)
-                num_output_bins_wrapper.array[CHANNEL] = num_output_levels[CHANNEL] - 1;
-
-            int histogram_init_block_threads    = 256;
-            int histogram_init_grid_dims        = (max_num_output_bins + histogram_init_block_threads - 1) / histogram_init_block_threads;
-
-            // Log DeviceHistogramInitKernel configuration
-            #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
-            _CubLog("Invoking DeviceHistogramInitKernel<<<%d, %d, 0, %lld>>>()\n",
-                histogram_init_grid_dims, histogram_init_block_threads, (long long) stream);
-            #endif
-
-            // Invoke histogram_init_kernel
-            THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(
-                histogram_init_grid_dims, histogram_init_block_threads, 0,
-                stream
-            ).doit(histogram_init_kernel,
-                num_output_bins_wrapper,
-                d_output_histograms_wrapper,
-                tile_queue);
-
-            // Return if empty problem
-            if ((blocks_per_row == 0) || (blocks_per_col == 0))
-                break;
-
-            // Log histogram_sweep_kernel configuration
-            #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
-            _CubLog("Invoking histogram_sweep_kernel<<<{%d, %d, %d}, %d, 0, %lld>>>(), %d pixels per thread, %d SM occupancy\n",
-                sweep_grid_dims.x, sweep_grid_dims.y, sweep_grid_dims.z,
-                histogram_sweep_config.block_threads, (long long) stream, histogram_sweep_config.pixels_per_thread, histogram_sweep_sm_occupancy);
-            #endif
-
-            // Invoke histogram_sweep_kernel
-            THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(
-                sweep_grid_dims, histogram_sweep_config.block_threads, 0, stream
-            ).doit(histogram_sweep_kernel,
-                d_samples,
-                num_output_bins_wrapper,
-                num_privatized_bins_wrapper,
-                d_output_histograms_wrapper,
-                d_privatized_histograms_wrapper,
-                output_decode_op_wrapper,
-                privatized_decode_op_wrapper,
-                num_row_pixels,
-                num_rows,
-                row_stride_samples,
-                tiles_per_row,
-                tile_queue);
-
-            // Check for failure to launch
-            if (CubDebug(error = cudaPeekAtLastError()))
-            {
-              break;
-            }
-
-            // Sync the stream if specified to flush runtime errors
-            error = detail::DebugSyncStream(stream);
-            if (CubDebug(error))
-            {
-                break;
-            }
+          max_levels = num_output_levels[channel];
         }
-        while (0);
+      }
+      int max_num_output_bins = max_levels - 1;
 
-        return error;
-    }
+      // Dispatch
+      if (max_num_output_bins > MAX_PRIVATIZED_SMEM_BINS)
+      {
+        // Too many bins to keep in shared memory.
+        const int PRIVATIZED_SMEM_BINS = 0;
 
-    template <typename PrivatizedDecodeOpT,
-              typename OutputDecodeOpT,
-              typename DeviceHistogramInitKernelT,
-              typename DeviceHistogramSweepKernelT>
-    CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-    CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t PrivatizedDispatch(
-      void *d_temp_storage,
-      size_t &temp_storage_bytes,
-      SampleIteratorT d_samples,
-      CounterT *d_output_histograms[NUM_ACTIVE_CHANNELS],
-      int num_privatized_levels[NUM_ACTIVE_CHANNELS],
-      PrivatizedDecodeOpT privatized_decode_op[NUM_ACTIVE_CHANNELS],
-      int num_output_levels[NUM_ACTIVE_CHANNELS],
-      OutputDecodeOpT output_decode_op[NUM_ACTIVE_CHANNELS],
-      int max_num_output_bins,
-      OffsetT num_row_pixels,
-      OffsetT num_rows,
-      OffsetT row_stride_samples,
-      DeviceHistogramInitKernelT histogram_init_kernel,
-      DeviceHistogramSweepKernelT histogram_sweep_kernel,
-      KernelConfig histogram_sweep_config,
-      cudaStream_t stream,
-      bool debug_synchronous)
-    {
-      CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
-
-      return PrivatizedDispatch<PrivatizedDecodeOpT,
-                                OutputDecodeOpT,
-                                DeviceHistogramInitKernelT,
-                                DeviceHistogramSweepKernelT>(
-        d_temp_storage,
-        temp_storage_bytes,
-        d_samples,
-        d_output_histograms,
-        num_privatized_levels,
-        privatized_decode_op,
-        num_output_levels,
-        output_decode_op,
-        max_num_output_bins,
-        num_row_pixels,
-        num_rows,
-        row_stride_samples,
-        histogram_init_kernel,
-        histogram_sweep_kernel,
-        histogram_sweep_config,
-        stream);
-    }
-
-
-    /**
-     * Dispatch routine for HistogramRange, specialized for sample types larger than 8bit
-     */
-    CUB_RUNTIME_FUNCTION
-    static cudaError_t DispatchRange(
-        void*               d_temp_storage,                             ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
-        size_t&             temp_storage_bytes,                         ///< [in,out] Reference to size in bytes of \p d_temp_storage allocation
-        SampleIteratorT     d_samples,                                  ///< [in] The pointer to the multi-channel input sequence of data samples. The samples from different channels are assumed to be interleaved (e.g., an array of 32-bit pixels where each pixel consists of four RGBA 8-bit samples).
-        CounterT*           d_output_histograms[NUM_ACTIVE_CHANNELS],   ///< [out] The pointers to the histogram counter output arrays, one for each active channel.  For channel<sub><em>i</em></sub>, the allocation length of <tt>d_histograms[i]</tt> should be <tt>num_output_levels[i]</tt> - 1.
-        int                 num_output_levels[NUM_ACTIVE_CHANNELS],     ///< [in] The number of boundaries (levels) for delineating histogram samples in each active channel.  Implies that the number of bins for channel<sub><em>i</em></sub> is <tt>num_output_levels[i]</tt> - 1.
-        LevelT              *d_levels[NUM_ACTIVE_CHANNELS],             ///< [in] The pointers to the arrays of boundaries (levels), one for each active channel.  Bin ranges are defined by consecutive boundary pairings: lower sample value boundaries are inclusive and upper sample value boundaries are exclusive.
-        OffsetT             num_row_pixels,                             ///< [in] The number of multi-channel pixels per row in the region of interest
-        OffsetT             num_rows,                                   ///< [in] The number of rows in the region of interest
-        OffsetT             row_stride_samples,                         ///< [in] The number of samples between starts of consecutive rows in the region of interest
-        cudaStream_t        stream,                                     ///< [in] CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
-        Int2Type<false>     /*is_byte_sample*/)                         ///< [in] Marker type indicating whether or not SampleT is a 8b type
-    {
-        cudaError error = cudaSuccess;
-        do
+        if (CubDebug(error = PrivatizedDispatch(
+                       d_temp_storage,
+                       temp_storage_bytes,
+                       d_samples,
+                       d_output_histograms,
+                       num_output_levels,
+                       privatized_decode_op,
+                       num_output_levels,
+                       output_decode_op,
+                       max_num_output_bins,
+                       num_row_pixels,
+                       num_rows,
+                       row_stride_samples,
+                       DeviceHistogramInitKernel<NUM_ACTIVE_CHANNELS, CounterT, OffsetT>,
+                       DeviceHistogramSweepKernel<PtxHistogramSweepPolicy,
+                                                  PRIVATIZED_SMEM_BINS,
+                                                  NUM_CHANNELS,
+                                                  NUM_ACTIVE_CHANNELS,
+                                                  SampleIteratorT,
+                                                  CounterT,
+                                                  PrivatizedDecodeOpT,
+                                                  OutputDecodeOpT,
+                                                  OffsetT>,
+                       histogram_sweep_config,
+                       stream)))
         {
-            // Get PTX version
-            int ptx_version = 0;
-            if (CubDebug(error = PtxVersion(ptx_version))) break;
-
-            // Get kernel dispatch configurations
-            KernelConfig histogram_sweep_config;
-            if (CubDebug(error = InitConfigs(ptx_version, histogram_sweep_config)))
-                break;
-
-            // Use the search transform op for converting samples to privatized bins
-            typedef SearchTransform<LevelT*> PrivatizedDecodeOpT;
-
-            // Use the pass-thru transform op for converting privatized bins to output bins
-            typedef PassThruTransform OutputDecodeOpT;
-
-            PrivatizedDecodeOpT     privatized_decode_op[NUM_ACTIVE_CHANNELS];
-            OutputDecodeOpT         output_decode_op[NUM_ACTIVE_CHANNELS];
-            int                     max_levels = num_output_levels[0];
-
-            for (int channel = 0; channel < NUM_ACTIVE_CHANNELS; ++channel)
-            {
-                privatized_decode_op[channel].Init(d_levels[channel], num_output_levels[channel]);
-                if (num_output_levels[channel] > max_levels)
-                    max_levels = num_output_levels[channel];
-            }
-            int max_num_output_bins = max_levels - 1;
-
-            // Dispatch
-            if (max_num_output_bins > MAX_PRIVATIZED_SMEM_BINS)
-            {
-                // Too many bins to keep in shared memory.
-                const int PRIVATIZED_SMEM_BINS = 0;
-
-                if (CubDebug(error = PrivatizedDispatch(
-                    d_temp_storage,
-                    temp_storage_bytes,
-                    d_samples,
-                    d_output_histograms,
-                    num_output_levels,
-                    privatized_decode_op,
-                    num_output_levels,
-                    output_decode_op,
-                    max_num_output_bins,
-                    num_row_pixels,
-                    num_rows,
-                    row_stride_samples,
-                    DeviceHistogramInitKernel<NUM_ACTIVE_CHANNELS, CounterT, OffsetT>,
-                    DeviceHistogramSweepKernel<PtxHistogramSweepPolicy, PRIVATIZED_SMEM_BINS, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, SampleIteratorT, CounterT, PrivatizedDecodeOpT, OutputDecodeOpT, OffsetT>,
-                    histogram_sweep_config,
-                    stream))) break;
-            }
-            else
-            {
-                // Dispatch shared-privatized approach
-                const int PRIVATIZED_SMEM_BINS = MAX_PRIVATIZED_SMEM_BINS;
-
-                if (CubDebug(error = PrivatizedDispatch(
-                    d_temp_storage,
-                    temp_storage_bytes,
-                    d_samples,
-                    d_output_histograms,
-                    num_output_levels,
-                    privatized_decode_op,
-                    num_output_levels,
-                    output_decode_op,
-                    max_num_output_bins,
-                    num_row_pixels,
-                    num_rows,
-                    row_stride_samples,
-                    DeviceHistogramInitKernel<NUM_ACTIVE_CHANNELS, CounterT, OffsetT>,
-                    DeviceHistogramSweepKernel<PtxHistogramSweepPolicy, PRIVATIZED_SMEM_BINS, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, SampleIteratorT, CounterT, PrivatizedDecodeOpT, OutputDecodeOpT, OffsetT>,
-                    histogram_sweep_config,
-                    stream))) break;
-            }
-
-        } while (0);
-
-        return error;
-    }
-
-    CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-    CUB_RUNTIME_FUNCTION
-    static cudaError_t
-    DispatchRange(void *d_temp_storage,
-                  size_t &temp_storage_bytes,
-                  SampleIteratorT d_samples,
-                  CounterT *d_output_histograms[NUM_ACTIVE_CHANNELS],
-                  int num_output_levels[NUM_ACTIVE_CHANNELS],
-                  LevelT *d_levels[NUM_ACTIVE_CHANNELS],
-                  OffsetT num_row_pixels,
-                  OffsetT num_rows,
-                  OffsetT row_stride_samples,
-                  cudaStream_t stream,
-                  bool debug_synchronous,
-                  Int2Type<false> is_byte_sample)
-    {
-      CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
-
-      return DispatchRange(d_temp_storage,
-                           temp_storage_bytes,
-                           d_samples,
-                           d_output_histograms,
-                           num_output_levels,
-                           d_levels,
-                           num_row_pixels,
-                           num_rows,
-                           row_stride_samples,
-                           stream,
-                           is_byte_sample);
-    }
-
-    /**
-     * Dispatch routine for HistogramRange, specialized for 8-bit sample types (computes 256-bin privatized histograms and then reduces to user-specified levels)
-     */
-    CUB_RUNTIME_FUNCTION
-    static cudaError_t DispatchRange(
-        void*               d_temp_storage,                             ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
-        size_t&             temp_storage_bytes,                         ///< [in,out] Reference to size in bytes of \p d_temp_storage allocation
-        SampleIteratorT     d_samples,                                  ///< [in] The pointer to the multi-channel input sequence of data samples. The samples from different channels are assumed to be interleaved (e.g., an array of 32-bit pixels where each pixel consists of four RGBA 8-bit samples).
-        CounterT*           d_output_histograms[NUM_ACTIVE_CHANNELS],   ///< [out] The pointers to the histogram counter output arrays, one for each active channel.  For channel<sub><em>i</em></sub>, the allocation length of <tt>d_histograms[i]</tt> should be <tt>num_output_levels[i]</tt> - 1.
-        int                 num_output_levels[NUM_ACTIVE_CHANNELS],     ///< [in] The number of boundaries (levels) for delineating histogram samples in each active channel.  Implies that the number of bins for channel<sub><em>i</em></sub> is <tt>num_output_levels[i]</tt> - 1.
-        LevelT              *d_levels[NUM_ACTIVE_CHANNELS],             ///< [in] The pointers to the arrays of boundaries (levels), one for each active channel.  Bin ranges are defined by consecutive boundary pairings: lower sample value boundaries are inclusive and upper sample value boundaries are exclusive.
-        OffsetT             num_row_pixels,                             ///< [in] The number of multi-channel pixels per row in the region of interest
-        OffsetT             num_rows,                                   ///< [in] The number of rows in the region of interest
-        OffsetT             row_stride_samples,                         ///< [in] The number of samples between starts of consecutive rows in the region of interest
-        cudaStream_t        stream,                                     ///< [in] CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
-        Int2Type<true>      /*is_byte_sample*/)                         ///< [in] Marker type indicating whether or not SampleT is a 8b type
-    {
-        cudaError error = cudaSuccess;
-        do
-        {
-            // Get PTX version
-            int ptx_version = 0;
-            if (CubDebug(error = PtxVersion(ptx_version))) break;
-
-            // Get kernel dispatch configurations
-            KernelConfig histogram_sweep_config;
-            if (CubDebug(error = InitConfigs(ptx_version, histogram_sweep_config)))
-                break;
-
-            // Use the pass-thru transform op for converting samples to privatized bins
-            typedef PassThruTransform PrivatizedDecodeOpT;
-
-            // Use the search transform op for converting privatized bins to output bins
-            typedef SearchTransform<LevelT*> OutputDecodeOpT;
-
-            int                         num_privatized_levels[NUM_ACTIVE_CHANNELS];
-            PrivatizedDecodeOpT         privatized_decode_op[NUM_ACTIVE_CHANNELS];
-            OutputDecodeOpT             output_decode_op[NUM_ACTIVE_CHANNELS];
-            int                         max_levels = num_output_levels[0];              // Maximum number of levels in any channel
-
-            for (int channel = 0; channel < NUM_ACTIVE_CHANNELS; ++channel)
-            {
-                num_privatized_levels[channel] = 257;
-                output_decode_op[channel].Init(d_levels[channel], num_output_levels[channel]);
-
-                if (num_output_levels[channel] > max_levels)
-                    max_levels = num_output_levels[channel];
-            }
-            int max_num_output_bins = max_levels - 1;
-
-            const int PRIVATIZED_SMEM_BINS = 256;
-
-            if (CubDebug(error = PrivatizedDispatch(
-                d_temp_storage,
-                temp_storage_bytes,
-                d_samples,
-                d_output_histograms,
-                num_privatized_levels,
-                privatized_decode_op,
-                num_output_levels,
-                output_decode_op,
-                max_num_output_bins,
-                num_row_pixels,
-                num_rows,
-                row_stride_samples,
-                DeviceHistogramInitKernel<NUM_ACTIVE_CHANNELS, CounterT, OffsetT>,
-                DeviceHistogramSweepKernel<PtxHistogramSweepPolicy, PRIVATIZED_SMEM_BINS, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, SampleIteratorT, CounterT, PrivatizedDecodeOpT, OutputDecodeOpT, OffsetT>,
-                histogram_sweep_config,
-                stream))) break;
-
-        } while (0);
-
-        return error;
-    }
-
-    CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-    CUB_RUNTIME_FUNCTION
-    static cudaError_t
-    DispatchRange(void *d_temp_storage,
-                  size_t &temp_storage_bytes,
-                  SampleIteratorT d_samples,
-                  CounterT *d_output_histograms[NUM_ACTIVE_CHANNELS],
-                  int num_output_levels[NUM_ACTIVE_CHANNELS],
-                  LevelT *d_levels[NUM_ACTIVE_CHANNELS],
-                  OffsetT num_row_pixels,
-                  OffsetT num_rows,
-                  OffsetT row_stride_samples,
-                  cudaStream_t stream,
-                  bool debug_synchronous,
-                  Int2Type<true> is_byte_sample)
-    {
-      CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
-
-      return DispatchRange(d_temp_storage,
-                           temp_storage_bytes,
-                           d_samples,
-                           d_output_histograms,
-                           num_output_levels,
-                           d_levels,
-                           num_row_pixels,
-                           num_rows,
-                           row_stride_samples,
-                           stream,
-                           is_byte_sample);
-    }
-
-    /**
-     * Dispatch routine for HistogramEven, specialized for sample types larger than 8-bit
-     */
-    CUB_RUNTIME_FUNCTION __forceinline__
-    static cudaError_t DispatchEven(
-        void*               d_temp_storage,                            ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
-        size_t&             temp_storage_bytes,                        ///< [in,out] Reference to size in bytes of \p d_temp_storage allocation
-        SampleIteratorT     d_samples,                                  ///< [in] The pointer to the input sequence of sample items. The samples from different channels are assumed to be interleaved (e.g., an array of 32-bit pixels where each pixel consists of four RGBA 8-bit samples).
-        CounterT*           d_output_histograms[NUM_ACTIVE_CHANNELS],  ///< [out] The pointers to the histogram counter output arrays, one for each active channel.  For channel<sub><em>i</em></sub>, the allocation length of <tt>d_histograms[i]</tt> should be <tt>num_output_levels[i]</tt> - 1.
-        int                 num_output_levels[NUM_ACTIVE_CHANNELS],     ///< [in] The number of bin level boundaries for delineating histogram samples in each active channel.  Implies that the number of bins for channel<sub><em>i</em></sub> is <tt>num_output_levels[i]</tt> - 1.
-        LevelT              lower_level[NUM_ACTIVE_CHANNELS],           ///< [in] The lower sample value bound (inclusive) for the lowest histogram bin in each active channel.
-        LevelT              upper_level[NUM_ACTIVE_CHANNELS],           ///< [in] The upper sample value bound (exclusive) for the highest histogram bin in each active channel.
-        OffsetT             num_row_pixels,                             ///< [in] The number of multi-channel pixels per row in the region of interest
-        OffsetT             num_rows,                                   ///< [in] The number of rows in the region of interest
-        OffsetT             row_stride_samples,                         ///< [in] The number of samples between starts of consecutive rows in the region of interest
-        cudaStream_t        stream,                                     ///< [in] CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
-        Int2Type<false>     /*is_byte_sample*/)                         ///< [in] Marker type indicating whether or not SampleT is a 8b type
-    {
-        cudaError error = cudaSuccess;
-        do
-        {
-            // Get PTX version
-            int ptx_version = 0;
-            if (CubDebug(error = PtxVersion(ptx_version))) break;
-
-            // Get kernel dispatch configurations
-            KernelConfig histogram_sweep_config;
-            if (CubDebug(error = InitConfigs(ptx_version, histogram_sweep_config)))
-                break;
-
-            // Use the scale transform op for converting samples to privatized bins
-            typedef ScaleTransform PrivatizedDecodeOpT;
-
-            // Use the pass-thru transform op for converting privatized bins to output bins
-            typedef PassThruTransform OutputDecodeOpT;
-
-            PrivatizedDecodeOpT         privatized_decode_op[NUM_ACTIVE_CHANNELS];
-            OutputDecodeOpT             output_decode_op[NUM_ACTIVE_CHANNELS];
-            int                         max_levels = num_output_levels[0];
-
-            for (int channel = 0; channel < NUM_ACTIVE_CHANNELS; ++channel)
-            {
-              error = privatized_decode_op[channel].Init(num_output_levels[channel],
-                                                         upper_level[channel],
-                                                         lower_level[channel]);
-              if (CubDebug(error != cudaSuccess))
-              {
-                // Make sure to also return a reasonable value for `temp_storage_bytes` in case of
-                // an overflow of the bin computation, in which case a subsequent algorithm
-                // invocation will also fail
-                if (!d_temp_storage)
-                {
-                  temp_storage_bytes = 1U;
-                }
-                return error;
-              }
-
-              if (num_output_levels[channel] > max_levels)
-              {
-                max_levels = num_output_levels[channel];
-              }
-            }
-            int max_num_output_bins = max_levels - 1;
-
-            if (max_num_output_bins > MAX_PRIVATIZED_SMEM_BINS)
-            {
-                // Dispatch shared-privatized approach
-                const int PRIVATIZED_SMEM_BINS = 0;
-
-                if (CubDebug(error = PrivatizedDispatch(
-                    d_temp_storage,
-                    temp_storage_bytes,
-                    d_samples,
-                    d_output_histograms,
-                    num_output_levels,
-                    privatized_decode_op,
-                    num_output_levels,
-                    output_decode_op,
-                    max_num_output_bins,
-                    num_row_pixels,
-                    num_rows,
-                    row_stride_samples,
-                    DeviceHistogramInitKernel<NUM_ACTIVE_CHANNELS, CounterT, OffsetT>,
-                    DeviceHistogramSweepKernel<PtxHistogramSweepPolicy, PRIVATIZED_SMEM_BINS, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, SampleIteratorT, CounterT, PrivatizedDecodeOpT, OutputDecodeOpT, OffsetT>,
-                    histogram_sweep_config,
-                    stream))) break;
-            }
-            else
-            {
-                // Dispatch shared-privatized approach
-                const int PRIVATIZED_SMEM_BINS = MAX_PRIVATIZED_SMEM_BINS;
-
-                if (CubDebug(error = PrivatizedDispatch(
-                    d_temp_storage,
-                    temp_storage_bytes,
-                    d_samples,
-                    d_output_histograms,
-                    num_output_levels,
-                    privatized_decode_op,
-                    num_output_levels,
-                    output_decode_op,
-                    max_num_output_bins,
-                    num_row_pixels,
-                    num_rows,
-                    row_stride_samples,
-                    DeviceHistogramInitKernel<NUM_ACTIVE_CHANNELS, CounterT, OffsetT>,
-                    DeviceHistogramSweepKernel<PtxHistogramSweepPolicy, PRIVATIZED_SMEM_BINS, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, SampleIteratorT, CounterT, PrivatizedDecodeOpT, OutputDecodeOpT, OffsetT>,
-                    histogram_sweep_config,
-                    stream))) break;
-            }
+          break;
         }
-        while (0);
+      }
+      else
+      {
+        // Dispatch shared-privatized approach
+        const int PRIVATIZED_SMEM_BINS = MAX_PRIVATIZED_SMEM_BINS;
 
-        return error;
-    }
-
-    CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-    CUB_RUNTIME_FUNCTION __forceinline__
-    static cudaError_t DispatchEven(
-        void*               d_temp_storage,                         
-        size_t&             temp_storage_bytes,                      
-        SampleIteratorT     d_samples,                                
-        CounterT*           d_output_histograms[NUM_ACTIVE_CHANNELS],  
-        int                 num_output_levels[NUM_ACTIVE_CHANNELS],   
-        LevelT              lower_level[NUM_ACTIVE_CHANNELS],          
-        LevelT              upper_level[NUM_ACTIVE_CHANNELS],           
-        OffsetT             num_row_pixels,                            
-        OffsetT             num_rows,                                   
-        OffsetT             row_stride_samples,                        
-        cudaStream_t        stream,                                     
-        bool                debug_synchronous,                          
-        Int2Type<false>     is_byte_sample)                    
-    {
-      CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
-
-      return DispatchEven(d_temp_storage,
-                          temp_storage_bytes,
-                          d_samples,
-                          d_output_histograms,
-                          num_output_levels,
-                          lower_level,
-                          upper_level,
-                          num_row_pixels,
-                          num_rows,
-                          row_stride_samples,
-                          stream,
-                          is_byte_sample);
-    }
-
-
-    /**
-     * Dispatch routine for HistogramEven, specialized for 8-bit sample types (computes 256-bin privatized histograms and then reduces to user-specified levels)
-     */
-    CUB_RUNTIME_FUNCTION __forceinline__
-    static cudaError_t DispatchEven(
-        void*               d_temp_storage,                             ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
-        size_t&             temp_storage_bytes,                         ///< [in,out] Reference to size in bytes of \p d_temp_storage allocation
-        SampleIteratorT     d_samples,                                  ///< [in] The pointer to the input sequence of sample items. The samples from different channels are assumed to be interleaved (e.g., an array of 32-bit pixels where each pixel consists of four RGBA 8-bit samples).
-        CounterT*           d_output_histograms[NUM_ACTIVE_CHANNELS],   ///< [out] The pointers to the histogram counter output arrays, one for each active channel.  For channel<sub><em>i</em></sub>, the allocation length of <tt>d_histograms[i]</tt> should be <tt>num_output_levels[i]</tt> - 1.
-        int                 num_output_levels[NUM_ACTIVE_CHANNELS],     ///< [in] The number of bin level boundaries for delineating histogram samples in each active channel.  Implies that the number of bins for channel<sub><em>i</em></sub> is <tt>num_output_levels[i]</tt> - 1.
-        LevelT              lower_level[NUM_ACTIVE_CHANNELS],           ///< [in] The lower sample value bound (inclusive) for the lowest histogram bin in each active channel.
-        LevelT              upper_level[NUM_ACTIVE_CHANNELS],           ///< [in] The upper sample value bound (exclusive) for the highest histogram bin in each active channel.
-        OffsetT             num_row_pixels,                             ///< [in] The number of multi-channel pixels per row in the region of interest
-        OffsetT             num_rows,                                   ///< [in] The number of rows in the region of interest
-        OffsetT             row_stride_samples,                         ///< [in] The number of samples between starts of consecutive rows in the region of interest
-        cudaStream_t        stream,                                     ///< [in] CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
-        Int2Type<true>      /*is_byte_sample*/)                         ///< [in] Marker type indicating whether or not SampleT is a 8b type
-    {
-        cudaError error = cudaSuccess;
-        do
+        if (CubDebug(error = PrivatizedDispatch(
+                       d_temp_storage,
+                       temp_storage_bytes,
+                       d_samples,
+                       d_output_histograms,
+                       num_output_levels,
+                       privatized_decode_op,
+                       num_output_levels,
+                       output_decode_op,
+                       max_num_output_bins,
+                       num_row_pixels,
+                       num_rows,
+                       row_stride_samples,
+                       DeviceHistogramInitKernel<NUM_ACTIVE_CHANNELS, CounterT, OffsetT>,
+                       DeviceHistogramSweepKernel<PtxHistogramSweepPolicy,
+                                                  PRIVATIZED_SMEM_BINS,
+                                                  NUM_CHANNELS,
+                                                  NUM_ACTIVE_CHANNELS,
+                                                  SampleIteratorT,
+                                                  CounterT,
+                                                  PrivatizedDecodeOpT,
+                                                  OutputDecodeOpT,
+                                                  OffsetT>,
+                       histogram_sweep_config,
+                       stream)))
         {
-            // Get PTX version
-            int ptx_version = 0;
-            if (CubDebug(error = PtxVersion(ptx_version))) break;
-
-            // Get kernel dispatch configurations
-            KernelConfig histogram_sweep_config;
-            if (CubDebug(error = InitConfigs(ptx_version, histogram_sweep_config)))
-                break;
-
-            // Use the pass-thru transform op for converting samples to privatized bins
-            typedef PassThruTransform PrivatizedDecodeOpT;
-
-            // Use the scale transform op for converting privatized bins to output bins
-            typedef ScaleTransform OutputDecodeOpT;
-
-            int                     num_privatized_levels[NUM_ACTIVE_CHANNELS];
-            PrivatizedDecodeOpT     privatized_decode_op[NUM_ACTIVE_CHANNELS];
-            OutputDecodeOpT         output_decode_op[NUM_ACTIVE_CHANNELS];
-            int                     max_levels = num_output_levels[0];
-
-            for (int channel = 0; channel < NUM_ACTIVE_CHANNELS; ++channel)
-            {
-                num_privatized_levels[channel] = 257;
-
-                output_decode_op[channel].Init(num_output_levels[channel],
-                                               upper_level[channel],
-                                               lower_level[channel]);
-
-                if (num_output_levels[channel] > max_levels)
-                    max_levels = num_output_levels[channel];
-            }
-            int max_num_output_bins = max_levels - 1;
-
-            const int PRIVATIZED_SMEM_BINS = 256;
-
-            if (CubDebug(error = PrivatizedDispatch(
-                d_temp_storage,
-                temp_storage_bytes,
-                d_samples,
-                d_output_histograms,
-                num_privatized_levels,
-                privatized_decode_op,
-                num_output_levels,
-                output_decode_op,
-                max_num_output_bins,
-                num_row_pixels,
-                num_rows,
-                row_stride_samples,
-                DeviceHistogramInitKernel<NUM_ACTIVE_CHANNELS, CounterT, OffsetT>,
-                DeviceHistogramSweepKernel<PtxHistogramSweepPolicy, PRIVATIZED_SMEM_BINS, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, SampleIteratorT, CounterT, PrivatizedDecodeOpT, OutputDecodeOpT, OffsetT>,
-                histogram_sweep_config,
-                stream))) break;
-
+          break;
         }
-        while (0);
+      }
+    } while (0);
 
-        return error;
-    }
+    return error;
+  }
 
-    CUB_RUNTIME_FUNCTION __forceinline__
-    static cudaError_t DispatchEven(
-        void*               d_temp_storage,                         
-        size_t&             temp_storage_bytes,                      
-        SampleIteratorT     d_samples,                                
-        CounterT*           d_output_histograms[NUM_ACTIVE_CHANNELS],  
-        int                 num_output_levels[NUM_ACTIVE_CHANNELS],     
-        LevelT              lower_level[NUM_ACTIVE_CHANNELS],          
-        LevelT              upper_level[NUM_ACTIVE_CHANNELS],           
-        OffsetT             num_row_pixels,                            
-        OffsetT             num_rows,                                   
-        OffsetT             row_stride_samples,                        
-        cudaStream_t        stream,                                     
-        bool                debug_synchronous,                          
-        Int2Type<true>      is_byte_sample)                         
+  CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
+  CUB_RUNTIME_FUNCTION
+  static cudaError_t DispatchRange(void *d_temp_storage,
+                                   size_t &temp_storage_bytes,
+                                   SampleIteratorT d_samples,
+                                   CounterT *d_output_histograms[NUM_ACTIVE_CHANNELS],
+                                   int num_output_levels[NUM_ACTIVE_CHANNELS],
+                                   LevelT *d_levels[NUM_ACTIVE_CHANNELS],
+                                   OffsetT num_row_pixels,
+                                   OffsetT num_rows,
+                                   OffsetT row_stride_samples,
+                                   cudaStream_t stream,
+                                   bool debug_synchronous,
+                                   Int2Type<false> is_byte_sample)
+  {
+    CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
+
+    return DispatchRange(d_temp_storage,
+                         temp_storage_bytes,
+                         d_samples,
+                         d_output_histograms,
+                         num_output_levels,
+                         d_levels,
+                         num_row_pixels,
+                         num_rows,
+                         row_stride_samples,
+                         stream,
+                         is_byte_sample);
+  }
+
+  /**
+   * Dispatch routine for HistogramRange, specialized for 8-bit sample types
+   * (computes 256-bin privatized histograms and then reduces to user-specified levels)
+   *
+   * @param d_temp_storage
+   *   Device-accessible allocation of temporary storage.
+   *   When NULL, the required allocation size is written to `temp_storage_bytes` and
+   *   no work is done.
+   *
+   * @param temp_storage_bytes
+   *   Reference to size in bytes of `d_temp_storage` allocation
+   *
+   * @param d_samples
+   *   The pointer to the multi-channel input sequence of data samples.
+   *   The samples from different channels are assumed to be interleaved
+   *   (e.g., an array of 32-bit pixels where each pixel consists of four RGBA 8-bit samples).
+   *
+   * @param d_output_histograms
+   *   The pointers to the histogram counter output arrays, one for each active channel.
+   *   For channel<sub><em>i</em></sub>, the allocation length of
+   *   `d_histograms[i]` should be `num_output_levels[i] - 1`.
+   *
+   * @param num_output_levels
+   *   The number of boundaries (levels) for delineating histogram samples in each active channel.
+   *   Implies that the number of bins for channel<sub><em>i</em></sub> is
+   *   `num_output_levels[i] - 1`.
+   *
+   * @param d_levels
+   *   The pointers to the arrays of boundaries (levels), one for each active channel.
+   *   Bin ranges are defined by consecutive boundary pairings: lower sample value boundaries are
+   *   inclusive and upper sample value boundaries are exclusive.
+   *
+   * @param num_row_pixels
+   *   The number of multi-channel pixels per row in the region of interest
+   *
+   * @param num_rows
+   *   The number of rows in the region of interest
+   *
+   * @param row_stride_samples
+   *   The number of samples between starts of consecutive rows in the region of interest
+   *
+   * @param stream
+   *   CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
+   *
+   * @param is_byte_sample
+   *   Marker type indicating whether or not SampleT is a 8b type
+   */
+  CUB_RUNTIME_FUNCTION
+  static cudaError_t DispatchRange(void *d_temp_storage,
+                                   size_t &temp_storage_bytes,
+                                   SampleIteratorT d_samples,
+                                   CounterT *d_output_histograms[NUM_ACTIVE_CHANNELS],
+                                   int num_output_levels[NUM_ACTIVE_CHANNELS],
+                                   LevelT *d_levels[NUM_ACTIVE_CHANNELS],
+                                   OffsetT num_row_pixels,
+                                   OffsetT num_rows,
+                                   OffsetT row_stride_samples,
+                                   cudaStream_t stream,
+                                   Int2Type<true> /*is_byte_sample*/)
+  {
+    cudaError error = cudaSuccess;
+    do
     {
-      CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
+      // Get PTX version
+      int ptx_version = 0;
+      if (CubDebug(error = PtxVersion(ptx_version)))
+      {
+        break;
+      }
 
-      return DispatchEven(d_temp_storage,
-                          temp_storage_bytes,
-                          d_samples,
-                          d_output_histograms,
-                          num_output_levels,
-                          lower_level,
-                          upper_level,
-                          num_row_pixels,
-                          num_rows,
-                          row_stride_samples,
-                          stream,
-                          is_byte_sample);
-    }
+      // Get kernel dispatch configurations
+      KernelConfig histogram_sweep_config;
+      if (CubDebug(error = InitConfigs(ptx_version, histogram_sweep_config)))
+      {
+        break;
+      }
+
+      // Use the pass-thru transform op for converting samples to privatized bins
+      typedef PassThruTransform PrivatizedDecodeOpT;
+
+      // Use the search transform op for converting privatized bins to output bins
+      typedef SearchTransform<LevelT *> OutputDecodeOpT;
+
+      int num_privatized_levels[NUM_ACTIVE_CHANNELS];
+      PrivatizedDecodeOpT privatized_decode_op[NUM_ACTIVE_CHANNELS];
+      OutputDecodeOpT output_decode_op[NUM_ACTIVE_CHANNELS];
+      int max_levels = num_output_levels[0]; // Maximum number of levels in any channel
+
+      for (int channel = 0; channel < NUM_ACTIVE_CHANNELS; ++channel)
+      {
+        num_privatized_levels[channel] = 257;
+        output_decode_op[channel].Init(d_levels[channel], num_output_levels[channel]);
+
+        if (num_output_levels[channel] > max_levels)
+        {
+          max_levels = num_output_levels[channel];
+        }
+      }
+      int max_num_output_bins = max_levels - 1;
+
+      const int PRIVATIZED_SMEM_BINS = 256;
+
+      if (CubDebug(error = PrivatizedDispatch(
+                     d_temp_storage,
+                     temp_storage_bytes,
+                     d_samples,
+                     d_output_histograms,
+                     num_privatized_levels,
+                     privatized_decode_op,
+                     num_output_levels,
+                     output_decode_op,
+                     max_num_output_bins,
+                     num_row_pixels,
+                     num_rows,
+                     row_stride_samples,
+                     DeviceHistogramInitKernel<NUM_ACTIVE_CHANNELS, CounterT, OffsetT>,
+                     DeviceHistogramSweepKernel<PtxHistogramSweepPolicy,
+                                                PRIVATIZED_SMEM_BINS,
+                                                NUM_CHANNELS,
+                                                NUM_ACTIVE_CHANNELS,
+                                                SampleIteratorT,
+                                                CounterT,
+                                                PrivatizedDecodeOpT,
+                                                OutputDecodeOpT,
+                                                OffsetT>,
+                     histogram_sweep_config,
+                     stream)))
+      {
+        break;
+      }
+    } while (0);
+
+    return error;
+  }
+
+  CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
+  CUB_RUNTIME_FUNCTION
+  static cudaError_t DispatchRange(void *d_temp_storage,
+                                   size_t &temp_storage_bytes,
+                                   SampleIteratorT d_samples,
+                                   CounterT *d_output_histograms[NUM_ACTIVE_CHANNELS],
+                                   int num_output_levels[NUM_ACTIVE_CHANNELS],
+                                   LevelT *d_levels[NUM_ACTIVE_CHANNELS],
+                                   OffsetT num_row_pixels,
+                                   OffsetT num_rows,
+                                   OffsetT row_stride_samples,
+                                   cudaStream_t stream,
+                                   bool debug_synchronous,
+                                   Int2Type<true> is_byte_sample)
+  {
+    CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
+
+    return DispatchRange(d_temp_storage,
+                         temp_storage_bytes,
+                         d_samples,
+                         d_output_histograms,
+                         num_output_levels,
+                         d_levels,
+                         num_row_pixels,
+                         num_rows,
+                         row_stride_samples,
+                         stream,
+                         is_byte_sample);
+  }
+
+  /**
+   * Dispatch routine for HistogramEven, specialized for sample types larger than 8-bit
+   *
+   * @param d_temp_storage
+   *   Device-accessible allocation of temporary storage.
+   *   When NULL, the required allocation size is written to
+   *   `temp_storage_bytes` and no work is done.
+   *
+   * @param temp_storage_bytes
+   *   Reference to size in bytes of `d_temp_storage` allocation
+   *
+   * @param d_samples
+   *   The pointer to the input sequence of sample items.
+   *   The samples from different channels are assumed to be interleaved
+   *   (e.g., an array of 32-bit pixels where each pixel consists of four RGBA 8-bit samples).
+   *
+   * @param d_output_histograms
+   *   The pointers to the histogram counter output arrays, one for each active channel.
+   *   For channel<sub><em>i</em></sub>, the allocation length of `d_histograms[i]` should be
+   *   `num_output_levels[i] - 1`.
+   *
+   * @param num_output_levels
+   *   The number of bin level boundaries for delineating histogram samples in each active channel.
+   *   Implies that the number of bins for channel<sub><em>i</em></sub> is
+   *   `num_output_levels[i] - 1`.
+   *
+   * @param lower_level
+   *   The lower sample value bound (inclusive) for the lowest histogram bin in each active channel.
+   *
+   * @param upper_level
+   *   The upper sample value bound (exclusive) for the highest histogram bin in each active
+   * channel.
+   *
+   * @param num_row_pixels
+   *   The number of multi-channel pixels per row in the region of interest
+   *
+   * @param num_rows
+   *   The number of rows in the region of interest
+   *
+   * @param row_stride_samples
+   *   The number of samples between starts of consecutive rows in the region of interest
+   *
+   * @param stream
+   *   CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
+   *
+   * @param is_byte_sample
+   *   Marker type indicating whether or not SampleT is a 8b type
+   */
+  CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
+  DispatchEven(void *d_temp_storage,
+               size_t &temp_storage_bytes,
+               SampleIteratorT d_samples,
+               CounterT *d_output_histograms[NUM_ACTIVE_CHANNELS],
+               int num_output_levels[NUM_ACTIVE_CHANNELS],
+               LevelT lower_level[NUM_ACTIVE_CHANNELS],
+               LevelT upper_level[NUM_ACTIVE_CHANNELS],
+               OffsetT num_row_pixels,
+               OffsetT num_rows,
+               OffsetT row_stride_samples,
+               cudaStream_t stream,
+               Int2Type<false> /*is_byte_sample*/)
+  {
+    cudaError error = cudaSuccess;
+    do
+    {
+      // Get PTX version
+      int ptx_version = 0;
+      if (CubDebug(error = PtxVersion(ptx_version)))
+      {
+        break;
+      }
+
+      // Get kernel dispatch configurations
+      KernelConfig histogram_sweep_config;
+      if (CubDebug(error = InitConfigs(ptx_version, histogram_sweep_config)))
+      {
+        break;
+      }
+
+      // Use the scale transform op for converting samples to privatized bins
+      typedef ScaleTransform PrivatizedDecodeOpT;
+
+      // Use the pass-thru transform op for converting privatized bins to output bins
+      typedef PassThruTransform OutputDecodeOpT;
+
+      PrivatizedDecodeOpT privatized_decode_op[NUM_ACTIVE_CHANNELS];
+      OutputDecodeOpT output_decode_op[NUM_ACTIVE_CHANNELS];
+      int max_levels = num_output_levels[0];
+
+      for (int channel = 0; channel < NUM_ACTIVE_CHANNELS; ++channel)
+      {
+        error = privatized_decode_op[channel].Init(num_output_levels[channel],
+                                                   upper_level[channel],
+                                                   lower_level[channel]);
+        if (CubDebug(error != cudaSuccess))
+        {
+          // Make sure to also return a reasonable value for `temp_storage_bytes` in case of
+          // an overflow of the bin computation, in which case a subsequent algorithm
+          // invocation will also fail
+          if (!d_temp_storage)
+          {
+            temp_storage_bytes = 1U;
+          }
+          return error;
+        }
+
+        if (num_output_levels[channel] > max_levels)
+        {
+          max_levels = num_output_levels[channel];
+        }
+      }
+      int max_num_output_bins = max_levels - 1;
+
+      if (max_num_output_bins > MAX_PRIVATIZED_SMEM_BINS)
+      {
+        // Dispatch shared-privatized approach
+        const int PRIVATIZED_SMEM_BINS = 0;
+
+        if (CubDebug(error = PrivatizedDispatch(
+                       d_temp_storage,
+                       temp_storage_bytes,
+                       d_samples,
+                       d_output_histograms,
+                       num_output_levels,
+                       privatized_decode_op,
+                       num_output_levels,
+                       output_decode_op,
+                       max_num_output_bins,
+                       num_row_pixels,
+                       num_rows,
+                       row_stride_samples,
+                       DeviceHistogramInitKernel<NUM_ACTIVE_CHANNELS, CounterT, OffsetT>,
+                       DeviceHistogramSweepKernel<PtxHistogramSweepPolicy,
+                                                  PRIVATIZED_SMEM_BINS,
+                                                  NUM_CHANNELS,
+                                                  NUM_ACTIVE_CHANNELS,
+                                                  SampleIteratorT,
+                                                  CounterT,
+                                                  PrivatizedDecodeOpT,
+                                                  OutputDecodeOpT,
+                                                  OffsetT>,
+                       histogram_sweep_config,
+                       stream)))
+        {
+          break;
+        }
+      }
+      else
+      {
+        // Dispatch shared-privatized approach
+        const int PRIVATIZED_SMEM_BINS = MAX_PRIVATIZED_SMEM_BINS;
+
+        if (CubDebug(error = PrivatizedDispatch(
+                       d_temp_storage,
+                       temp_storage_bytes,
+                       d_samples,
+                       d_output_histograms,
+                       num_output_levels,
+                       privatized_decode_op,
+                       num_output_levels,
+                       output_decode_op,
+                       max_num_output_bins,
+                       num_row_pixels,
+                       num_rows,
+                       row_stride_samples,
+                       DeviceHistogramInitKernel<NUM_ACTIVE_CHANNELS, CounterT, OffsetT>,
+                       DeviceHistogramSweepKernel<PtxHistogramSweepPolicy,
+                                                  PRIVATIZED_SMEM_BINS,
+                                                  NUM_CHANNELS,
+                                                  NUM_ACTIVE_CHANNELS,
+                                                  SampleIteratorT,
+                                                  CounterT,
+                                                  PrivatizedDecodeOpT,
+                                                  OutputDecodeOpT,
+                                                  OffsetT>,
+                       histogram_sweep_config,
+                       stream)))
+        {
+          break;
+        }
+      }
+    } while (0);
+
+    return error;
+  }
+
+  CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
+  CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
+  DispatchEven(void *d_temp_storage,
+               size_t &temp_storage_bytes,
+               SampleIteratorT d_samples,
+               CounterT *d_output_histograms[NUM_ACTIVE_CHANNELS],
+               int num_output_levels[NUM_ACTIVE_CHANNELS],
+               LevelT lower_level[NUM_ACTIVE_CHANNELS],
+               LevelT upper_level[NUM_ACTIVE_CHANNELS],
+               OffsetT num_row_pixels,
+               OffsetT num_rows,
+               OffsetT row_stride_samples,
+               cudaStream_t stream,
+               bool debug_synchronous,
+               Int2Type<false> is_byte_sample)
+  {
+    CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
+
+    return DispatchEven(d_temp_storage,
+                        temp_storage_bytes,
+                        d_samples,
+                        d_output_histograms,
+                        num_output_levels,
+                        lower_level,
+                        upper_level,
+                        num_row_pixels,
+                        num_rows,
+                        row_stride_samples,
+                        stream,
+                        is_byte_sample);
+  }
+
+  /**
+   * Dispatch routine for HistogramEven, specialized for 8-bit sample types
+   * (computes 256-bin privatized histograms and then reduces to user-specified levels)
+   *
+   * @param d_temp_storage
+   *   Device-accessible allocation of temporary storage.
+   *   When NULL, the required allocation size is written to `temp_storage_bytes` and
+   *   no work is done.
+   *
+   * @param temp_storage_bytes
+   *   Reference to size in bytes of `d_temp_storage` allocation
+   *
+   * @param d_samples
+   *   The pointer to the input sequence of sample items. The samples from different channels are
+   *   assumed to be interleaved (e.g., an array of 32-bit pixels where each pixel consists of
+   *   four RGBA 8-bit samples).
+   *
+   * @param d_output_histograms
+   *   The pointers to the histogram counter output arrays, one for each active channel.
+   *   For channel<sub><em>i</em></sub>, the allocation length of `d_histograms[i]` should be
+   *   `num_output_levels[i] - 1`.
+   *
+   * @param num_output_levels
+   *   The number of bin level boundaries for delineating histogram samples in each active channel.
+   *   Implies that the number of bins for channel<sub><em>i</em></sub> is
+   *   `num_output_levels[i] - 1`.
+   *
+   * @param lower_level
+   *   The lower sample value bound (inclusive) for the lowest histogram bin in each active channel.
+   *
+   * @param upper_level
+   *   The upper sample value bound (exclusive) for the highest histogram bin in each active
+   * channel.
+   *
+   * @param num_row_pixels
+   *   The number of multi-channel pixels per row in the region of interest
+   *
+   * @param num_rows
+   *   The number of rows in the region of interest
+   *
+   * @param row_stride_samples
+   *   The number of samples between starts of consecutive rows in the region of interest
+   *
+   * @param stream
+   *   CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
+   *
+   * @param is_byte_sample
+   *   type indicating whether or not SampleT is a 8b type
+   */
+  CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
+  DispatchEven(void *d_temp_storage,
+               size_t &temp_storage_bytes,
+               SampleIteratorT d_samples,
+               CounterT *d_output_histograms[NUM_ACTIVE_CHANNELS],
+               int num_output_levels[NUM_ACTIVE_CHANNELS],
+               LevelT lower_level[NUM_ACTIVE_CHANNELS],
+               LevelT upper_level[NUM_ACTIVE_CHANNELS],
+               OffsetT num_row_pixels,
+               OffsetT num_rows,
+               OffsetT row_stride_samples,
+               cudaStream_t stream,
+               Int2Type<true> /*is_byte_sample*/)
+  {
+    cudaError error = cudaSuccess;
+    do
+    {
+      // Get PTX version
+      int ptx_version = 0;
+      if (CubDebug(error = PtxVersion(ptx_version)))
+      {
+        break;
+      }
+
+      // Get kernel dispatch configurations
+      KernelConfig histogram_sweep_config;
+      if (CubDebug(error = InitConfigs(ptx_version, histogram_sweep_config)))
+      {
+        break;
+      }
+
+      // Use the pass-thru transform op for converting samples to privatized bins
+      typedef PassThruTransform PrivatizedDecodeOpT;
+
+      // Use the scale transform op for converting privatized bins to output bins
+      typedef ScaleTransform OutputDecodeOpT;
+
+      int num_privatized_levels[NUM_ACTIVE_CHANNELS];
+      PrivatizedDecodeOpT privatized_decode_op[NUM_ACTIVE_CHANNELS];
+      OutputDecodeOpT output_decode_op[NUM_ACTIVE_CHANNELS];
+      int max_levels = num_output_levels[0];
+
+      for (int channel = 0; channel < NUM_ACTIVE_CHANNELS; ++channel)
+      {
+        num_privatized_levels[channel] = 257;
+
+        output_decode_op[channel].Init(num_output_levels[channel],
+                                       upper_level[channel],
+                                       lower_level[channel]);
+
+        if (num_output_levels[channel] > max_levels)
+        {
+          max_levels = num_output_levels[channel];
+        }
+      }
+      int max_num_output_bins = max_levels - 1;
+
+      const int PRIVATIZED_SMEM_BINS = 256;
+
+      if (CubDebug(error = PrivatizedDispatch(
+                     d_temp_storage,
+                     temp_storage_bytes,
+                     d_samples,
+                     d_output_histograms,
+                     num_privatized_levels,
+                     privatized_decode_op,
+                     num_output_levels,
+                     output_decode_op,
+                     max_num_output_bins,
+                     num_row_pixels,
+                     num_rows,
+                     row_stride_samples,
+                     DeviceHistogramInitKernel<NUM_ACTIVE_CHANNELS, CounterT, OffsetT>,
+                     DeviceHistogramSweepKernel<PtxHistogramSweepPolicy,
+                                                PRIVATIZED_SMEM_BINS,
+                                                NUM_CHANNELS,
+                                                NUM_ACTIVE_CHANNELS,
+                                                SampleIteratorT,
+                                                CounterT,
+                                                PrivatizedDecodeOpT,
+                                                OutputDecodeOpT,
+                                                OffsetT>,
+                     histogram_sweep_config,
+                     stream)))
+      {
+        break;
+      }
+    } while (0);
+
+    return error;
+  }
+
+  CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
+  DispatchEven(void *d_temp_storage,
+               size_t &temp_storage_bytes,
+               SampleIteratorT d_samples,
+               CounterT *d_output_histograms[NUM_ACTIVE_CHANNELS],
+               int num_output_levels[NUM_ACTIVE_CHANNELS],
+               LevelT lower_level[NUM_ACTIVE_CHANNELS],
+               LevelT upper_level[NUM_ACTIVE_CHANNELS],
+               OffsetT num_row_pixels,
+               OffsetT num_rows,
+               OffsetT row_stride_samples,
+               cudaStream_t stream,
+               bool debug_synchronous,
+               Int2Type<true> is_byte_sample)
+  {
+    CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
+
+    return DispatchEven(d_temp_storage,
+                        temp_storage_bytes,
+                        d_samples,
+                        d_output_histograms,
+                        num_output_levels,
+                        lower_level,
+                        upper_level,
+                        num_row_pixels,
+                        num_rows,
+                        row_stride_samples,
+                        stream,
+                        is_byte_sample);
+  }
 };
 
-
 CUB_NAMESPACE_END
-
-

--- a/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/device/dispatch/dispatch_histogram.cuh
@@ -592,6 +592,10 @@ struct dispatch_histogram
  *
  * @tparam OffsetT
  *   Signed integer type for global offsets
+ *
+ * @tparam SelectedPolicy 
+ *   Implementation detail, do not specify directly, requirements on the 
+ *   content of this type are subject to breaking change.
  */
 template <int NUM_CHANNELS,
           int NUM_ACTIVE_CHANNELS,

--- a/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/device/dispatch/dispatch_histogram.cuh
@@ -258,6 +258,7 @@ struct device_histogram_policy_hub
   /// SM35
   struct Policy350 : ChainedPolicy<350, Policy350, Policy350>
   {
+    // TODO This might be worth it to separate usual histogram and the multi one
     using AgentHistogramPolicyT =
       AgentHistogramPolicy<128, TScale<8>::VALUE, BLOCK_LOAD_DIRECT, LOAD_LDG, true, BLEND, true>;
   };
@@ -265,6 +266,7 @@ struct device_histogram_policy_hub
   /// SM50
   struct Policy500 : ChainedPolicy<500, Policy500, Policy350>
   {
+    // TODO This might be worth it to separate usual histogram and the multi one
     using AgentHistogramPolicyT =
       AgentHistogramPolicy<384, TScale<16>::VALUE, BLOCK_LOAD_DIRECT, LOAD_LDG, true, SMEM, false>;
   };

--- a/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -651,7 +651,9 @@ struct sm90_small_key_tuning
 
 // keys
 template <> struct sm90_small_key_tuning<1,  0, 4> { static constexpr int threads = 512; static constexpr int items = 19; };
+template <> struct sm90_small_key_tuning<1,  0, 8> { static constexpr int threads = 512; static constexpr int items = 19; };
 template <> struct sm90_small_key_tuning<2,  0, 4> { static constexpr int threads = 512; static constexpr int items = 19; };
+template <> struct sm90_small_key_tuning<2,  0, 8> { static constexpr int threads = 512; static constexpr int items = 19; };
 
 // pairs  8:xx
 template <> struct sm90_small_key_tuning<1,  1, 4> { static constexpr int threads = 512; static constexpr int items = 15; };

--- a/cub/device/dispatch/dispatch_rle.cuh
+++ b/cub/device/dispatch/dispatch_rle.cuh
@@ -27,8 +27,9 @@
  ******************************************************************************/
 
 /**
- * \file
- * cub::DeviceRle provides device-wide, parallel operations for run-length-encoding sequences of data items residing within device-accessible memory.
+ * @file
+ *   cub::DeviceRle provides device-wide, parallel operations for run-length-encoding sequences of
+ *   data items residing within device-accessible memory.
  */
 
 #pragma once
@@ -36,20 +37,19 @@
 #include <cub/agent/agent_rle.cuh>
 #include <cub/config.cuh>
 #include <cub/device/dispatch/dispatch_scan.cuh>
-#include <cub/thread/thread_operators.cuh>
 #include <cub/grid/grid_queue.cuh>
+#include <cub/thread/thread_operators.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
 
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 
-#include <nv/target>
-
 #include <cstdio>
 #include <iterator>
 
-CUB_NAMESPACE_BEGIN
+#include <nv/target>
 
+CUB_NAMESPACE_BEGIN
 
 /******************************************************************************
  * Kernel entry points
@@ -61,48 +61,88 @@ CUB_NAMESPACE_BEGIN
  * Performs functor-based selection if SelectOp functor type != NullType
  * Otherwise performs flag-based selection if FlagIterator's value type != NullType
  * Otherwise performs discontinuity selection (keep unique)
+ *
+ * @tparam AgentRlePolicyT
+ *   Parameterized AgentRlePolicyT tuning policy type
+ *
+ * @tparam InputIteratorT
+ *   Random-access input iterator type for reading input items \iterator
+ *
+ * @tparam OffsetsOutputIteratorT
+ *   Random-access output iterator type for writing run-offset values \iterator
+ *
+ * @tparam LengthsOutputIteratorT
+ *   Random-access output iterator type for writing run-length values \iterator
+ *
+ * @tparam NumRunsOutputIteratorT
+ *   Output iterator type for recording the number of runs encountered \iterator
+ *
+ * @tparam ScanTileStateT
+ *   Tile status interface type
+ *
+ * @tparam EqualityOpT
+ *   T equality operator type
+ *
+ * @tparam OffsetT
+ *   Signed integer type for global offsets
+ *
+ * @param d_in
+ *   Pointer to input sequence of data items
+ *
+ * @param d_offsets_out
+ *   Pointer to output sequence of run-offsets
+ *
+ * @param d_lengths_out
+ *   Pointer to output sequence of run-lengths
+ *
+ * @param d_num_runs_out
+ *   Pointer to total number of runs (i.e., length of `d_offsets_out`)
+ *
+ * @param tile_status
+ *   Tile status interface
+ *
+ * @param equality_op
+ *   Equality operator for input items
+ *
+ * @param num_items
+ *   Total number of input items (i.e., length of `d_in`)
+ *
+ * @param num_tiles
+ *   Total number of tiles for the entire problem
  */
-template <
-    typename            AgentRlePolicyT,        ///< Parameterized AgentRlePolicyT tuning policy type
-    typename            InputIteratorT,             ///< Random-access input iterator type for reading input items \iterator
-    typename            OffsetsOutputIteratorT,     ///< Random-access output iterator type for writing run-offset values \iterator
-    typename            LengthsOutputIteratorT,     ///< Random-access output iterator type for writing run-length values \iterator
-    typename            NumRunsOutputIteratorT,     ///< Output iterator type for recording the number of runs encountered \iterator
-    typename            ScanTileStateT,              ///< Tile status interface type
-    typename            EqualityOpT,                 ///< T equality operator type
-    typename            OffsetT>                    ///< Signed integer type for global offsets
-__launch_bounds__ (int(AgentRlePolicyT::BLOCK_THREADS))
-__global__ void DeviceRleSweepKernel(
-    InputIteratorT              d_in,               ///< [in] Pointer to input sequence of data items
-    OffsetsOutputIteratorT      d_offsets_out,      ///< [out] Pointer to output sequence of run-offsets
-    LengthsOutputIteratorT      d_lengths_out,      ///< [out] Pointer to output sequence of run-lengths
-    NumRunsOutputIteratorT      d_num_runs_out,     ///< [out] Pointer to total number of runs (i.e., length of \p d_offsets_out)
-    ScanTileStateT              tile_status,        ///< [in] Tile status interface
-    EqualityOpT                 equality_op,        ///< [in] Equality operator for input items
-    OffsetT                     num_items,          ///< [in] Total number of input items (i.e., length of \p d_in)
-    int                         num_tiles)          ///< [in] Total number of tiles for the entire problem
+template <typename AgentRlePolicyT,
+          typename InputIteratorT,
+          typename OffsetsOutputIteratorT,
+          typename LengthsOutputIteratorT,
+          typename NumRunsOutputIteratorT,
+          typename ScanTileStateT,
+          typename EqualityOpT,
+          typename OffsetT>
+__launch_bounds__(int(AgentRlePolicyT::BLOCK_THREADS)) __global__
+  void DeviceRleSweepKernel(InputIteratorT d_in,
+                            OffsetsOutputIteratorT d_offsets_out,
+                            LengthsOutputIteratorT d_lengths_out,
+                            NumRunsOutputIteratorT d_num_runs_out,
+                            ScanTileStateT tile_status,
+                            EqualityOpT equality_op,
+                            OffsetT num_items,
+                            int num_tiles)
 {
-    // Thread block type for selecting data from input tiles
-    typedef AgentRle<
-        AgentRlePolicyT,
-        InputIteratorT,
-        OffsetsOutputIteratorT,
-        LengthsOutputIteratorT,
-        EqualityOpT,
-        OffsetT> AgentRleT;
+  // Thread block type for selecting data from input tiles
+  using AgentRleT = AgentRle<AgentRlePolicyT,
+                             InputIteratorT,
+                             OffsetsOutputIteratorT,
+                             LengthsOutputIteratorT,
+                             EqualityOpT,
+                             OffsetT>;
 
-    // Shared memory for AgentRle
-    __shared__ typename AgentRleT::TempStorage temp_storage;
+  // Shared memory for AgentRle
+  __shared__ typename AgentRleT::TempStorage temp_storage;
 
-    // Process tiles
-    AgentRleT(temp_storage, d_in, d_offsets_out, d_lengths_out, equality_op, num_items).ConsumeRange(
-        num_tiles,
-        tile_status,
-        d_num_runs_out);
+  // Process tiles
+  AgentRleT(temp_storage, d_in, d_offsets_out, d_lengths_out, equality_op, num_items)
+    .ConsumeRange(num_tiles, tile_status, d_num_runs_out);
 }
-
-
-
 
 /******************************************************************************
  * Dispatch
@@ -110,275 +150,355 @@ __global__ void DeviceRleSweepKernel(
 
 /**
  * Utility class for dispatching the appropriately-tuned kernels for DeviceRle
+ *
+ * @tparam InputIteratorT
+ *   Random-access input iterator type for reading input items \iterator
+ *
+ * @tparam OffsetsOutputIteratorT
+ *   Random-access output iterator type for writing run-offset values \iterator
+ *
+ * @tparam LengthsOutputIteratorT
+ *   Random-access output iterator type for writing run-length values \iterator
+ *
+ * @tparam NumRunsOutputIteratorT
+ *   Output iterator type for recording the number of runs encountered \iterator
+ *
+ * @tparam EqualityOpT
+ *   T equality operator type
+ *
+ * @tparam OffsetT
+ *   Signed integer type for global offsets
  */
-template <
-    typename            InputIteratorT,             ///< Random-access input iterator type for reading input items \iterator
-    typename            OffsetsOutputIteratorT,     ///< Random-access output iterator type for writing run-offset values \iterator
-    typename            LengthsOutputIteratorT,     ///< Random-access output iterator type for writing run-length values \iterator
-    typename            NumRunsOutputIteratorT,     ///< Output iterator type for recording the number of runs encountered \iterator
-    typename            EqualityOpT,                ///< T equality operator type
-    typename            OffsetT>                    ///< Signed integer type for global offsets
+template <typename InputIteratorT,
+          typename OffsetsOutputIteratorT,
+          typename LengthsOutputIteratorT,
+          typename NumRunsOutputIteratorT,
+          typename EqualityOpT,
+          typename OffsetT>
 struct DeviceRleDispatch
 {
-    /******************************************************************************
-     * Types and constants
-     ******************************************************************************/
+  /******************************************************************************
+   * Types and constants
+   ******************************************************************************/
 
-    // The input value type
-    using T = cub::detail::value_t<InputIteratorT>;
+  // The input value type
+  using T = cub::detail::value_t<InputIteratorT>;
 
-    // The lengths output value type
-    using LengthT =
-      cub::detail::non_void_value_t<LengthsOutputIteratorT, OffsetT>;
+  // The lengths output value type
+  using LengthT = cub::detail::non_void_value_t<LengthsOutputIteratorT, OffsetT>;
 
+  enum
+  {
+    INIT_KERNEL_THREADS = 128,
+  };
+
+  // Tile status descriptor interface type
+  using ScanTileStateT = ReduceByKeyScanTileState<LengthT, OffsetT>;
+
+  /******************************************************************************
+   * Tuning policies
+   ******************************************************************************/
+
+  /// SM35
+  struct Policy350
+  {
     enum
     {
-        INIT_KERNEL_THREADS = 128,
+      NOMINAL_4B_ITEMS_PER_THREAD = 15,
+      ITEMS_PER_THREAD            = CUB_MIN(NOMINAL_4B_ITEMS_PER_THREAD,
+                                 CUB_MAX(1, (NOMINAL_4B_ITEMS_PER_THREAD * 4 / sizeof(T)))),
     };
 
-    // Tile status descriptor interface type
-    using ScanTileStateT = ReduceByKeyScanTileState<LengthT, OffsetT>;
+    using RleSweepPolicy =
+      AgentRlePolicy<96, ITEMS_PER_THREAD, BLOCK_LOAD_DIRECT, LOAD_LDG, true, BLOCK_SCAN_WARP_SCANS>;
+  };
 
+  /******************************************************************************
+   * Tuning policies of current PTX compiler pass
+   ******************************************************************************/
 
-    /******************************************************************************
-     * Tuning policies
-     ******************************************************************************/
+  using PtxPolicy = Policy350;
 
-    /// SM35
-    struct Policy350
+  // "Opaque" policies (whose parameterizations aren't reflected in the type signature)
+  struct PtxRleSweepPolicy : PtxPolicy::RleSweepPolicy
+  {};
+
+  /******************************************************************************
+   * Utilities
+   ******************************************************************************/
+
+  /**
+   * Initialize kernel dispatch configurations with the policies corresponding to the PTX assembly
+   * we will use
+   */
+  template <typename KernelConfig>
+  CUB_RUNTIME_FUNCTION __forceinline__ static void InitConfigs(int /*ptx_version*/,
+                                                               KernelConfig &device_rle_config)
+  {
+    NV_IF_TARGET(NV_IS_DEVICE,
+                 (
+                   // We're on the device, so initialize the kernel dispatch configurations with the
+                   // current PTX policy
+                   device_rle_config.template Init<PtxRleSweepPolicy>();),
+                 (
+                   // We're on the host, so lookup and initialize the kernel dispatch configurations
+                   // with the policies that match the device's PTX version
+
+                   // (There's only one policy right now)
+                   device_rle_config.template Init<typename Policy350::RleSweepPolicy>();));
+  }
+
+  /**
+   * Kernel kernel dispatch configuration.  Mirrors the constants within AgentRlePolicyT.
+   */
+  struct KernelConfig
+  {
+    int block_threads;
+    int items_per_thread;
+    BlockLoadAlgorithm load_policy;
+    bool store_warp_time_slicing;
+    BlockScanAlgorithm scan_algorithm;
+
+    template <typename AgentRlePolicyT>
+    CUB_RUNTIME_FUNCTION __forceinline__ void Init()
     {
-        enum {
-            NOMINAL_4B_ITEMS_PER_THREAD = 15,
-            ITEMS_PER_THREAD            = CUB_MIN(NOMINAL_4B_ITEMS_PER_THREAD, CUB_MAX(1, (NOMINAL_4B_ITEMS_PER_THREAD * 4 / sizeof(T)))),
-        };
-
-        typedef AgentRlePolicy<
-                96,
-                ITEMS_PER_THREAD,
-                BLOCK_LOAD_DIRECT,
-                LOAD_LDG,
-                true,
-                BLOCK_SCAN_WARP_SCANS>
-            RleSweepPolicy;
-    };
-
-    /******************************************************************************
-     * Tuning policies of current PTX compiler pass
-     ******************************************************************************/
-
-    typedef Policy350 PtxPolicy;
-
-    // "Opaque" policies (whose parameterizations aren't reflected in the type signature)
-    struct PtxRleSweepPolicy : PtxPolicy::RleSweepPolicy {};
-
-
-    /******************************************************************************
-     * Utilities
-     ******************************************************************************/
-
-    /**
-     * Initialize kernel dispatch configurations with the policies corresponding to the PTX assembly we will use
-     */
-    template <typename KernelConfig>
-    CUB_RUNTIME_FUNCTION __forceinline__
-    static void InitConfigs(
-        int             /*ptx_version*/,
-        KernelConfig&   device_rle_config)
-    {
-      NV_IF_TARGET(NV_IS_DEVICE,
-      (
-          // We're on the device, so initialize the kernel dispatch configurations with the current PTX policy
-          device_rle_config.template Init<PtxRleSweepPolicy>();
-      ), (
-          // We're on the host, so lookup and initialize the kernel dispatch configurations with the policies that match the device's PTX version
-
-          // (There's only one policy right now)
-          device_rle_config.template Init<typename Policy350::RleSweepPolicy>();
-      ));
+      block_threads           = AgentRlePolicyT::BLOCK_THREADS;
+      items_per_thread        = AgentRlePolicyT::ITEMS_PER_THREAD;
+      load_policy             = AgentRlePolicyT::LOAD_ALGORITHM;
+      store_warp_time_slicing = AgentRlePolicyT::STORE_WARP_TIME_SLICING;
+      scan_algorithm          = AgentRlePolicyT::SCAN_ALGORITHM;
     }
 
-
-    /**
-     * Kernel kernel dispatch configuration.  Mirrors the constants within AgentRlePolicyT.
-     */
-    struct KernelConfig
+    CUB_RUNTIME_FUNCTION __forceinline__ void Print()
     {
-        int                     block_threads;
-        int                     items_per_thread;
-        BlockLoadAlgorithm      load_policy;
-        bool                    store_warp_time_slicing;
-        BlockScanAlgorithm      scan_algorithm;
-
-        template <typename AgentRlePolicyT>
-        CUB_RUNTIME_FUNCTION __forceinline__
-        void Init()
-        {
-            block_threads               = AgentRlePolicyT::BLOCK_THREADS;
-            items_per_thread            = AgentRlePolicyT::ITEMS_PER_THREAD;
-            load_policy                 = AgentRlePolicyT::LOAD_ALGORITHM;
-            store_warp_time_slicing     = AgentRlePolicyT::STORE_WARP_TIME_SLICING;
-            scan_algorithm              = AgentRlePolicyT::SCAN_ALGORITHM;
-        }
-
-        CUB_RUNTIME_FUNCTION __forceinline__
-        void Print()
-        {
-            printf("%d, %d, %d, %d, %d",
-                block_threads,
-                items_per_thread,
-                load_policy,
-                store_warp_time_slicing,
-                scan_algorithm);
-        }
-    };
-
-
-    /******************************************************************************
-     * Dispatch entrypoints
-     ******************************************************************************/
-
-    /**
-     * Internal dispatch routine for computing a device-wide run-length-encode using the
-     * specified kernel functions.
-     */
-    template <
-        typename                    DeviceScanInitKernelPtr,        ///< Function type of cub::DeviceScanInitKernel
-        typename                    DeviceRleSweepKernelPtr>        ///< Function type of cub::DeviceRleSweepKernelPtr
-    CUB_RUNTIME_FUNCTION __forceinline__
-    static cudaError_t Dispatch(
-        void*                       d_temp_storage,                 ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
-        size_t&                     temp_storage_bytes,             ///< [in,out] Reference to size in bytes of \p d_temp_storage allocation
-        InputIteratorT              d_in,                           ///< [in] Pointer to the input sequence of data items
-        OffsetsOutputIteratorT      d_offsets_out,                  ///< [out] Pointer to the output sequence of run-offsets
-        LengthsOutputIteratorT      d_lengths_out,                  ///< [out] Pointer to the output sequence of run-lengths
-        NumRunsOutputIteratorT      d_num_runs_out,                 ///< [out] Pointer to the total number of runs encountered (i.e., length of \p d_offsets_out)
-        EqualityOpT                 equality_op,                    ///< [in] Equality operator for input items
-        OffsetT                     num_items,                      ///< [in] Total number of input items (i.e., length of \p d_in)
-        cudaStream_t                stream,                         ///< [in] CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
-        int                         /*ptx_version*/,                ///< [in] PTX version of dispatch kernels
-        DeviceScanInitKernelPtr     device_scan_init_kernel,        ///< [in] Kernel function pointer to parameterization of cub::DeviceScanInitKernel
-        DeviceRleSweepKernelPtr     device_rle_sweep_kernel,        ///< [in] Kernel function pointer to parameterization of cub::DeviceRleSweepKernel
-        KernelConfig                device_rle_config)              ///< [in] Dispatch parameters that match the policy that \p device_rle_sweep_kernel was compiled for
-    {
-        cudaError error = cudaSuccess;
-        do
-        {
-            // Get device ordinal
-            int device_ordinal;
-            if (CubDebug(error = cudaGetDevice(&device_ordinal))) break;
-
-            // Number of input tiles
-            int tile_size = device_rle_config.block_threads * device_rle_config.items_per_thread;
-            int num_tiles = static_cast<int>(cub::DivideAndRoundUp(num_items, tile_size));
-
-            // Specify temporary storage allocation requirements
-            size_t  allocation_sizes[1];
-            if (CubDebug(error = ScanTileStateT::AllocationSize(num_tiles, allocation_sizes[0]))) break;    // bytes needed for tile status descriptors
-
-            // Compute allocation pointers into the single storage blob (or compute the necessary size of the blob)
-            void* allocations[1] = {};
-            if (CubDebug(error = AliasTemporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes))) break;
-            if (d_temp_storage == NULL)
-            {
-                // Return if the caller is simply requesting the size of the storage allocation
-                break;
-            }
-
-            // Construct the tile status interface
-            ScanTileStateT tile_status;
-            if (CubDebug(error = tile_status.Init(num_tiles, allocations[0], allocation_sizes[0]))) break;
-
-            // Log device_scan_init_kernel configuration
-            int init_grid_size = CUB_MAX(1, cub::DivideAndRoundUp(num_tiles, INIT_KERNEL_THREADS));
-
-            #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
-            _CubLog("Invoking device_scan_init_kernel<<<%d, %d, 0, %lld>>>()\n", init_grid_size, INIT_KERNEL_THREADS, (long long) stream);
-            #endif
-
-            // Invoke device_scan_init_kernel to initialize tile descriptors and queue descriptors
-            THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(
-                init_grid_size, INIT_KERNEL_THREADS, 0, stream
-            ).doit(device_scan_init_kernel,
-                tile_status,
-                num_tiles,
-                d_num_runs_out);
-
-            // Check for failure to launch
-            if (CubDebug(error = cudaPeekAtLastError()))
-            {
-                break;
-            }
-
-            // Sync the stream if specified to flush runtime errors
-            error = detail::DebugSyncStream(stream);
-            if (CubDebug(error))
-            {
-              break;
-            }
-
-            // Return if empty problem
-            if (num_items == 0)
-            {
-                break;
-            }
-
-            // Get SM occupancy for device_rle_sweep_kernel
-            int device_rle_kernel_sm_occupancy;
-            if (CubDebug(error = MaxSmOccupancy(
-                device_rle_kernel_sm_occupancy,            // out
-                device_rle_sweep_kernel,
-                device_rle_config.block_threads))) break;
-
-            // Get max x-dimension of grid
-            int max_dim_x;
-            if (CubDebug(error = cudaDeviceGetAttribute(&max_dim_x, cudaDevAttrMaxGridDimX, device_ordinal))) break;;
-
-            // Get grid size for scanning tiles
-            dim3 scan_grid_size;
-            scan_grid_size.z = 1;
-            scan_grid_size.y = cub::DivideAndRoundUp(num_tiles, max_dim_x);
-            scan_grid_size.x = CUB_MIN(num_tiles, max_dim_x);
-
-            // Log device_rle_sweep_kernel configuration
-            #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
-            _CubLog("Invoking device_rle_sweep_kernel<<<{%d,%d,%d}, %d, 0, %lld>>>(), %d items per thread, %d SM occupancy\n",
-                scan_grid_size.x, scan_grid_size.y, scan_grid_size.z, device_rle_config.block_threads, (long long) stream, device_rle_config.items_per_thread, device_rle_kernel_sm_occupancy);
-            #endif
-
-            // Invoke device_rle_sweep_kernel
-            THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(
-                scan_grid_size, device_rle_config.block_threads, 0, stream
-            ).doit(device_rle_sweep_kernel,
-                d_in,
-                d_offsets_out,
-                d_lengths_out,
-                d_num_runs_out,
-                tile_status,
-                equality_op,
-                num_items,
-                num_tiles);
-
-            // Check for failure to launch
-            if (CubDebug(error = cudaPeekAtLastError()))
-            {
-                break;
-            }
-
-            // Sync the stream if specified to flush runtime errors
-            error = detail::DebugSyncStream(stream);
-            if (CubDebug(error))
-            {
-              break;
-            }
-        }
-        while (0);
-
-        return error;
+      printf("%d, %d, %d, %d, %d",
+             block_threads,
+             items_per_thread,
+             load_policy,
+             store_warp_time_slicing,
+             scan_algorithm);
     }
+  };
 
+  /******************************************************************************
+   * Dispatch entrypoints
+   ******************************************************************************/
 
-    template <typename DeviceScanInitKernelPtr, typename DeviceRleSweepKernelPtr>
-    CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
+  /**
+   * Internal dispatch routine for computing a device-wide run-length-encode using the
+   * specified kernel functions.
+   *
+   * @tparam DeviceScanInitKernelPtr
+   *   Function type of cub::DeviceScanInitKernel
+   *
+   * @tparam DeviceRleSweepKernelPtr
+   *   Function type of cub::DeviceRleSweepKernelPtr
+   *
+   * @param d_temp_storage
+   *   Device-accessible allocation of temporary storage.
+   *   When NULL, the required allocation size is written to
+   *   `temp_storage_bytes` and no work is done.
+   *
+   * @param temp_storage_bytes
+   *   Reference to size in bytes of `d_temp_storage` allocation
+   *
+   * @param d_in
+   *   Pointer to the input sequence of data items
+   *
+   * @param d_offsets_out
+   *   Pointer to the output sequence of run-offsets
+   *
+   * @param d_lengths_out
+   *   Pointer to the output sequence of run-lengths
+   *
+   * @param d_num_runs_out
+   *   Pointer to the total number of runs encountered (i.e., length of `d_offsets_out`)
+   *
+   * @param equality_op
+   *   Equality operator for input items
+   *
+   * @param num_items
+   *   Total number of input items (i.e., length of `d_in`)
+   *
+   * @param stream
+   *   CUDA stream to launch kernels within. Default is stream<sub>0</sub>.
+   *
+   * @param ptx_version
+   *   PTX version of dispatch kernels
+   *
+   * @param device_scan_init_kernel
+   *   Kernel function pointer to parameterization of cub::DeviceScanInitKernel
+   *
+   * @param device_rle_sweep_kernel
+   *   Kernel function pointer to parameterization of cub::DeviceRleSweepKernel
+   *
+   * @param device_rle_config
+   *   Dispatch parameters that match the policy that `device_rle_sweep_kernel` was compiled for
+   */
+  template <typename DeviceScanInitKernelPtr, typename DeviceRleSweepKernelPtr>
+  CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
+  Dispatch(void *d_temp_storage,
+           size_t &temp_storage_bytes,
+           InputIteratorT d_in,
+           OffsetsOutputIteratorT d_offsets_out,
+           LengthsOutputIteratorT d_lengths_out,
+           NumRunsOutputIteratorT d_num_runs_out,
+           EqualityOpT equality_op,
+           OffsetT num_items,
+           cudaStream_t stream,
+           int /*ptx_version*/,
+           DeviceScanInitKernelPtr device_scan_init_kernel,
+           DeviceRleSweepKernelPtr device_rle_sweep_kernel,
+           KernelConfig device_rle_config)
+  {
+    cudaError error = cudaSuccess;
+    do
+    {
+      // Get device ordinal
+      int device_ordinal;
+      if (CubDebug(error = cudaGetDevice(&device_ordinal)))
+        break;
+
+      // Number of input tiles
+      int tile_size = device_rle_config.block_threads * device_rle_config.items_per_thread;
+      int num_tiles = static_cast<int>(cub::DivideAndRoundUp(num_items, tile_size));
+
+      // Specify temporary storage allocation requirements
+      size_t allocation_sizes[1];
+      if (CubDebug(error = ScanTileStateT::AllocationSize(num_tiles, allocation_sizes[0])))
+      {
+        break; // bytes needed for tile status descriptors
+      }
+
+      // Compute allocation pointers into the single storage blob (or compute the necessary size of
+      // the blob)
+      void *allocations[1] = {};
+      if (CubDebug(
+            error =
+              AliasTemporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
+      {
+        break;
+      }
+
+      if (d_temp_storage == NULL)
+      {
+        // Return if the caller is simply requesting the size of the storage allocation
+        break;
+      }
+
+      // Construct the tile status interface
+      ScanTileStateT tile_status;
+      if (CubDebug(error = tile_status.Init(num_tiles, allocations[0], allocation_sizes[0])))
+      {
+        break;
+      }
+
+      // Log device_scan_init_kernel configuration
+      int init_grid_size = CUB_MAX(1, cub::DivideAndRoundUp(num_tiles, INIT_KERNEL_THREADS));
+
+#ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
+      _CubLog("Invoking device_scan_init_kernel<<<%d, %d, 0, %lld>>>()\n",
+              init_grid_size,
+              INIT_KERNEL_THREADS,
+              (long long)stream);
+#endif
+
+      // Invoke device_scan_init_kernel to initialize tile descriptors and queue descriptors
+      THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(init_grid_size,
+                                                              INIT_KERNEL_THREADS,
+                                                              0,
+                                                              stream)
+        .doit(device_scan_init_kernel, tile_status, num_tiles, d_num_runs_out);
+
+      // Check for failure to launch
+      if (CubDebug(error = cudaPeekAtLastError()))
+      {
+        break;
+      }
+
+      // Sync the stream if specified to flush runtime errors
+      error = detail::DebugSyncStream(stream);
+      if (CubDebug(error))
+      {
+        break;
+      }
+
+      // Return if empty problem
+      if (num_items == 0)
+      {
+        break;
+      }
+
+      // Get SM occupancy for device_rle_sweep_kernel
+      int device_rle_kernel_sm_occupancy;
+      if (CubDebug(error = MaxSmOccupancy(device_rle_kernel_sm_occupancy, // out
+                                          device_rle_sweep_kernel,
+                                          device_rle_config.block_threads)))
+      {
+        break;
+      }
+
+      // Get max x-dimension of grid
+      int max_dim_x;
+      if (CubDebug(
+            error = cudaDeviceGetAttribute(&max_dim_x, cudaDevAttrMaxGridDimX, device_ordinal)))
+      {
+        break;
+      }
+
+      // Get grid size for scanning tiles
+      dim3 scan_grid_size;
+      scan_grid_size.z = 1;
+      scan_grid_size.y = cub::DivideAndRoundUp(num_tiles, max_dim_x);
+      scan_grid_size.x = CUB_MIN(num_tiles, max_dim_x);
+
+// Log device_rle_sweep_kernel configuration
+#ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
+      _CubLog("Invoking device_rle_sweep_kernel<<<{%d,%d,%d}, %d, 0, %lld>>>(), %d items per "
+              "thread, %d SM occupancy\n",
+              scan_grid_size.x,
+              scan_grid_size.y,
+              scan_grid_size.z,
+              device_rle_config.block_threads,
+              (long long)stream,
+              device_rle_config.items_per_thread,
+              device_rle_kernel_sm_occupancy);
+#endif
+
+      // Invoke device_rle_sweep_kernel
+      THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(scan_grid_size,
+                                                              device_rle_config.block_threads,
+                                                              0,
+                                                              stream)
+        .doit(device_rle_sweep_kernel,
+              d_in,
+              d_offsets_out,
+              d_lengths_out,
+              d_num_runs_out,
+              tile_status,
+              equality_op,
+              num_items,
+              num_tiles);
+
+      // Check for failure to launch
+      if (CubDebug(error = cudaPeekAtLastError()))
+      {
+        break;
+      }
+
+      // Sync the stream if specified to flush runtime errors
+      error = detail::DebugSyncStream(stream);
+      if (CubDebug(error))
+      {
+        break;
+      }
+    } while (0);
+
+    return error;
+  }
+
+  template <typename DeviceScanInitKernelPtr, typename DeviceRleSweepKernelPtr>
+  CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
     CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
     Dispatch(void *d_temp_storage,
              size_t &temp_storage_bytes,
@@ -394,99 +514,135 @@ struct DeviceRleDispatch
              DeviceScanInitKernelPtr device_scan_init_kernel,
              DeviceRleSweepKernelPtr device_rle_sweep_kernel,
              KernelConfig device_rle_config)
+  {
+    CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
+
+    return Dispatch<DeviceScanInitKernelPtr, DeviceRleSweepKernelPtr>(d_temp_storage,
+                                                                      temp_storage_bytes,
+                                                                      d_in,
+                                                                      d_offsets_out,
+                                                                      d_lengths_out,
+                                                                      d_num_runs_out,
+                                                                      equality_op,
+                                                                      num_items,
+                                                                      stream,
+                                                                      ptx_version,
+                                                                      device_scan_init_kernel,
+                                                                      device_rle_sweep_kernel,
+                                                                      device_rle_config);
+  }
+
+  /**
+   * Internal dispatch routine
+   *
+   * @param d_temp_storage
+   *   Device-accessible allocation of temporary storage.
+   *   When NULL, the required allocation size is written to
+   *   `temp_storage_bytes` and no work is done.
+   *
+   * @param temp_storage_bytes
+   *   Reference to size in bytes of `d_temp_storage` allocation
+   *
+   * @param d_in
+   *   Pointer to input sequence of data items
+   *
+   * @param d_offsets_out
+   *   Pointer to output sequence of run-offsets
+   *
+   * @param d_lengths_out
+   *   Pointer to output sequence of run-lengths
+   *
+   * @param d_num_runs_out
+   *   Pointer to total number of runs (i.e., length of `d_offsets_out`)
+   *
+   * @param equality_op
+   *   Equality operator for input items
+   *
+   * @param num_items
+   *   Total number of input items (i.e., length of `d_in`)
+   *
+   * @param stream
+   *   <b>[optional]</b> CUDA stream to launch kernels within.
+   *   Default is stream<sub>0</sub>.
+   */
+  CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
+  Dispatch(void *d_temp_storage,
+           size_t &temp_storage_bytes,
+           InputIteratorT d_in,
+           OffsetsOutputIteratorT d_offsets_out,
+           LengthsOutputIteratorT d_lengths_out,
+           NumRunsOutputIteratorT d_num_runs_out,
+           EqualityOpT equality_op,
+           OffsetT num_items,
+           cudaStream_t stream)
+  {
+    cudaError error = cudaSuccess;
+    do
     {
-      CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
+      // Get PTX version
+      int ptx_version = 0;
+      if (CubDebug(error = PtxVersion(ptx_version)))
+      {
+        break;
+      }
 
-      return Dispatch<DeviceScanInitKernelPtr, DeviceRleSweepKernelPtr>(
-        d_temp_storage,
-        temp_storage_bytes,
-        d_in,
-        d_offsets_out,
-        d_lengths_out,
-        d_num_runs_out,
-        equality_op,
-        num_items,
-        stream,
-        ptx_version,
-        device_scan_init_kernel,
-        device_rle_sweep_kernel,
-        device_rle_config);
-    }
+      // Get kernel kernel dispatch configurations
+      KernelConfig device_rle_config;
+      InitConfigs(ptx_version, device_rle_config);
 
-    /**
-     * Internal dispatch routine
-     */
-    CUB_RUNTIME_FUNCTION __forceinline__
-    static cudaError_t Dispatch(
-        void*                       d_temp_storage,                 ///< [in] Device-accessible allocation of temporary storage.  When NULL, the required allocation size is written to \p temp_storage_bytes and no work is done.
-        size_t&                     temp_storage_bytes,             ///< [in,out] Reference to size in bytes of \p d_temp_storage allocation
-        InputIteratorT              d_in,                           ///< [in] Pointer to input sequence of data items
-        OffsetsOutputIteratorT      d_offsets_out,                  ///< [out] Pointer to output sequence of run-offsets
-        LengthsOutputIteratorT      d_lengths_out,                  ///< [out] Pointer to output sequence of run-lengths
-        NumRunsOutputIteratorT      d_num_runs_out,                 ///< [out] Pointer to total number of runs (i.e., length of \p d_offsets_out)
-        EqualityOpT                 equality_op,                    ///< [in] Equality operator for input items
-        OffsetT                     num_items,                      ///< [in] Total number of input items (i.e., length of \p d_in)
-        cudaStream_t                stream)                         ///< [in] <b>[optional]</b> CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
-    {
-        cudaError error = cudaSuccess;
-        do
-        {
-            // Get PTX version
-            int ptx_version = 0;
-            if (CubDebug(error = PtxVersion(ptx_version))) break;
+      // Dispatch
+      if (CubDebug(error = Dispatch(d_temp_storage,
+                                    temp_storage_bytes,
+                                    d_in,
+                                    d_offsets_out,
+                                    d_lengths_out,
+                                    d_num_runs_out,
+                                    equality_op,
+                                    num_items,
+                                    stream,
+                                    ptx_version,
+                                    DeviceCompactInitKernel<ScanTileStateT, NumRunsOutputIteratorT>,
+                                    DeviceRleSweepKernel<PtxRleSweepPolicy,
+                                                         InputIteratorT,
+                                                         OffsetsOutputIteratorT,
+                                                         LengthsOutputIteratorT,
+                                                         NumRunsOutputIteratorT,
+                                                         ScanTileStateT,
+                                                         EqualityOpT,
+                                                         OffsetT>,
+                                    device_rle_config)))
+      {
+        break;
+      }
+    } while (0);
 
-            // Get kernel kernel dispatch configurations
-            KernelConfig device_rle_config;
-            InitConfigs(ptx_version, device_rle_config);
+    return error;
+  }
 
-            // Dispatch
-            if (CubDebug(error = Dispatch(
-                d_temp_storage,
-                temp_storage_bytes,
-                d_in,
-                d_offsets_out,
-                d_lengths_out,
-                d_num_runs_out,
-                equality_op,
-                num_items,
-                stream,
-                ptx_version,
-                DeviceCompactInitKernel<ScanTileStateT, NumRunsOutputIteratorT>,
-                DeviceRleSweepKernel<PtxRleSweepPolicy, InputIteratorT, OffsetsOutputIteratorT, LengthsOutputIteratorT, NumRunsOutputIteratorT, ScanTileStateT, EqualityOpT, OffsetT>,
-                device_rle_config))) break;
-        }
-        while (0);
+  CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
+  Dispatch(void *d_temp_storage,
+           size_t &temp_storage_bytes,
+           InputIteratorT d_in,
+           OffsetsOutputIteratorT d_offsets_out,
+           LengthsOutputIteratorT d_lengths_out,
+           NumRunsOutputIteratorT d_num_runs_out,
+           EqualityOpT equality_op,
+           OffsetT num_items,
+           cudaStream_t stream,
+           bool debug_synchronous)
+  {
+    CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
 
-        return error;
-    }
-
-    CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
-    Dispatch(void *d_temp_storage,
-             size_t &temp_storage_bytes,
-             InputIteratorT d_in,
-             OffsetsOutputIteratorT d_offsets_out,
-             LengthsOutputIteratorT d_lengths_out,
-             NumRunsOutputIteratorT d_num_runs_out,
-             EqualityOpT equality_op,
-             OffsetT num_items,
-             cudaStream_t stream,
-             bool debug_synchronous)
-    {
-      CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
-
-      return Dispatch(d_temp_storage,
-                      temp_storage_bytes,
-                      d_in,
-                      d_offsets_out,
-                      d_lengths_out,
-                      d_num_runs_out,
-                      equality_op,
-                      num_items,
-                      stream);
-    }
+    return Dispatch(d_temp_storage,
+                    temp_storage_bytes,
+                    d_in,
+                    d_offsets_out,
+                    d_lengths_out,
+                    d_num_runs_out,
+                    equality_op,
+                    num_items,
+                    stream);
+  }
 };
 
-
 CUB_NAMESPACE_END
-
-

--- a/cub/device/dispatch/dispatch_three_way_partition.cuh
+++ b/cub/device/dispatch/dispatch_three_way_partition.cuh
@@ -27,9 +27,6 @@
 
 #pragma once
 
-#include <iterator>
-#include <cstdio>
-
 #include <cub/agent/agent_three_way_partition.cuh>
 #include <cub/config.cuh>
 #include <cub/device/dispatch/dispatch_scan.cuh>
@@ -38,12 +35,14 @@
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
 
-#include <nv/target>
-
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 
-CUB_NAMESPACE_BEGIN
+#include <cstdio>
+#include <iterator>
 
+#include <nv/target>
+
+CUB_NAMESPACE_BEGIN
 
 /******************************************************************************
  * Kernel entry points
@@ -60,28 +59,27 @@ template <typename AgentThreeWayPartitionPolicyT,
           typename SelectSecondPartOp,
           typename OffsetT>
 __launch_bounds__(int(AgentThreeWayPartitionPolicyT::BLOCK_THREADS)) __global__
-void DeviceThreeWayPartitionKernel(InputIteratorT d_in,
-                                   FirstOutputIteratorT d_first_part_out,
-                                   SecondOutputIteratorT d_second_part_out,
-                                   UnselectedOutputIteratorT d_unselected_out,
-                                   NumSelectedIteratorT d_num_selected_out,
-                                   ScanTileStateT tile_status_1,
-                                   ScanTileStateT tile_status_2,
-                                   SelectFirstPartOp select_first_part_op,
-                                   SelectSecondPartOp select_second_part_op,
-                                   OffsetT num_items,
-                                   int num_tiles)
+  void DeviceThreeWayPartitionKernel(InputIteratorT d_in,
+                                     FirstOutputIteratorT d_first_part_out,
+                                     SecondOutputIteratorT d_second_part_out,
+                                     UnselectedOutputIteratorT d_unselected_out,
+                                     NumSelectedIteratorT d_num_selected_out,
+                                     ScanTileStateT tile_status_1,
+                                     ScanTileStateT tile_status_2,
+                                     SelectFirstPartOp select_first_part_op,
+                                     SelectSecondPartOp select_second_part_op,
+                                     OffsetT num_items,
+                                     int num_tiles)
 {
   // Thread block type for selecting data from input tiles
-  using AgentThreeWayPartitionT =
-    AgentThreeWayPartition<AgentThreeWayPartitionPolicyT,
-                           InputIteratorT,
-                           FirstOutputIteratorT,
-                           SecondOutputIteratorT,
-                           UnselectedOutputIteratorT,
-                           SelectFirstPartOp,
-                           SelectSecondPartOp,
-                           OffsetT>;
+  using AgentThreeWayPartitionT = AgentThreeWayPartition<AgentThreeWayPartitionPolicyT,
+                                                         InputIteratorT,
+                                                         FirstOutputIteratorT,
+                                                         SecondOutputIteratorT,
+                                                         UnselectedOutputIteratorT,
+                                                         SelectFirstPartOp,
+                                                         SelectSecondPartOp,
+                                                         OffsetT>;
 
   // Shared memory for AgentThreeWayPartition
   __shared__ typename AgentThreeWayPartitionT::TempStorage temp_storage;
@@ -120,13 +118,11 @@ void DeviceThreeWayPartitionKernel(InputIteratorT d_in,
  *   Pointer to the total number of items selected
  *   (i.e., length of @p d_selected_out)
  */
-template <typename ScanTileStateT,
-          typename NumSelectedIteratorT>
-__global__ void
-DeviceThreeWayPartitionInitKernel(ScanTileStateT tile_state_1,
-                                  ScanTileStateT tile_state_2,
-                                  int num_tiles,
-                                  NumSelectedIteratorT d_num_selected_out)
+template <typename ScanTileStateT, typename NumSelectedIteratorT>
+__global__ void DeviceThreeWayPartitionInitKernel(ScanTileStateT tile_state_1,
+                                                  ScanTileStateT tile_state_2,
+                                                  int num_tiles,
+                                                  NumSelectedIteratorT d_num_selected_out)
 {
   // Initialize tile status
   tile_state_1.InitializeStatus(num_tiles);
@@ -160,11 +156,10 @@ struct DispatchThreeWayPartitionIf
    * Types and constants
    ****************************************************************************/
 
-  using InputT = cub::detail::value_t<InputIteratorT>;
+  using InputT         = cub::detail::value_t<InputIteratorT>;
   using ScanTileStateT = cub::ScanTileState<OffsetT>;
 
   constexpr static int INIT_KERNEL_THREADS = 256;
-
 
   /*****************************************************************************
    * Tuning policies
@@ -175,12 +170,11 @@ struct DispatchThreeWayPartitionIf
   {
     constexpr static int ITEMS_PER_THREAD = Nominal4BItemsToItems<InputT>(9);
 
-    using ThreeWayPartitionPolicy =
-      cub::AgentThreeWayPartitionPolicy<256,
-                                        ITEMS_PER_THREAD,
-                                        cub::BLOCK_LOAD_DIRECT,
-                                        cub::LOAD_DEFAULT,
-                                        cub::BLOCK_SCAN_WARP_SCANS>;
+    using ThreeWayPartitionPolicy = cub::AgentThreeWayPartitionPolicy<256,
+                                                                      ITEMS_PER_THREAD,
+                                                                      cub::BLOCK_LOAD_DIRECT,
+                                                                      cub::LOAD_DEFAULT,
+                                                                      cub::BLOCK_SCAN_WARP_SCANS>;
   };
 
   /*****************************************************************************
@@ -190,8 +184,8 @@ struct DispatchThreeWayPartitionIf
   using PtxPolicy = Policy350;
 
   // "Opaque" policies (whose parameterizations aren't reflected in the type signature)
-  struct PtxThreeWayPartitionPolicyT : PtxPolicy::ThreeWayPartitionPolicy {};
-
+  struct PtxThreeWayPartitionPolicyT : PtxPolicy::ThreeWayPartitionPolicy
+  {};
 
   /*****************************************************************************
    * Utilities
@@ -202,25 +196,20 @@ struct DispatchThreeWayPartitionIf
    * to the PTX assembly we will use
    */
   template <typename KernelConfig>
-  CUB_RUNTIME_FUNCTION __forceinline__
-  static void InitConfigs(
-    int             ptx_version,
-    KernelConfig    &select_if_config)
+  CUB_RUNTIME_FUNCTION __forceinline__ static void InitConfigs(int ptx_version,
+                                                               KernelConfig &select_if_config)
   {
-    NV_IF_TARGET(
-      NV_IS_DEVICE,
-      ((void)ptx_version;
-       // We're on the device, so initialize the kernel dispatch configurations
-       // with the current PTX policy
-       select_if_config.template Init<PtxThreeWayPartitionPolicyT>();),
-      (// We're on the host, so lookup and initialize the kernel dispatch
-       // configurations with the policies that match the device's PTX version
-       // (There's only one policy right now)
-       (void)ptx_version;
-       select_if_config
-         .template Init<typename Policy350::ThreeWayPartitionPolicy>();));
+    NV_IF_TARGET(NV_IS_DEVICE,
+                 ((void)ptx_version;
+                  // We're on the device, so initialize the kernel dispatch configurations
+                  // with the current PTX policy
+                  select_if_config.template Init<PtxThreeWayPartitionPolicyT>();),
+                 ( // We're on the host, so lookup and initialize the kernel dispatch
+                   // configurations with the policies that match the device's PTX version
+                   // (There's only one policy right now)
+                   (void)ptx_version;
+                   select_if_config.template Init<typename Policy350::ThreeWayPartitionPolicy>();));
   }
-
 
   /**
    * Kernel dispatch configuration.
@@ -232,22 +221,19 @@ struct DispatchThreeWayPartitionIf
     int tile_items;
 
     template <typename PolicyT>
-    CUB_RUNTIME_FUNCTION __forceinline__
-    void Init()
+    CUB_RUNTIME_FUNCTION __forceinline__ void Init()
     {
-      block_threads       = PolicyT::BLOCK_THREADS;
-      items_per_thread    = PolicyT::ITEMS_PER_THREAD;
-      tile_items          = block_threads * items_per_thread;
+      block_threads    = PolicyT::BLOCK_THREADS;
+      items_per_thread = PolicyT::ITEMS_PER_THREAD;
+      tile_items       = block_threads * items_per_thread;
     }
   };
-
 
   /*****************************************************************************
    * Dispatch entrypoints
    ****************************************************************************/
 
-  template <typename ScanInitKernelPtrT,
-            typename SelectIfKernelPtrT>
+  template <typename ScanInitKernelPtrT, typename SelectIfKernelPtrT>
   CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
   Dispatch(void *d_temp_storage,
            std::size_t &temp_storage_bytes,
@@ -284,8 +270,7 @@ struct DispatchThreeWayPartitionIf
       // Specify temporary storage allocation requirements
       size_t allocation_sizes[2]; // bytes needed for tile status descriptors
 
-      if (CubDebug(error = ScanTileStateT::AllocationSize(num_tiles,
-                                                          allocation_sizes[0])))
+      if (CubDebug(error = ScanTileStateT::AllocationSize(num_tiles, allocation_sizes[0])))
       {
         break;
       }
@@ -294,7 +279,7 @@ struct DispatchThreeWayPartitionIf
 
       // Compute allocation pointers into the single storage blob (or compute
       // the necessary size of the blob)
-      void* allocations[2] = {};
+      void *allocations[2] = {};
       if (CubDebug(error = cub::AliasTemporaries(d_temp_storage,
                                                  temp_storage_bytes,
                                                  allocations,
@@ -320,16 +305,12 @@ struct DispatchThreeWayPartitionIf
       ScanTileStateT tile_status_1;
       ScanTileStateT tile_status_2;
 
-      if (CubDebug(error = tile_status_1.Init(num_tiles,
-                                              allocations[0],
-                                              allocation_sizes[0])))
+      if (CubDebug(error = tile_status_1.Init(num_tiles, allocations[0], allocation_sizes[0])))
       {
         break;
       }
 
-      if (CubDebug(error = tile_status_2.Init(num_tiles,
-                                              allocations[1],
-                                              allocation_sizes[1])))
+      if (CubDebug(error = tile_status_2.Init(num_tiles, allocations[1], allocation_sizes[1])))
       {
         break;
       }
@@ -337,21 +318,23 @@ struct DispatchThreeWayPartitionIf
       // Log three_way_partition_init_kernel configuration
       int init_grid_size = CUB_MAX(1, DivideAndRoundUp(num_tiles, INIT_KERNEL_THREADS));
 
-      #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
+#ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
       _CubLog("Invoking three_way_partition_init_kernel<<<%d, %d, 0, %lld>>>()\n",
               init_grid_size,
               INIT_KERNEL_THREADS,
               reinterpret_cast<long long>(stream));
-      #endif
+#endif
 
       // Invoke three_way_partition_init_kernel to initialize tile descriptors
-      THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(
-        init_grid_size, INIT_KERNEL_THREADS, 0, stream
-      ).doit(three_way_partition_init_kernel,
-             tile_status_1,
-             tile_status_2,
-             num_tiles,
-             d_num_selected_out);
+      THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(init_grid_size,
+                                                              INIT_KERNEL_THREADS,
+                                                              0,
+                                                              stream)
+        .doit(three_way_partition_init_kernel,
+              tile_status_1,
+              tile_status_2,
+              num_tiles,
+              d_num_selected_out);
 
       // Check for failure to launch
       if (CubDebug(error = cudaPeekAtLastError()))
@@ -368,9 +351,8 @@ struct DispatchThreeWayPartitionIf
 
       // Get max x-dimension of grid
       int max_dim_x;
-      if (CubDebug(error = cudaDeviceGetAttribute(&max_dim_x,
-                                                  cudaDevAttrMaxGridDimX,
-                                                  device_ordinal)))
+      if (CubDebug(
+            error = cudaDeviceGetAttribute(&max_dim_x, cudaDevAttrMaxGridDimX, device_ordinal)))
       {
         break;
       }
@@ -381,15 +363,14 @@ struct DispatchThreeWayPartitionIf
       scan_grid_size.y = DivideAndRoundUp(num_tiles, max_dim_x);
       scan_grid_size.x = CUB_MIN(num_tiles, max_dim_x);
 
-      // Log select_if_kernel configuration
-      #ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
+// Log select_if_kernel configuration
+#ifdef CUB_DETAIL_DEBUG_ENABLE_LOG
       {
         // Get SM occupancy for select_if_kernel
         int range_select_sm_occupancy;
-        if (CubDebug(error = MaxSmOccupancy(
-          range_select_sm_occupancy,            // out
-          three_way_partition_kernel,
-          three_way_partition_config.block_threads)))
+        if (CubDebug(error = MaxSmOccupancy(range_select_sm_occupancy, // out
+                                            three_way_partition_kernel,
+                                            three_way_partition_config.block_threads)))
         {
           break;
         }
@@ -404,23 +385,26 @@ struct DispatchThreeWayPartitionIf
                 three_way_partition_config.items_per_thread,
                 range_select_sm_occupancy);
       }
-      #endif
+#endif
 
       // Invoke select_if_kernel
       THRUST_NS_QUALIFIER::cuda_cub::launcher::triple_chevron(
-        scan_grid_size, three_way_partition_config.block_threads, 0, stream
-      ).doit(three_way_partition_kernel,
-             d_in,
-             d_first_part_out,
-             d_second_part_out,
-             d_unselected_out,
-             d_num_selected_out,
-             tile_status_1,
-             tile_status_2,
-             select_first_part_op,
-             select_second_part_op,
-             num_items,
-             num_tiles);
+        scan_grid_size,
+        three_way_partition_config.block_threads,
+        0,
+        stream)
+        .doit(three_way_partition_kernel,
+              d_in,
+              d_first_part_out,
+              d_second_part_out,
+              d_unselected_out,
+              d_num_selected_out,
+              tile_status_1,
+              tile_status_2,
+              select_first_part_op,
+              select_second_part_op,
+              num_items,
+              num_tiles);
 
       // Check for failure to launch
       if (CubDebug(error = cudaPeekAtLastError()))
@@ -434,15 +418,53 @@ struct DispatchThreeWayPartitionIf
       {
         break;
       }
-    }
-    while (0);
+    } while (0);
 
     return error;
   }
 
-  template <typename ScanInitKernelPtrT,
-            typename SelectIfKernelPtrT>
+  template <typename ScanInitKernelPtrT, typename SelectIfKernelPtrT>
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
+    CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
+    Dispatch(void *d_temp_storage,
+             std::size_t &temp_storage_bytes,
+             InputIteratorT d_in,
+             FirstOutputIteratorT d_first_part_out,
+             SecondOutputIteratorT d_second_part_out,
+             UnselectedOutputIteratorT d_unselected_out,
+             NumSelectedIteratorT d_num_selected_out,
+             SelectFirstPartOp select_first_part_op,
+             SelectSecondPartOp select_second_part_op,
+             OffsetT num_items,
+             cudaStream_t stream,
+             bool debug_synchronous,
+             int ptx_version,
+             ScanInitKernelPtrT three_way_partition_init_kernel,
+             SelectIfKernelPtrT three_way_partition_kernel,
+             KernelConfig three_way_partition_config)
+  {
+    CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
+
+    return Dispatch<ScanInitKernelPtrT, SelectIfKernelPtrT>(d_temp_storage,
+                                                            temp_storage_bytes,
+                                                            d_in,
+                                                            d_first_part_out,
+                                                            d_second_part_out,
+                                                            d_unselected_out,
+                                                            d_num_selected_out,
+                                                            select_first_part_op,
+                                                            select_second_part_op,
+                                                            num_items,
+                                                            stream,
+                                                            ptx_version,
+                                                            three_way_partition_init_kernel,
+                                                            three_way_partition_kernel,
+                                                            three_way_partition_config);
+  }
+
+  /**
+   * Internal dispatch routine
+   */
   CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
   Dispatch(void *d_temp_storage,
            std::size_t &temp_storage_bytes,
@@ -454,50 +476,7 @@ struct DispatchThreeWayPartitionIf
            SelectFirstPartOp select_first_part_op,
            SelectSecondPartOp select_second_part_op,
            OffsetT num_items,
-           cudaStream_t stream,
-           bool debug_synchronous,
-           int ptx_version,
-           ScanInitKernelPtrT three_way_partition_init_kernel,
-           SelectIfKernelPtrT three_way_partition_kernel,
-           KernelConfig three_way_partition_config)
-  {
-    CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
-
-    return Dispatch<ScanInitKernelPtrT, SelectIfKernelPtrT>(
-      d_temp_storage,
-      temp_storage_bytes,
-      d_in,
-      d_first_part_out,
-      d_second_part_out,
-      d_unselected_out,
-      d_num_selected_out,
-      select_first_part_op,
-      select_second_part_op,
-      num_items,
-      stream,
-      ptx_version,
-      three_way_partition_init_kernel,
-      three_way_partition_kernel,
-      three_way_partition_config);
-  }
-
-
-  /**
-   * Internal dispatch routine
-   */
-  CUB_RUNTIME_FUNCTION __forceinline__
-  static cudaError_t Dispatch(
-    void*                       d_temp_storage,
-    std::size_t&                temp_storage_bytes,
-    InputIteratorT              d_in,
-    FirstOutputIteratorT        d_first_part_out,
-    SecondOutputIteratorT       d_second_part_out,
-    UnselectedOutputIteratorT   d_unselected_out,
-    NumSelectedIteratorT        d_num_selected_out,
-    SelectFirstPartOp           select_first_part_op,
-    SelectSecondPartOp          select_second_part_op,
-    OffsetT                     num_items,
-    cudaStream_t                stream)
+           cudaStream_t stream)
   {
     cudaError error = cudaSuccess;
 
@@ -528,8 +507,7 @@ struct DispatchThreeWayPartitionIf
                      num_items,
                      stream,
                      ptx_version,
-                     DeviceThreeWayPartitionInitKernel<ScanTileStateT,
-                                                       NumSelectedIteratorT>,
+                     DeviceThreeWayPartitionInitKernel<ScanTileStateT, NumSelectedIteratorT>,
                      DeviceThreeWayPartitionKernel<PtxThreeWayPartitionPolicyT,
                                                    InputIteratorT,
                                                    FirstOutputIteratorT,
@@ -550,20 +528,19 @@ struct DispatchThreeWayPartitionIf
   }
 
   CUB_DETAIL_RUNTIME_DEBUG_SYNC_IS_NOT_SUPPORTED
-  CUB_RUNTIME_FUNCTION __forceinline__
-  static cudaError_t Dispatch(
-    void*                       d_temp_storage,
-    std::size_t&                temp_storage_bytes,
-    InputIteratorT              d_in,
-    FirstOutputIteratorT        d_first_part_out,
-    SecondOutputIteratorT       d_second_part_out,
-    UnselectedOutputIteratorT   d_unselected_out,
-    NumSelectedIteratorT        d_num_selected_out,
-    SelectFirstPartOp           select_first_part_op,
-    SelectSecondPartOp          select_second_part_op,
-    OffsetT                     num_items,
-    cudaStream_t                stream,
-    bool                        debug_synchronous)
+  CUB_RUNTIME_FUNCTION __forceinline__ static cudaError_t
+  Dispatch(void *d_temp_storage,
+           std::size_t &temp_storage_bytes,
+           InputIteratorT d_in,
+           FirstOutputIteratorT d_first_part_out,
+           SecondOutputIteratorT d_second_part_out,
+           UnselectedOutputIteratorT d_unselected_out,
+           NumSelectedIteratorT d_num_selected_out,
+           SelectFirstPartOp select_first_part_op,
+           SelectSecondPartOp select_second_part_op,
+           OffsetT num_items,
+           cudaStream_t stream,
+           bool debug_synchronous)
   {
     CUB_DETAIL_RUNTIME_DEBUG_SYNC_USAGE_LOG
 
@@ -580,6 +557,5 @@ struct DispatchThreeWayPartitionIf
                     stream);
   }
 };
-
 
 CUB_NAMESPACE_END


### PR DESCRIPTION
This PR addresses https://github.com/NVIDIA/cub/issues/689. It adds tuning policy to histogram, rle, three way partition, and reduce by key. This breaks kernels, dispatch constructors, along with some member functions taking kernels as arguments. The change is required to tune mentioned algorithms. Furthermore, we consider API taking kernels and the kernels themselves an implementation detail. The dispatch layer should be used as `DispatchAlgorithmT::Dispatch(...)`. The member functions taking kernels are not considered entry points. Therefore, we do not treat changes in this PR as breaking ones. 

Since the tuning policy was just introduced for tuning purposes, the content of tuning policy is subject to change. Newly introduced tuning policies are documented as an implementation detail for now. 

Apart from that, this PR introduces benchmarks for mentioned algorithms and adds some missing tunings for radix sort / H100. 