### PR TITLE
Fix reduce by key tile state for Pascal

### DIFF
--- a/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/agent/single_pass_scan_operators.cuh
@@ -194,7 +194,12 @@ struct no_delay_constructor_t
 {
   struct delay_t
   {
-    __device__ __forceinline__ void operator()() {}
+    __device__ __forceinline__ void operator()() 
+    {
+      NV_IF_TARGET(NV_PROVIDES_SM_70,
+                  (),
+                  (__threadfence_block();));
+    }
   };
 
   __device__ __forceinline__ no_delay_constructor_t(unsigned int /* seed */)
@@ -997,7 +1002,7 @@ struct ReduceByKeyScanTileState<ValueT, KeyT, true>
     /**
      * Wait for the corresponding tile to become non-invalid
      */
-    template <class DelayT = detail::fixed_delay_constructor_t<350, 450>> 
+    template <class DelayT = detail::fixed_delay_constructor_t<350, 450>::delay_t> 
     __device__ __forceinline__ void WaitForValid(
         int                     tile_idx,
         StatusWord              &status,


### PR DESCRIPTION
Last week's [PR](https://github.com/NVIDIA/cub/pull/710) introduced a regression for direct users of `ReduceByKeyScanTileState` on pre-Volta architectures. Delay should contain thread fence in pre-Volta cases in order to prevent hoisting.