### PR TITLE
Introduce SM90 tuning policy into scan

### DIFF
--- a/benchmarks/scripts/analyze.py
+++ b/benchmarks/scripts/analyze.py
@@ -221,7 +221,7 @@ def iterate_case_dfs(args, callable):
 
                 for gpu in ctk_cub_df['gpu'].unique():
                     target_df = ctk_cub_df[ctk_cub_df['gpu'] == gpu]
-                    target_df.drop(columns=['ctk', 'cub', 'gpu'], inplace=True)
+                    target_df = target_df.drop(columns=['ctk', 'cub', 'gpu'])
                     target_df = compute_speedup(target_df)
 
                     for ct_point in ct_space(target_df):

--- a/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/device/dispatch/dispatch_scan.cuh
@@ -199,7 +199,51 @@ __launch_bounds__(int(ChainedPolicyT::ActivePolicy::ScanPolicyT::BLOCK_THREADS))
  * Policy
  ******************************************************************************/
 
-template <typename AccumT> ///< Data type
+namespace detail
+{
+namespace scan
+{
+
+template <int Threads, int Items, int L2B, int L2W>
+struct tuning
+{
+  static constexpr int threads = Threads;
+  static constexpr int items   = Items;
+
+  using delay_constructor = detail::fixed_delay_constructor_t<L2B, L2W>;
+};
+
+template <class AccumT,
+          bool PrimitiveOp,
+          bool PrimitiveAccumulator = Traits<AccumT>::PRIMITIVE,
+          std::size_t AccumSize     = sizeof(AccumT)>
+struct sm90_tuning
+{
+  static constexpr int threads = 128;
+  static constexpr int items   = 15;
+
+  using delay_constructor = detail::default_delay_constructor_t<AccumT>;
+};
+
+// clang-format off
+template <class T> struct sm90_tuning<T, true, true, 1> : tuning<192, 22, 168, 1140> {};
+template <class T> struct sm90_tuning<T, true, true, 2> : tuning<512, 12, 376, 1125> {};
+template <class T> struct sm90_tuning<T, true, true, 4> : tuning<128, 24, 648, 1245> {};
+template <class T> struct sm90_tuning<T, true, true, 8> : tuning<224, 24, 632, 1290> {};
+
+template <> struct sm90_tuning<float,  true, true,  sizeof(float)> : tuning<128, 24, 688, 1140> {};
+template <> struct sm90_tuning<double, true, true, sizeof(double)> : tuning<224, 24, 576, 1215> {};
+
+#if CUB_IS_INT128_ENABLED 
+template <> struct sm90_tuning< __int128_t, true, false,  sizeof(__int128_t)> : tuning<576, 21, 860, 630> {};
+template <> struct sm90_tuning<__uint128_t, true, false, sizeof(__uint128_t)> : tuning<576, 21, 860, 630> {};
+#endif
+// clang-format on
+
+} // namespace scan
+} // namespace detail
+
+template <typename AccumT, typename ScanOpT = Sum> 
 struct DeviceScanPolicy
 {
   // For large values, use timesliced loads/stores to fit shared memory.
@@ -271,7 +315,22 @@ struct DeviceScanPolicy
                                  detail::default_delay_constructor_t<AccumT>>;
   };
 
-  using MaxPolicy = Policy600;
+  /// SM900
+  struct Policy900 : ChainedPolicy<900, Policy900, Policy600>
+  {
+    using tuning = detail::scan::sm90_tuning<AccumT, detail::basic_binary_op_t<ScanOpT>::value>;
+
+    using ScanPolicyT = policy_t<tuning::threads,
+                                 tuning::items,
+                                 AccumT,
+                                 ScanTransposedLoad,
+                                 LOAD_DEFAULT,
+                                 ScanTransposedStore,
+                                 BLOCK_SCAN_WARP_SCANS,
+                                 typename tuning::delay_constructor>;
+  };
+
+  using MaxPolicy = Policy900;
 };
 
 /******************************************************************************
@@ -312,7 +371,7 @@ template <typename InputIteratorT,
                 cub::detail::value_t<InputIteratorT>,
                 typename InitValueT::value_type>,
               cub::detail::value_t<InputIteratorT>>,
-          typename SelectedPolicy = DeviceScanPolicy<AccumT>>
+          typename SelectedPolicy = DeviceScanPolicy<AccumT, ScanOpT>>
 struct DispatchScan : SelectedPolicy
 {
   //---------------------------------------------------------------------

--- a/cub/thread/thread_operators.cuh
+++ b/cub/thread/thread_operators.cuh
@@ -215,6 +215,33 @@ struct ArgMin
   }
 };
 
+namespace detail
+{
+template <class OpT>
+struct basic_binary_op_t
+{
+  static constexpr bool value = false;
+};
+
+template <>
+struct basic_binary_op_t<Sum>
+{
+  static constexpr bool value = true;
+};
+
+template <>
+struct basic_binary_op_t<Min>
+{
+  static constexpr bool value = true;
+};
+
+template <>
+struct basic_binary_op_t<Max>
+{
+  static constexpr bool value = true;
+};
+} // namespace detail
+
 /// @brief Default cast functor
 template <typename B>
 struct CastOp


### PR DESCRIPTION
Sum tuning converges on the following speedups:
| I8 | I16 | I32 | I64 | I128 | F32 | F64 |
| --: | ----: | ---: | ---: | ---: |  ---: |  ---: | 
| -17% | -4% | -6% | -12% | -60% | -17% | -12% |  

<details>

|  T      |  Elements      |   Cmp Noise |         Diff |   %Diff |
|--------:|---------------:|------------:|-------------:|--------:|
|   I8    |      2^16      |       1.77% |    -0.257 us |  -2.64% |
|   I8    |      2^20      |       1.75% |     0.111 us |   0.89% |
|   I8    |      2^24      |       1.58% |    -4.403 us |  -9.64% |
|   I8    |      2^28      |       0.46% |   -98.185 us | -16.66% |
|   I16   |      2^16      |       2.16% |    -0.109 us |  -1.05% |
|   I16   |      2^20      |       1.70% |    -0.050 us |  -0.38% |
|   I16   |      2^24      |       2.23% |    -0.450 us |  -0.95% |
|   I16   |      2^28      |       0.77% |   -21.629 us |  -3.67% |
|   I32   |      2^16      |       2.47% |    -0.283 us |  -2.65% |
|   I32   |      2^20      |       1.86% |    -0.058 us |  -0.41% |
|   I32   |      2^24      |       2.67% |    -3.394 us |  -5.06% |
|   I32   |      2^28      |       0.84% |   -49.091 us |  -5.49% |
|   I64   |      2^16      |       2.75% |     0.001 us |   0.01% |
|   I64   |      2^20      |       1.65% |    -0.795 us |  -4.65% |
|   I64   |      2^24      |       1.40% |   -13.917 us | -11.33% |
|   I64   |      2^28      |       0.38% |  -209.888 us | -11.80% |
|  I128   |      2^16      |       1.44% |    -2.008 us | -12.19% |
|  I128   |      2^20      |       2.20% |   -25.715 us | -44.01% |
|  I128   |      2^24      |       0.78% |  -422.172 us | -58.26% |
|  I128   |      2^28      |       0.21% | -6815.555 us | -59.76% |
|   F32   |      2^16      |       2.56% |     0.268 us |   2.60% |
|   F32   |      2^20      |       1.75% |     0.038 us |   0.27% |
|   F32   |      2^24      |       2.67% |    -9.592 us | -13.13% |
|   F32   |      2^28      |       0.85% |  -167.330 us | -16.51% |
|   F64   |      2^16      |       1.96% |    -0.105 us |  -0.98% |
|   F64   |      2^20      |       1.50% |    -0.564 us |  -3.28% |
|   F64   |      2^24      |       1.43% |   -13.789 us | -11.19% |
|   F64   |      2^28      |       0.37% |  -211.389 us | -11.84% |

</details>

Max tuning converges on the following speedups:
| I8 | I16 | I32 | I64 | I128 | F32 | F64 |
| --: | ----: | ---: | ---: | ---: |  ---: |  ---: | 
| -11% | -15% | -17% | -12% | -60% | -17% | -12% |  

<details>

|  T      |  Elements      |   Cmp Noise |         Diff |   %Diff |
|--------:|---------------:|------------:|-------------:|--------:|
|   I8    |      2^16      |       1.64% |     0.986 us |  10.05% |
|   I8    |      2^20      |       2.25% |    -0.573 us |  -4.29% |
|   I8    |      2^24      |       3.09% |    -2.266 us |  -5.06% |
|   I8    |      2^28      |       1.08% |   -61.789 us | -10.69% |
|   I16   |      2^16      |       1.87% |     1.539 us |  14.54% |
|   I16   |      2^20      |       1.77% |    -0.085 us |  -0.61% |
|   I16   |      2^24      |       4.20% |    -3.506 us |  -6.69% |
|   I16   |      2^28      |       1.45% |  -104.667 us | -14.86% |
|   I32   |      2^16      |       2.40% |     0.271 us |   2.58% |
|   I32   |      2^20      |       1.82% |     0.203 us |   1.44% |
|   I32   |      2^24      |       2.59% |    -9.628 us | -13.14% |
|   I32   |      2^28      |       0.86% |  -171.725 us | -16.91% |
|   I64   |      2^16      |       1.95% |     0.156 us |   1.45% |
|   I64   |      2^20      |       2.04% |    -0.374 us |  -2.18% |
|   I64   |      2^24      |       1.38% |   -13.216 us | -10.74% |
|   I64   |      2^28      |       0.34% |  -208.144 us | -11.66% |
|  I128   |      2^16      |       1.45% |    -1.113 us |  -6.51% |
|  I128   |      2^20      |       1.68% |   -24.723 us | -41.24% |
|  I128   |      2^24      |       0.73% |  -414.426 us | -55.87% |
|  I128   |      2^28      |       0.18% | -6720.791 us | -57.51% |
|   F32   |      2^16      |       2.18% |    -0.180 us |  -1.67% |
|   F32   |      2^20      |       1.70% |    -0.253 us |  -1.74% |
|   F32   |      2^24      |       2.68% |    -9.860 us | -13.39% |
|   F32   |      2^28      |       0.82% |  -168.664 us | -16.58% |
|   F64   |      2^16      |       1.97% |    -0.346 us |  -3.13% |
|   F64   |      2^20      |       1.54% |    -1.011 us |  -5.73% |
|   F64   |      2^24      |       1.42% |   -13.938 us | -11.28% |
|   F64   |      2^28      |       0.37% |  -209.521 us | -11.72% |

</details>
