### PR TITLE
Improve docs for warp-wide primitives

### DIFF
--- a/cub/warp/warp_exchange.cuh
+++ b/cub/warp/warp_exchange.cuh
@@ -185,7 +185,7 @@ public:
    *        <em>striped</em> arrangement.
    *
    * @par
-   * \smemreuse
+   * @smemwarpreuse
    *
    * @par Snippet
    * The code snippet below illustrates the conversion from a "blocked" to a
@@ -254,7 +254,7 @@ public:
    *        <em>blocked</em> arrangement.
    *
    * @par
-   * \smemreuse
+   * @smemwarpreuse
    *
    * @par Snippet
    * The code snippet below illustrates the conversion from a "striped" to a
@@ -321,7 +321,7 @@ public:
    *        into <em>striped</em> arrangement.
    *
    * @par
-   * \smemreuse
+   * @smemwarpreuse
    *
    * @par Snippet
    * The code snippet below illustrates the conversion from a "scatter" to a
@@ -379,7 +379,7 @@ public:
    *        into <em>striped</em> arrangement.
    *
    * @par
-   * \smemreuse
+   * @smemwarpreuse
    *
    * @par Snippet
    * The code snippet below illustrates the conversion from a "scatter" to a

--- a/cub/warp/warp_load.cuh
+++ b/cub/warp/warp_load.cuh
@@ -25,10 +25,7 @@
  *
  ******************************************************************************/
 
-/**
- * @file
- * Operations for reading linear tiles of data into the CUDA warp.
- */
+//! @file Operations for reading linear tiles of data into the CUDA warp.
 
 #pragma once
 
@@ -46,11 +43,10 @@
 CUB_NAMESPACE_BEGIN
 
 
-/**
- * @brief cub::WarpLoadAlgorithm enumerates alternative algorithms for
- *        cub::WarpLoad to read a linear segment of data from memory into a
- *        a CUDA warp.
- */
+//! @rst
+//! ``cub::WarpLoadAlgorithm`` enumerates alternative algorithms for :cpp:struct:`cub::WarpLoad` to 
+//! read a linear segment of data from memory into a CUDA warp.
+//! @endrst
 enum WarpLoadAlgorithm
 {
   /**
@@ -519,7 +515,7 @@ public:
    * @brief Load a linear segment of items from memory.
    *
    * @par
-   * \smemreuse
+   * @smemwarpreuse
    *
    * @par Snippet
    * @code
@@ -569,7 +565,7 @@ public:
    * @brief Load a linear segment of items from memory, guarded by range.
    *
    * @par
-   * \smemreuse
+   * @smemwarpreuse
    *
    * @par Snippet
    * @code
@@ -626,7 +622,7 @@ public:
    * @brief Load a linear segment of items from memory, guarded by range.
    *
    * @par
-   * \smemreuse
+   * @smemwarpreuse
    *
    * @par Snippet
    * @code

--- a/cub/warp/warp_load.cuh
+++ b/cub/warp/warp_load.cuh
@@ -29,9 +29,6 @@
 
 #pragma once
 
-#include <iterator>
-#include <type_traits>
-
 #include <cub/block/block_load.cuh>
 #include <cub/config.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
@@ -39,12 +36,13 @@
 #include <cub/util_type.cuh>
 #include <cub/warp/warp_exchange.cuh>
 
+#include <iterator>
+#include <type_traits>
 
 CUB_NAMESPACE_BEGIN
 
-
 //! @rst
-//! ``cub::WarpLoadAlgorithm`` enumerates alternative algorithms for :cpp:struct:`cub::WarpLoad` to 
+//! ``cub::WarpLoadAlgorithm`` enumerates alternative algorithms for :cpp:struct:`cub::WarpLoad` to
 //! read a linear segment of data from memory into a CUDA warp.
 //! @endrst
 enum WarpLoadAlgorithm
@@ -52,12 +50,12 @@ enum WarpLoadAlgorithm
   //! @rst
   //! Overview
   //! ++++++++++++++++++++++++++
-  //! 
+  //!
   //! A :ref:`blocked arrangement <flexible-data-arrangement>` of data is read directly from memory.
-  //! 
+  //!
   //! Performance Considerations
   //! ++++++++++++++++++++++++++
-  //! 
+  //!
   //! The utilization of memory transactions (coalescing) decreases as the
   //! access stride between threads increases (i.e., the number items per thread).
   //! @endrst
@@ -66,12 +64,12 @@ enum WarpLoadAlgorithm
   //! @rst
   //! Overview
   //! ++++++++++++++++++++++++++
-  //! 
+  //!
   //! A :ref:`striped arrangement <flexible-data-arrangement>` of data is read directly from memory.
-  //! 
+  //!
   //! Performance Considerations
   //! ++++++++++++++++++++++++++
-  //! 
+  //!
   //! The utilization of memory transactions (coalescing) doesn't depend on
   //! the number of items per thread.
   //! @endrst
@@ -80,12 +78,12 @@ enum WarpLoadAlgorithm
   //! @rst
   //! Overview
   //! ++++++++++++++++++++++++++
-  //!  
-  //! A :ref:`blocked arrangement <flexible-data-arrangement>` of data is read from memory using 
+  //!
+  //! A :ref:`blocked arrangement <flexible-data-arrangement>` of data is read from memory using
   //! CUDA's built-in vectorized loads as a coalescing optimization.
-  //! For example, ``ld.global.v4.s32`` instructions will be generated when ``T = int`` and 
+  //! For example, ``ld.global.v4.s32`` instructions will be generated when ``T = int`` and
   //! ``ITEMS_PER_THREAD % 4 == 0``.
-  //!  
+  //!
   //! Performance Considerations
   //! ++++++++++++++++++++++++++
   //!
@@ -98,7 +96,7 @@ enum WarpLoadAlgorithm
   //!   - ``ITEMS_PER_THREAD`` is odd
   //!   - The ``InputIteratorT`` is not a simple pointer type
   //!   - The block input offset is not quadword-aligned
-  //!   - The data type ``T`` is not a built-in primitive or CUDA vector type 
+  //!   - The data type ``T`` is not a built-in primitive or CUDA vector type
   //!     (e.g., ``short``, ``int2``, ``double``, ``float2``, etc.)
   //! @endrst
   WARP_LOAD_VECTORIZE,
@@ -106,9 +104,9 @@ enum WarpLoadAlgorithm
   //! @rst
   //! Overview
   //! ++++++++++++++++++++++++++
-  //!  
-  //! A :ref:`striped arrangement <flexible-data-arrangement>` of data is read efficiently from 
-  //! memory and then locally transposed into a 
+  //!
+  //! A :ref:`striped arrangement <flexible-data-arrangement>` of data is read efficiently from
+  //! memory and then locally transposed into a
   //! :ref:`blocked arrangement <flexible-data-arrangement>`.
   //!
   //! Performance Considerations
@@ -116,18 +114,17 @@ enum WarpLoadAlgorithm
   //!
   //! - The utilization of memory transactions (coalescing) remains high
   //!   regardless of items loaded per thread.
-  //! - The local reordering incurs slightly longer latencies and throughput than the direct 
+  //! - The local reordering incurs slightly longer latencies and throughput than the direct
   //!   ``cub::WARP_LOAD_DIRECT`` and ``cub::WARP_LOAD_VECTORIZE`` alternatives.
   //! @endrst
   WARP_LOAD_TRANSPOSE
 };
 
-
 //! @rst
-//! The WarpLoad class provides :ref:`collective <collective-primitives>` data movement methods for 
-//! loading a linear segment of items from memory into a 
+//! The WarpLoad class provides :ref:`collective <collective-primitives>` data movement methods for
+//! loading a linear segment of items from memory into a
 //! :ref:`blocked arrangement <flexible-data-arrangement>` across a CUDA thread warp.
-//! 
+//!
 //! Overview
 //! ++++++++++++++++
 //!
@@ -138,19 +135,19 @@ enum WarpLoadAlgorithm
 //! - WarpLoad can be optionally specialized by different data movement strategies:
 //!
 //!   #. :cpp:enumerator:`cub::WARP_LOAD_DIRECT`:
-//!      a :ref:`blocked arrangement <flexible-data-arrangement>` of data is read directly from 
+//!      a :ref:`blocked arrangement <flexible-data-arrangement>` of data is read directly from
 //!      memory.
 //!   #. :cpp:enumerator:`cub::WARP_LOAD_STRIPED`:
-//!      a :ref:`striped arrangement <flexible-data-arrangement>` of data is read directly from 
+//!      a :ref:`striped arrangement <flexible-data-arrangement>` of data is read directly from
 //!      memory.
-//!   #. :cpp:enumerator:`cub::WARP_LOAD_VECTORIZE`: 
-//!      a :ref:`blocked arrangement <flexible-data-arrangement>` of data is read directly from 
-//!      memory using CUDA's built-in vectorized loads as a coalescing optimization. 
-//!   #. :cpp:enumerator:`cub::WARP_LOAD_TRANSPOSE`: 
-//!      a :ref:`striped arrangement <flexible-data-arrangement>` of data is read directly from 
-//!      memory and is then locally transposed into a 
+//!   #. :cpp:enumerator:`cub::WARP_LOAD_VECTORIZE`:
+//!      a :ref:`blocked arrangement <flexible-data-arrangement>` of data is read directly from
+//!      memory using CUDA's built-in vectorized loads as a coalescing optimization.
+//!   #. :cpp:enumerator:`cub::WARP_LOAD_TRANSPOSE`:
+//!      a :ref:`striped arrangement <flexible-data-arrangement>` of data is read directly from
+//!      memory and is then locally transposed into a
 //!      :ref:`blocked arrangement <flexible-data-arrangement>`.
-//! 
+//!
 //! A Simple Example
 //! ++++++++++++++++
 //!
@@ -163,26 +160,26 @@ enum WarpLoadAlgorithm
 //! .. code-block:: c++
 //!
 //!    #include <cub/cub.cuh>   // or equivalently <cub/warp/warp_load.cuh>
-//! 
+//!
 //!    __global__ void ExampleKernel(int *d_data, ...)
 //!    {
 //!        constexpr int warp_threads = 16;
 //!        constexpr int block_threads = 256;
 //!        constexpr int items_per_thread = 4;
-//! 
+//!
 //!        // Specialize WarpLoad for a warp of 16 threads owning 4 integer items each
 //!        using WarpLoadT = WarpLoad<int,
 //!                                   items_per_thread,
 //!                                   cub::WARP_LOAD_TRANSPOSE,
 //!                                   warp_threads>;
-//! 
+//!
 //!        constexpr int warps_in_block = block_threads / warp_threads;
 //!        constexpr int tile_size = items_per_thread * warp_threads;
 //!        const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
-//! 
+//!
 //!        // Allocate shared memory for WarpLoad
 //!        __shared__ typename WarpLoadT::TempStorage temp_storage[warps_in_block];
-//! 
+//!
 //!        // Load a segment of consecutive items that are blocked across threads
 //!        int thread_data[items_per_thread];
 //!        WarpLoadT(temp_storage[warp_id]).Load(d_data + warp_id * tile_size,
@@ -192,31 +189,31 @@ enum WarpLoadAlgorithm
 //! The set of ``thread_data`` across the first logical warp of threads in those
 //! threads will be: ``{ [0,1,2,3], [4,5,6,7], ..., [60,61,62,63] }``.
 //! @endrst
-//! 
+//!
 //! @tparam InputT
 //!   The data type to read into (which must be convertible from the input
 //!   iterator's value type).
-//! 
+//!
 //! @tparam ITEMS_PER_THREAD
 //!   The number of consecutive items partitioned onto each thread.
-//! 
+//!
 //! @tparam ALGORITHM
 //!   <b>[optional]</b> cub::WarpLoadAlgorithm tuning policy.
 //!   default: cub::WARP_LOAD_DIRECT.
-//! 
+//!
 //! @tparam LOGICAL_WARP_THREADS
 //!   <b>[optional]</b> The number of threads per "logical" warp (may be less
 //!   than the number of hardware warp threads). Default is the warp size of the
 //!   targeted CUDA compute-capability (e.g., 32 threads for SM86). Must be a
 //!   power of two.
-//! 
+//!
 //! @tparam LEGACY_PTX_ARCH
 //!   Unused.
-template <typename          InputT,
-          int               ITEMS_PER_THREAD,
-          WarpLoadAlgorithm ALGORITHM            = WARP_LOAD_DIRECT,
-          int               LOGICAL_WARP_THREADS = CUB_PTX_WARP_THREADS,
-          int               LEGACY_PTX_ARCH      = 0>
+template <typename InputT,
+          int ITEMS_PER_THREAD,
+          WarpLoadAlgorithm ALGORITHM = WARP_LOAD_DIRECT,
+          int LOGICAL_WARP_THREADS    = CUB_PTX_WARP_THREADS,
+          int LEGACY_PTX_ARCH         = 0>
 class WarpLoad
 {
   constexpr static bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
@@ -225,7 +222,6 @@ class WarpLoad
                 "LOGICAL_WARP_THREADS must be a power of two");
 
 private:
-
   /*****************************************************************************
    * Algorithmic variants
    ****************************************************************************/
@@ -234,7 +230,6 @@ private:
   template <WarpLoadAlgorithm _POLICY, int DUMMY>
   struct LoadInternal;
 
-
   template <int DUMMY>
   struct LoadInternal<WARP_LOAD_DIRECT, DUMMY>
   {
@@ -242,40 +237,34 @@ private:
 
     int linear_tid;
 
-    __device__ __forceinline__
-    LoadInternal(TempStorage & /*temp_storage*/,
-                 int linear_tid)
+    __device__ __forceinline__ LoadInternal(TempStorage & /*temp_storage*/, int linear_tid)
         : linear_tid(linear_tid)
     {}
 
     template <typename InputIteratorT>
-    __device__ __forceinline__ void Load(
-      InputIteratorT  block_itr,
-      InputT          (&items)[ITEMS_PER_THREAD])
+    __device__ __forceinline__ void Load(InputIteratorT block_itr,
+                                         InputT (&items)[ITEMS_PER_THREAD])
     {
       LoadDirectBlocked(linear_tid, block_itr, items);
     }
 
     template <typename InputIteratorT>
-    __device__ __forceinline__ void Load(
-      InputIteratorT  block_itr,
-      InputT          (&items)[ITEMS_PER_THREAD],
-      int             valid_items)
+    __device__ __forceinline__ void Load(InputIteratorT block_itr,
+                                         InputT (&items)[ITEMS_PER_THREAD],
+                                         int valid_items)
     {
       LoadDirectBlocked(linear_tid, block_itr, items, valid_items);
     }
 
     template <typename InputIteratorT, typename DefaultT>
-    __device__ __forceinline__ void Load(
-      InputIteratorT  block_itr,
-      InputT          (&items)[ITEMS_PER_THREAD],
-      int             valid_items,
-      DefaultT        oob_default)
+    __device__ __forceinline__ void Load(InputIteratorT block_itr,
+                                         InputT (&items)[ITEMS_PER_THREAD],
+                                         int valid_items,
+                                         DefaultT oob_default)
     {
       LoadDirectBlocked(linear_tid, block_itr, items, valid_items, oob_default);
     }
   };
-
 
   template <int DUMMY>
   struct LoadInternal<WARP_LOAD_STRIPED, DUMMY>
@@ -284,39 +273,30 @@ private:
 
     int linear_tid;
 
-    __device__ __forceinline__
-    LoadInternal(TempStorage & /*temp_storage*/,
-                 int linear_tid)
+    __device__ __forceinline__ LoadInternal(TempStorage & /*temp_storage*/, int linear_tid)
         : linear_tid(linear_tid)
     {}
 
     template <typename InputIteratorT>
-    __device__ __forceinline__ void Load(
-      InputIteratorT  block_itr,
-      InputT          (&items)[ITEMS_PER_THREAD])
+    __device__ __forceinline__ void Load(InputIteratorT block_itr,
+                                         InputT (&items)[ITEMS_PER_THREAD])
     {
       LoadDirectStriped<LOGICAL_WARP_THREADS>(linear_tid, block_itr, items);
     }
 
     template <typename InputIteratorT>
-    __device__ __forceinline__ void Load(
-      InputIteratorT  block_itr,
-      InputT          (&items)[ITEMS_PER_THREAD],
-      int             valid_items)
+    __device__ __forceinline__ void Load(InputIteratorT block_itr,
+                                         InputT (&items)[ITEMS_PER_THREAD],
+                                         int valid_items)
     {
-      LoadDirectStriped<LOGICAL_WARP_THREADS>(linear_tid,
-                                              block_itr,
-                                              items,
-                                              valid_items);
+      LoadDirectStriped<LOGICAL_WARP_THREADS>(linear_tid, block_itr, items, valid_items);
     }
 
-    template <typename InputIteratorT,
-              typename DefaultT>
-    __device__ __forceinline__ void Load(
-      InputIteratorT  block_itr,
-      InputT          (&items)[ITEMS_PER_THREAD],
-      int             valid_items,
-      DefaultT        oob_default)
+    template <typename InputIteratorT, typename DefaultT>
+    __device__ __forceinline__ void Load(InputIteratorT block_itr,
+                                         InputT (&items)[ITEMS_PER_THREAD],
+                                         int valid_items,
+                                         DefaultT oob_default)
     {
       LoadDirectStriped<LOGICAL_WARP_THREADS>(linear_tid,
                                               block_itr,
@@ -326,7 +306,6 @@ private:
     }
   };
 
-
   template <int DUMMY>
   struct LoadInternal<WARP_LOAD_VECTORIZE, DUMMY>
   {
@@ -334,124 +313,103 @@ private:
 
     int linear_tid;
 
-    __device__ __forceinline__
-    LoadInternal(TempStorage &/*temp_storage*/,
-                 int linear_tid)
-      : linear_tid(linear_tid)
+    __device__ __forceinline__ LoadInternal(TempStorage & /*temp_storage*/, int linear_tid)
+        : linear_tid(linear_tid)
     {}
 
     template <typename InputIteratorT>
-    __device__ __forceinline__ void Load(
-      InputT               *block_ptr,
-      InputT               (&items)[ITEMS_PER_THREAD])
+    __device__ __forceinline__ void Load(InputT *block_ptr, InputT (&items)[ITEMS_PER_THREAD])
     {
-      InternalLoadDirectBlockedVectorized<LOAD_DEFAULT>(linear_tid,
-                                                        block_ptr,
-                                                        items);
+      InternalLoadDirectBlockedVectorized<LOAD_DEFAULT>(linear_tid, block_ptr, items);
     }
 
     template <typename InputIteratorT>
-    __device__ __forceinline__ void Load(
-      const InputT         *block_ptr,
-      InputT               (&items)[ITEMS_PER_THREAD])
+    __device__ __forceinline__ void Load(const InputT *block_ptr, InputT (&items)[ITEMS_PER_THREAD])
     {
-      InternalLoadDirectBlockedVectorized<LOAD_DEFAULT>(linear_tid,
-                                                        block_ptr,
-                                                        items);
+      InternalLoadDirectBlockedVectorized<LOAD_DEFAULT>(linear_tid, block_ptr, items);
     }
 
-    template <
-      CacheLoadModifier   MODIFIER,
-      typename            ValueType,
-      typename            OffsetT>
-    __device__ __forceinline__ void Load(
-      CacheModifiedInputIterator<MODIFIER, ValueType, OffsetT>    block_itr,
-      InputT                                                     (&items)[ITEMS_PER_THREAD])
+    template <CacheLoadModifier MODIFIER, typename ValueType, typename OffsetT>
+    __device__ __forceinline__ void
+    Load(CacheModifiedInputIterator<MODIFIER, ValueType, OffsetT> block_itr,
+         InputT (&items)[ITEMS_PER_THREAD])
     {
-      InternalLoadDirectBlockedVectorized<MODIFIER>(linear_tid,
-                                                    block_itr.ptr,
-                                                    items);
+      InternalLoadDirectBlockedVectorized<MODIFIER>(linear_tid, block_itr.ptr, items);
     }
 
     template <typename _InputIteratorT>
-    __device__ __forceinline__ void Load(
-      _InputIteratorT   block_itr,
-      InputT           (&items)[ITEMS_PER_THREAD])
+    __device__ __forceinline__ void Load(_InputIteratorT block_itr,
+                                         InputT (&items)[ITEMS_PER_THREAD])
     {
       LoadDirectBlocked(linear_tid, block_itr, items);
     }
 
     template <typename InputIteratorT>
-    __device__ __forceinline__ void Load(
-      InputIteratorT  block_itr,
-      InputT          (&items)[ITEMS_PER_THREAD],
-      int             valid_items)
+    __device__ __forceinline__ void Load(InputIteratorT block_itr,
+                                         InputT (&items)[ITEMS_PER_THREAD],
+                                         int valid_items)
     {
       LoadDirectBlocked(linear_tid, block_itr, items, valid_items);
     }
 
     template <typename InputIteratorT, typename DefaultT>
-    __device__ __forceinline__ void Load(
-      InputIteratorT  block_itr,
-      InputT          (&items)[ITEMS_PER_THREAD],
-      int             valid_items,
-      DefaultT        oob_default)
+    __device__ __forceinline__ void Load(InputIteratorT block_itr,
+                                         InputT (&items)[ITEMS_PER_THREAD],
+                                         int valid_items,
+                                         DefaultT oob_default)
     {
       LoadDirectBlocked(linear_tid, block_itr, items, valid_items, oob_default);
     }
   };
 
-
   template <int DUMMY>
   struct LoadInternal<WARP_LOAD_TRANSPOSE, DUMMY>
   {
-    using WarpExchangeT =
-      WarpExchange<InputT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS>;
+    using WarpExchangeT = WarpExchange<InputT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS>;
 
     struct _TempStorage : WarpExchangeT::TempStorage
     {};
 
-    struct TempStorage : Uninitialized<_TempStorage> {};
+    struct TempStorage : Uninitialized<_TempStorage>
+    {};
 
     _TempStorage &temp_storage;
 
     int linear_tid;
 
-    __device__ __forceinline__ LoadInternal(
-      TempStorage &temp_storage,
-      int linear_tid)
-      :
-      temp_storage(temp_storage.Alias()),
-      linear_tid(linear_tid)
+    __device__ __forceinline__ LoadInternal(TempStorage &temp_storage, int linear_tid)
+        : temp_storage(temp_storage.Alias())
+        , linear_tid(linear_tid)
     {}
 
     template <typename InputIteratorT>
-    __device__ __forceinline__ void Load(
-      InputIteratorT  block_itr,
-      InputT          (&items)[ITEMS_PER_THREAD])
+    __device__ __forceinline__ void Load(InputIteratorT block_itr,
+                                         InputT (&items)[ITEMS_PER_THREAD])
     {
       LoadDirectStriped<LOGICAL_WARP_THREADS>(linear_tid, block_itr, items);
       WarpExchangeT(temp_storage).StripedToBlocked(items, items);
     }
 
     template <typename InputIteratorT>
-    __device__ __forceinline__ void Load(
-      InputIteratorT  block_itr,
-      InputT          (&items)[ITEMS_PER_THREAD],
-      int             valid_items)
+    __device__ __forceinline__ void Load(InputIteratorT block_itr,
+                                         InputT (&items)[ITEMS_PER_THREAD],
+                                         int valid_items)
     {
       LoadDirectStriped<LOGICAL_WARP_THREADS>(linear_tid, block_itr, items, valid_items);
       WarpExchangeT(temp_storage).StripedToBlocked(items, items);
     }
 
     template <typename InputIteratorT, typename DefaultT>
-    __device__ __forceinline__ void Load(
-      InputIteratorT  block_itr,
-      InputT          (&items)[ITEMS_PER_THREAD],
-      int             valid_items,
-      DefaultT        oob_default)
+    __device__ __forceinline__ void Load(InputIteratorT block_itr,
+                                         InputT (&items)[ITEMS_PER_THREAD],
+                                         int valid_items,
+                                         DefaultT oob_default)
     {
-      LoadDirectStriped<LOGICAL_WARP_THREADS>(linear_tid, block_itr, items, valid_items, oob_default);
+      LoadDirectStriped<LOGICAL_WARP_THREADS>(linear_tid,
+                                              block_itr,
+                                              items,
+                                              valid_items,
+                                              oob_default);
       WarpExchangeT(temp_storage).StripedToBlocked(items, items);
     }
   };
@@ -466,18 +424,16 @@ private:
   /// Shared memory storage layout type
   using _TempStorage = typename InternalLoad::TempStorage;
 
-
   /*****************************************************************************
    * Utility methods
    ****************************************************************************/
 
   /// Internal storage allocator
-  __device__ __forceinline__ _TempStorage& PrivateStorage()
+  __device__ __forceinline__ _TempStorage &PrivateStorage()
   {
     __shared__ _TempStorage private_storage;
     return private_storage;
   }
-
 
   /*****************************************************************************
    * Thread fields
@@ -490,25 +446,23 @@ private:
   int linear_tid;
 
 public:
-
   /// @smemstorage{WarpLoad}
-  struct TempStorage : Uninitialized<_TempStorage> {};
+  struct TempStorage : Uninitialized<_TempStorage>
+  {};
 
   //! @name Collective constructors
   //! @{
 
   //! @brief Collective constructor using a private static allocation of
   //!        shared memory as temporary storage.
-  __device__ __forceinline__
-  WarpLoad()
+  __device__ __forceinline__ WarpLoad()
       : temp_storage(PrivateStorage())
       , linear_tid(IS_ARCH_WARP ? LaneId() : (LaneId() % LOGICAL_WARP_THREADS))
   {}
 
   //! @brief Collective constructor using the specified memory allocation as
   //!        temporary storage.
-  __device__ __forceinline__
-  WarpLoad(TempStorage &temp_storage)
+  __device__ __forceinline__ WarpLoad(TempStorage &temp_storage)
       : temp_storage(temp_storage.Alias())
       , linear_tid(IS_ARCH_WARP ? LaneId() : (LaneId() % LOGICAL_WARP_THREADS))
   {}
@@ -561,8 +515,7 @@ public:
   //! @param[in] block_itr The thread block's base input iterator for loading from
   //! @param[out] items Data to load
   template <typename InputIteratorT>
-  __device__ __forceinline__ void Load(InputIteratorT block_itr,
-                                       InputT (&items)[ITEMS_PER_THREAD])
+  __device__ __forceinline__ void Load(InputIteratorT block_itr, InputT (&items)[ITEMS_PER_THREAD])
   {
     InternalLoad(temp_storage, linear_tid).Load(block_itr, items);
   }
@@ -606,7 +559,7 @@ public:
   //!
   //! Suppose the input ``d_data`` is ``0, 1, 2, 3, 4, 5, ...`` and ``valid_items`` is ``5``.
   //! The set of ``thread_data`` across the first logical warp of threads in those threads will be:
-  //! ``{ [0,1,2,3], [4,?,?,?], ..., [?,?,?,?] }`` with only the first two threads being unmasked to 
+  //! ``{ [0,1,2,3], [4,?,?,?], ..., [?,?,?,?] }`` with only the first two threads being unmasked to
   //! load portions of valid data (and other items remaining unassigned).
   //! @endrst
   //!
@@ -620,7 +573,6 @@ public:
   {
     InternalLoad(temp_storage, linear_tid).Load(block_itr, items, valid_items);
   }
-
 
   //! @rst
   //! Load a linear segment of items from memory, guarded by range.
@@ -660,9 +612,9 @@ public:
   //!                                              valid_items,
   //!                                              -1);
   //!
-  //! Suppose the input ``d_data`` is ``0, 1, 2, 3, 4, 5, ...``, ``valid_items`` is ``5``, and the 
-  //! out-of-bounds default is ``-1``. The set of ``thread_data`` across the first logical warp of 
-  //! threads in those threads will be: ``{ [0,1,2,3], [4,-1,-1,-1], ..., [-1,-1,-1,-1] }`` with 
+  //! Suppose the input ``d_data`` is ``0, 1, 2, 3, 4, 5, ...``, ``valid_items`` is ``5``, and the
+  //! out-of-bounds default is ``-1``. The set of ``thread_data`` across the first logical warp of
+  //! threads in those threads will be: ``{ [0,1,2,3], [4,-1,-1,-1], ..., [-1,-1,-1,-1] }`` with
   //! only the first two threads being unmasked to load portions of valid data (and other items
   //! are assigned ``-1``).
   //! @endrst
@@ -671,19 +623,16 @@ public:
   //! @param[out] items Data to load
   //! @param[in] valid_items Number of valid items to load
   //! @param[in] oob_default Default value to assign out-of-bound items
-  template <typename InputIteratorT,
-            typename DefaultT>
+  template <typename InputIteratorT, typename DefaultT>
   __device__ __forceinline__ void Load(InputIteratorT block_itr,
                                        InputT (&items)[ITEMS_PER_THREAD],
                                        int valid_items,
                                        DefaultT oob_default)
   {
-    InternalLoad(temp_storage, linear_tid)
-      .Load(block_itr, items, valid_items, oob_default);
+    InternalLoad(temp_storage, linear_tid).Load(block_itr, items, valid_items, oob_default);
   }
 
   //! @} end member group
 };
-
 
 CUB_NAMESPACE_END

--- a/cub/warp/warp_load.cuh
+++ b/cub/warp/warp_load.cuh
@@ -49,155 +49,169 @@ CUB_NAMESPACE_BEGIN
 //! @endrst
 enum WarpLoadAlgorithm
 {
-  /**
-   * @par Overview
-   *
-   * A [<em>blocked arrangement</em>](index.html#sec5sec3) of data is read
-   * directly from memory.
-   *
-   * @par Performance Considerations
-   * The utilization of memory transactions (coalescing) decreases as the
-   * access stride between threads increases (i.e., the number items per thread).
-   */
+  //! @rst
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //! 
+  //! A :ref:`blocked arrangement <flexible-data-arrangement>` of data is read directly from memory.
+  //! 
+  //! Performance Considerations
+  //! ++++++++++++++++++++++++++
+  //! 
+  //! The utilization of memory transactions (coalescing) decreases as the
+  //! access stride between threads increases (i.e., the number items per thread).
+  //! @endrst
   WARP_LOAD_DIRECT,
 
-  /**
-   * @par Overview
-   *
-   * A [<em>striped arrangement</em>](index.html#sec5sec3) of data is read
-   * directly from memory.
-   *
-   * @par Performance Considerations
-   * The utilization of memory transactions (coalescing) doesn't depend on
-   * the number of items per thread.
-   */
+  //! @rst
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //! 
+  //! A :ref:`striped arrangement <flexible-data-arrangement>` of data is read directly from memory.
+  //! 
+  //! Performance Considerations
+  //! ++++++++++++++++++++++++++
+  //! 
+  //! The utilization of memory transactions (coalescing) doesn't depend on
+  //! the number of items per thread.
+  //! @endrst
   WARP_LOAD_STRIPED,
 
-  /**
-   * @par Overview
-   *
-   * A [<em>blocked arrangement</em>](index.html#sec5sec3) of data is read
-   * from memory using CUDA's built-in vectorized loads as a coalescing optimization.
-   * For example, <tt>ld.global.v4.s32</tt> instructions will be generated
-   * when @p T = @p int and @p ITEMS_PER_THREAD % 4 == 0.
-   *
-   * @par Performance Considerations
-   * - The utilization of memory transactions (coalescing) remains high until the the
-   *   access stride between threads (i.e., the number items per thread) exceeds the
-   *   maximum vector load width (typically 4 items or 64B, whichever is lower).
-   * - The following conditions will prevent vectorization and loading will fall
-   *   back to cub::WARP_LOAD_DIRECT:
-   *   - @p ITEMS_PER_THREAD is odd
-   *   - The @p InputIteratorT is not a simple pointer type
-   *   - The block input offset is not quadword-aligned
-   *   - The data type @p T is not a built-in primitive or CUDA vector type
-   *     (e.g., @p short, @p int2, @p double, @p float2, etc.)
-   */
+  //! @rst
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //!  
+  //! A :ref:`blocked arrangement <flexible-data-arrangement>` of data is read from memory using 
+  //! CUDA's built-in vectorized loads as a coalescing optimization.
+  //! For example, ``ld.global.v4.s32`` instructions will be generated when ``T = int`` and 
+  //! ``ITEMS_PER_THREAD % 4 == 0``.
+  //!  
+  //! Performance Considerations
+  //! ++++++++++++++++++++++++++
+  //!
+  //! - The utilization of memory transactions (coalescing) remains high until the the
+  //!   access stride between threads (i.e., the number items per thread) exceeds the
+  //!   maximum vector load width (typically 4 items or 64B, whichever is lower).
+  //! - The following conditions will prevent vectorization and loading will fall
+  //!   back to cub::WARP_LOAD_DIRECT:
+  //!
+  //!   - ``ITEMS_PER_THREAD`` is odd
+  //!   - The ``InputIteratorT`` is not a simple pointer type
+  //!   - The block input offset is not quadword-aligned
+  //!   - The data type ``T`` is not a built-in primitive or CUDA vector type 
+  //!     (e.g., ``short``, ``int2``, ``double``, ``float2``, etc.)
+  //! @endrst
   WARP_LOAD_VECTORIZE,
 
-  /**
-   * @par Overview
-   *
-   * A [<em>striped arrangement</em>](index.html#sec5sec3) of data is read
-   * efficiently from memory and then locally transposed into a
-   * [<em>blocked arrangement</em>](index.html#sec5sec3).
-   *
-   * @par Performance Considerations
-   * - The utilization of memory transactions (coalescing) remains high
-   *   regardless of items loaded per thread.
-   * - The local reordering incurs slightly longer latencies and throughput than
-   *   the direct cub::WARP_LOAD_DIRECT and cub::WARP_LOAD_VECTORIZE
-   *   alternatives.
-   */
+  //! @rst
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //!  
+  //! A :ref:`striped arrangement <flexible-data-arrangement>` of data is read efficiently from 
+  //! memory and then locally transposed into a 
+  //! :ref:`blocked arrangement <flexible-data-arrangement>`.
+  //!
+  //! Performance Considerations
+  //! ++++++++++++++++++++++++++
+  //!
+  //! - The utilization of memory transactions (coalescing) remains high
+  //!   regardless of items loaded per thread.
+  //! - The local reordering incurs slightly longer latencies and throughput than the direct 
+  //!   ``cub::WARP_LOAD_DIRECT`` and ``cub::WARP_LOAD_VECTORIZE`` alternatives.
+  //! @endrst
   WARP_LOAD_TRANSPOSE
 };
 
-/**
- * @brief The WarpLoad class provides [<em>collective</em>](index.html#sec0)
- *        data movement methods for loading a linear segment of items from
- *        memory into a [<em>blocked arrangement</em>](index.html#sec5sec3)
- *        across a CUDA thread block.
- * @ingroup WarpModule
- * @ingroup UtilIo
- *
- * @tparam InputT
- *   The data type to read into (which must be convertible from the input
- *   iterator's value type).
- *
- * @tparam ITEMS_PER_THREAD
- *   The number of consecutive items partitioned onto each thread.
- *
- * @tparam ALGORITHM
- *   <b>[optional]</b> cub::WarpLoadAlgorithm tuning policy.
- *   default: cub::WARP_LOAD_DIRECT.
- *
- * @tparam LOGICAL_WARP_THREADS
- *   <b>[optional]</b> The number of threads per "logical" warp (may be less
- *   than the number of hardware warp threads). Default is the warp size of the
- *   targeted CUDA compute-capability (e.g., 32 threads for SM86). Must be a
- *   power of two.
- *
- * @tparam LEGACY_PTX_ARCH
- *   Unused.
- *
- * @par Overview
- * - The WarpLoad class provides a single data movement abstraction that can be
- *   specialized to implement different cub::WarpLoadAlgorithm strategies. This
- *   facilitates different performance policies for different architectures, data
- *   types, granularity sizes, etc.
- * - WarpLoad can be optionally specialized by different data movement strategies:
- *   -# <b>cub::WARP_LOAD_DIRECT</b>. A [<em>blocked arrangement</em>](index.html#sec5sec3)
- *      of data is read directly from memory. [More...](@ref cub::WarpLoadAlgorithm)
-*    -# <b>cub::WARP_LOAD_STRIPED,</b>. A [<em>striped arrangement</em>](index.html#sec5sec3)
- *      of data is read directly from memory.  [More...](@ref cub::WarpLoadAlgorithm)
- *   -# <b>cub::WARP_LOAD_VECTORIZE</b>. A [<em>blocked arrangement</em>](index.html#sec5sec3)
- *      of data is read directly from memory using CUDA's built-in vectorized
- *      loads as a coalescing optimization. [More...](@ref cub::WarpLoadAlgorithm)
- *   -# <b>cub::WARP_LOAD_TRANSPOSE</b>. A [<em>striped arrangement</em>](index.html#sec5sec3)
- *      of data is read directly from memory and is then locally transposed into a
- *      [<em>blocked arrangement</em>](index.html#sec5sec3). [More...](@ref cub::WarpLoadAlgorithm)
- *
- * @par A Simple Example
- * @par
- * The code snippet below illustrates the loading of a linear segment of 64
- * integers into a "blocked" arrangement across 16 threads where each thread
- * owns 4 consecutive items. The load is specialized for @p WARP_LOAD_TRANSPOSE,
- * meaning memory references are efficiently coalesced using a warp-striped access
- * pattern (after which items are locally reordered among threads).
- * @par
- * @code
- * #include <cub/cub.cuh>   // or equivalently <cub/warp/warp_load.cuh>
- *
- * __global__ void ExampleKernel(int *d_data, ...)
- * {
- *     constexpr int warp_threads = 16;
- *     constexpr int block_threads = 256;
- *     constexpr int items_per_thread = 4;
- *
- *     // Specialize WarpLoad for a warp of 16 threads owning 4 integer items each
- *     using WarpLoadT = WarpLoad<int,
- *                                items_per_thread,
- *                                cub::WARP_LOAD_TRANSPOSE,
- *                                warp_threads>;
- *
- *     constexpr int warps_in_block = block_threads / warp_threads;
- *     constexpr int tile_size = items_per_thread * warp_threads;
- *     const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
- *
- *     // Allocate shared memory for WarpLoad
- *     __shared__ typename WarpLoadT::TempStorage temp_storage[warps_in_block];
- *
- *     // Load a segment of consecutive items that are blocked across threads
- *     int thread_data[items_per_thread];
- *     WarpLoadT(temp_storage[warp_id]).Load(d_data + warp_id * tile_size,
- *                                           thread_data);
- * @endcode
- * @par
- * Suppose the input @p d_data is <tt>0, 1, 2, 3, 4, 5, ...</tt>.
- * The set of @p thread_data across the first logical warp of threads in those
- * threads will be:
- * <tt>{ [0,1,2,3], [4,5,6,7], ..., [60,61,62,63] }</tt>.
- */
+
+//! @rst
+//! The WarpLoad class provides :ref:`collective <collective-primitives>` data movement methods for 
+//! loading a linear segment of items from memory into a 
+//! :ref:`blocked arrangement <flexible-data-arrangement>` across a CUDA thread warp.
+//! 
+//! Overview
+//! ++++++++++++++++
+//!
+//! - The WarpLoad class provides a single data movement abstraction that can be
+//!   specialized to implement different cub::WarpLoadAlgorithm strategies. This
+//!   facilitates different performance policies for different architectures, data
+//!   types, granularity sizes, etc.
+//! - WarpLoad can be optionally specialized by different data movement strategies:
+//!
+//!   #. :cpp:enumerator:`cub::WARP_LOAD_DIRECT`:
+//!      a :ref:`blocked arrangement <flexible-data-arrangement>` of data is read directly from 
+//!      memory.
+//!   #. :cpp:enumerator:`cub::WARP_LOAD_STRIPED`:
+//!      a :ref:`striped arrangement <flexible-data-arrangement>` of data is read directly from 
+//!      memory.
+//!   #. :cpp:enumerator:`cub::WARP_LOAD_VECTORIZE`: 
+//!      a :ref:`blocked arrangement <flexible-data-arrangement>` of data is read directly from 
+//!      memory using CUDA's built-in vectorized loads as a coalescing optimization. 
+//!   #. :cpp:enumerator:`cub::WARP_LOAD_TRANSPOSE`: 
+//!      a :ref:`striped arrangement <flexible-data-arrangement>` of data is read directly from 
+//!      memory and is then locally transposed into a 
+//!      :ref:`blocked arrangement <flexible-data-arrangement>`.
+//! 
+//! A Simple Example
+//! ++++++++++++++++
+//!
+//! The code snippet below illustrates the loading of a linear segment of 64
+//! integers into a "blocked" arrangement across 16 threads where each thread
+//! owns 4 consecutive items. The load is specialized for ``WARP_LOAD_TRANSPOSE``,
+//! meaning memory references are efficiently coalesced using a warp-striped access
+//! pattern (after which items are locally reordered among threads).
+//!
+//! .. code-block:: c++
+//!
+//!    #include <cub/cub.cuh>   // or equivalently <cub/warp/warp_load.cuh>
+//! 
+//!    __global__ void ExampleKernel(int *d_data, ...)
+//!    {
+//!        constexpr int warp_threads = 16;
+//!        constexpr int block_threads = 256;
+//!        constexpr int items_per_thread = 4;
+//! 
+//!        // Specialize WarpLoad for a warp of 16 threads owning 4 integer items each
+//!        using WarpLoadT = WarpLoad<int,
+//!                                   items_per_thread,
+//!                                   cub::WARP_LOAD_TRANSPOSE,
+//!                                   warp_threads>;
+//! 
+//!        constexpr int warps_in_block = block_threads / warp_threads;
+//!        constexpr int tile_size = items_per_thread * warp_threads;
+//!        const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
+//! 
+//!        // Allocate shared memory for WarpLoad
+//!        __shared__ typename WarpLoadT::TempStorage temp_storage[warps_in_block];
+//! 
+//!        // Load a segment of consecutive items that are blocked across threads
+//!        int thread_data[items_per_thread];
+//!        WarpLoadT(temp_storage[warp_id]).Load(d_data + warp_id * tile_size,
+//!                                           thread_data);
+//!
+//! Suppose the input ``d_data`` is ``0, 1, 2, 3, 4, 5, ...``.
+//! The set of ``thread_data`` across the first logical warp of threads in those
+//! threads will be: ``{ [0,1,2,3], [4,5,6,7], ..., [60,61,62,63] }``.
+//! @endrst
+//! 
+//! @tparam InputT
+//!   The data type to read into (which must be convertible from the input
+//!   iterator's value type).
+//! 
+//! @tparam ITEMS_PER_THREAD
+//!   The number of consecutive items partitioned onto each thread.
+//! 
+//! @tparam ALGORITHM
+//!   <b>[optional]</b> cub::WarpLoadAlgorithm tuning policy.
+//!   default: cub::WARP_LOAD_DIRECT.
+//! 
+//! @tparam LOGICAL_WARP_THREADS
+//!   <b>[optional]</b> The number of threads per "logical" warp (may be less
+//!   than the number of hardware warp threads). Default is the warp size of the
+//!   targeted CUDA compute-capability (e.g., 32 threads for SM86). Must be a
+//!   power of two.
+//! 
+//! @tparam LEGACY_PTX_ARCH
+//!   Unused.
 template <typename          InputT,
           int               ITEMS_PER_THREAD,
           WarpLoadAlgorithm ALGORITHM            = WARP_LOAD_DIRECT,
@@ -480,80 +494,72 @@ public:
   /// @smemstorage{WarpLoad}
   struct TempStorage : Uninitialized<_TempStorage> {};
 
-  /*************************************************************************//**
-   * @name Collective constructors
-   ****************************************************************************/
-  //@{
+  //! @name Collective constructors
+  //! @{
 
-  /**
-   * @brief Collective constructor using a private static allocation of
-   *        shared memory as temporary storage.
-   */
+  //! @brief Collective constructor using a private static allocation of
+  //!        shared memory as temporary storage.
   __device__ __forceinline__
   WarpLoad()
       : temp_storage(PrivateStorage())
       , linear_tid(IS_ARCH_WARP ? LaneId() : (LaneId() % LOGICAL_WARP_THREADS))
   {}
 
-  /**
-   * @brief Collective constructor using the specified memory allocation as
-   *        temporary storage.
-   */
+  //! @brief Collective constructor using the specified memory allocation as
+  //!        temporary storage.
   __device__ __forceinline__
   WarpLoad(TempStorage &temp_storage)
       : temp_storage(temp_storage.Alias())
       , linear_tid(IS_ARCH_WARP ? LaneId() : (LaneId() % LOGICAL_WARP_THREADS))
   {}
 
-  //@}  end member group
-  /*************************************************************************//**
-   * @name Data movement
-   ****************************************************************************/
-  //@{
+  //! @} end member group
+  //! @name Data movement
+  //! @{
 
-  /**
-   * @brief Load a linear segment of items from memory.
-   *
-   * @par
-   * @smemwarpreuse
-   *
-   * @par Snippet
-   * @code
-   * #include <cub/cub.cuh>   // or equivalently <cub/warp/warp_load.cuh>
-   *
-   * __global__ void ExampleKernel(int *d_data, ...)
-   * {
-   *     constexpr int warp_threads = 16;
-   *     constexpr int block_threads = 256;
-   *     constexpr int items_per_thread = 4;
-   *
-   *     // Specialize WarpLoad for a warp of 16 threads owning 4 integer items each
-   *     using WarpLoadT = WarpLoad<int,
-   *                                items_per_thread,
-   *                                cub::WARP_LOAD_TRANSPOSE,
-   *                                warp_threads>;
-   *
-   *     constexpr int warps_in_block = block_threads / warp_threads;
-   *     constexpr int tile_size = items_per_thread * warp_threads;
-   *     const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
-   *
-   *     // Allocate shared memory for WarpLoad
-   *     __shared__ typename WarpLoadT::TempStorage temp_storage[warps_in_block];
-   *
-   *     // Load a segment of consecutive items that are blocked across threads
-   *     int thread_data[items_per_thread];
-   *     WarpLoadT(temp_storage[warp_id]).Load(d_data + warp_id * tile_size,
-   *                                           thread_data);
-   * @endcode
-   * @par
-   * Suppose the input @p d_data is <tt>0, 1, 2, 3, 4, 5, ...</tt>.
-   * The set of @p thread_data across the first logical warp of threads in those
-   * threads will be:
-   * <tt>{ [0,1,2,3], [4,5,6,7], ..., [60,61,62,63] }</tt>.
-   *
-   * @param[in] block_itr The thread block's base input iterator for loading from
-   * @param[out] items Data to load
-   */
+  //! @rst
+  //! Load a linear segment of items from memory.
+  //!
+  //! @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>   // or equivalently <cub/warp/warp_load.cuh>
+  //!
+  //!    __global__ void ExampleKernel(int *d_data, ...)
+  //!    {
+  //!        constexpr int warp_threads = 16;
+  //!        constexpr int block_threads = 256;
+  //!        constexpr int items_per_thread = 4;
+  //!
+  //!        // Specialize WarpLoad for a warp of 16 threads owning 4 integer items each
+  //!        using WarpLoadT = WarpLoad<int,
+  //!                                   items_per_thread,
+  //!                                   cub::WARP_LOAD_TRANSPOSE,
+  //!                                   warp_threads>;
+  //!
+  //!        constexpr int warps_in_block = block_threads / warp_threads;
+  //!        constexpr int tile_size = items_per_thread * warp_threads;
+  //!        const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
+  //!
+  //!        // Allocate shared memory for WarpLoad
+  //!        __shared__ typename WarpLoadT::TempStorage temp_storage[warps_in_block];
+  //!
+  //!        // Load a segment of consecutive items that are blocked across threads
+  //!        int thread_data[items_per_thread];
+  //!        WarpLoadT(temp_storage[warp_id]).Load(d_data + warp_id * tile_size,
+  //!                                              thread_data);
+  //!
+  //! Suppose the input ``d_data`` is ``0, 1, 2, 3, 4, 5, ...``,
+  //! The set of ``thread_data`` across the first logical warp of threads in those
+  //! threads will be: ``{ [0,1,2,3], [4,5,6,7], ..., [60,61,62,63] }``.
+  //! @endrst
+  //!
+  //! @param[in] block_itr The thread block's base input iterator for loading from
+  //! @param[out] items Data to load
   template <typename InputIteratorT>
   __device__ __forceinline__ void Load(InputIteratorT block_itr,
                                        InputT (&items)[ITEMS_PER_THREAD])
@@ -561,54 +567,52 @@ public:
     InternalLoad(temp_storage, linear_tid).Load(block_itr, items);
   }
 
-  /**
-   * @brief Load a linear segment of items from memory, guarded by range.
-   *
-   * @par
-   * @smemwarpreuse
-   *
-   * @par Snippet
-   * @code
-   * #include <cub/cub.cuh>   // or equivalently <cub/warp/warp_load.cuh>
-   *
-   * __global__ void ExampleKernel(int *d_data, int valid_items, ...)
-   * {
-   *     constexpr int warp_threads = 16;
-   *     constexpr int block_threads = 256;
-   *     constexpr int items_per_thread = 4;
-   *
-   *     // Specialize WarpLoad for a warp of 16 threads owning 4 integer items each
-   *     using WarpLoadT = WarpLoad<int,
-   *                                items_per_thread,
-   *                                cub::WARP_LOAD_TRANSPOSE,
-   *                                warp_threads>;
-   *
-   *     constexpr int warps_in_block = block_threads / warp_threads;
-   *     constexpr int tile_size = items_per_thread * warp_threads;
-   *     const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
-   *
-   *     // Allocate shared memory for WarpLoad
-   *     __shared__ typename WarpLoadT::TempStorage temp_storage[warps_in_block];
-   *
-   *     // Load a segment of consecutive items that are blocked across threads
-   *     int thread_data[items_per_thread];
-   *     WarpLoadT(temp_storage[warp_id]).Load(d_data + warp_id * tile_size,
-   *                                           thread_data,
-   *                                           valid_items);
-   * @endcod
-   * @par
-   * Suppose the input @p d_data is <tt>0, 1, 2, 3, 4, 5, ...</tt> and @p valid_items
-   * is @p 5.
-   * The set of @p thread_data across the first logical warp of threads in those
-   * threads will be:
-   * <tt>{ [0,1,2,3], [4,?,?,?], ..., [?,?,?,?] }</tt> with only the first
-   * two threads being unmasked to load portions of valid data (and other items
-   * remaining unassigned).
-   *
-   * @param[in] block_itr The thread block's base input iterator for loading from
-   * @param[out] items Data to load
-   * @param[in] valid_items Number of valid items to load
-   */
+  //! @rst
+  //! Load a linear segment of items from memory, guarded by range.
+  //!
+  //! @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>   // or equivalently <cub/warp/warp_load.cuh>
+  //!
+  //!    __global__ void ExampleKernel(int *d_data, int valid_items, ...)
+  //!    {
+  //!        constexpr int warp_threads = 16;
+  //!        constexpr int block_threads = 256;
+  //!        constexpr int items_per_thread = 4;
+  //!
+  //!        // Specialize WarpLoad for a warp of 16 threads owning 4 integer items each
+  //!        using WarpLoadT = WarpLoad<int,
+  //!                                   items_per_thread,
+  //!                                   cub::WARP_LOAD_TRANSPOSE,
+  //!                                   warp_threads>;
+  //!
+  //!        constexpr int warps_in_block = block_threads / warp_threads;
+  //!        constexpr int tile_size = items_per_thread * warp_threads;
+  //!        const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
+  //!
+  //!        // Allocate shared memory for WarpLoad
+  //!        __shared__ typename WarpLoadT::TempStorage temp_storage[warps_in_block];
+  //!
+  //!        // Load a segment of consecutive items that are blocked across threads
+  //!        int thread_data[items_per_thread];
+  //!        WarpLoadT(temp_storage[warp_id]).Load(d_data + warp_id * tile_size,
+  //!                                              thread_data,
+  //!                                              valid_items);
+  //!
+  //! Suppose the input ``d_data`` is ``0, 1, 2, 3, 4, 5, ...`` and ``valid_items`` is ``5``.
+  //! The set of ``thread_data`` across the first logical warp of threads in those threads will be:
+  //! ``{ [0,1,2,3], [4,?,?,?], ..., [?,?,?,?] }`` with only the first two threads being unmasked to 
+  //! load portions of valid data (and other items remaining unassigned).
+  //! @endrst
+  //!
+  //! @param[in] block_itr The thread block's base input iterator for loading from
+  //! @param[out] items Data to load
+  //! @param[in] valid_items Number of valid items to load
   template <typename InputIteratorT>
   __device__ __forceinline__ void Load(InputIteratorT block_itr,
                                        InputT (&items)[ITEMS_PER_THREAD],
@@ -618,56 +622,55 @@ public:
   }
 
 
-  /**
-   * @brief Load a linear segment of items from memory, guarded by range.
-   *
-   * @par
-   * @smemwarpreuse
-   *
-   * @par Snippet
-   * @code
-   * #include <cub/cub.cuh>   // or equivalently <cub/warp/warp_load.cuh>
-   *
-   * __global__ void ExampleKernel(int *d_data, int valid_items, ...)
-   * {
-   *     constexpr int warp_threads = 16;
-   *     constexpr int block_threads = 256;
-   *     constexpr int items_per_thread = 4;
-   *
-   *     // Specialize WarpLoad for a warp of 16 threads owning 4 integer items each
-   *     using WarpLoadT = WarpLoad<int,
-   *                                items_per_thread,
-   *                                cub::WARP_LOAD_TRANSPOSE,
-   *                                warp_threads>;
-   *
-   *     constexpr int warps_in_block = block_threads / warp_threads;
-   *     constexpr int tile_size = items_per_thread * warp_threads;
-   *     const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
-   *
-   *     // Allocate shared memory for WarpLoad
-   *     __shared__ typename WarpLoadT::TempStorage temp_storage[warps_in_block];
-   *
-   *     // Load a segment of consecutive items that are blocked across threads
-   *     int thread_data[items_per_thread];
-   *     WarpLoadT(temp_storage[warp_id]).Load(d_data + warp_id * tile_size,
-   *                                           thread_data,
-   *                                           valid_items,
-   *                                           -1);
-   * @endcode
-   * @par
-   * Suppose the input @p d_data is <tt>0, 1, 2, 3, 4, 5, ...</tt>, @p valid_items
-   * is @p 5, and the out-of-bounds default is @p -1.
-   * The set of @p thread_data across the first logical warp of threads in those
-   * threads will be:
-   * <tt>{ [0,1,2,3], [4,-1,-1,-1], ..., [-1,-1,-1,-1] }</tt> with only the first
-   * two threads being unmasked to load portions of valid data (and other items
-   * are assigned @p -1).
-   *
-   * @param[in] block_itr The thread block's base input iterator for loading from
-   * @param[out] items Data to load
-   * @param[in] valid_items Number of valid items to load
-   * @param[in] oob_default Default value to assign out-of-bound items
-   */
+  //! @rst
+  //! Load a linear segment of items from memory, guarded by range.
+  //!
+  //! @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>   // or equivalently <cub/warp/warp_load.cuh>
+  //!
+  //!    __global__ void ExampleKernel(int *d_data, int valid_items, ...)
+  //!    {
+  //!        constexpr int warp_threads = 16;
+  //!        constexpr int block_threads = 256;
+  //!        constexpr int items_per_thread = 4;
+  //!
+  //!        // Specialize WarpLoad for a warp of 16 threads owning 4 integer items each
+  //!        using WarpLoadT = WarpLoad<int,
+  //!                                   items_per_thread,
+  //!                                   cub::WARP_LOAD_TRANSPOSE,
+  //!                                   warp_threads>;
+  //!
+  //!        constexpr int warps_in_block = block_threads / warp_threads;
+  //!        constexpr int tile_size = items_per_thread * warp_threads;
+  //!        const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
+  //!
+  //!        // Allocate shared memory for WarpLoad
+  //!        __shared__ typename WarpLoadT::TempStorage temp_storage[warps_in_block];
+  //!
+  //!        // Load a segment of consecutive items that are blocked across threads
+  //!        int thread_data[items_per_thread];
+  //!        WarpLoadT(temp_storage[warp_id]).Load(d_data + warp_id * tile_size,
+  //!                                              thread_data,
+  //!                                              valid_items,
+  //!                                              -1);
+  //!
+  //! Suppose the input ``d_data`` is ``0, 1, 2, 3, 4, 5, ...``, ``valid_items`` is ``5``, and the 
+  //! out-of-bounds default is ``-1``. The set of ``thread_data`` across the first logical warp of 
+  //! threads in those threads will be: ``{ [0,1,2,3], [4,-1,-1,-1], ..., [-1,-1,-1,-1] }`` with 
+  //! only the first two threads being unmasked to load portions of valid data (and other items
+  //! are assigned ``-1``).
+  //! @endrst
+  //!
+  //! @param[in] block_itr The thread block's base input iterator for loading from
+  //! @param[out] items Data to load
+  //! @param[in] valid_items Number of valid items to load
+  //! @param[in] oob_default Default value to assign out-of-bound items
   template <typename InputIteratorT,
             typename DefaultT>
   __device__ __forceinline__ void Load(InputIteratorT block_itr,
@@ -679,7 +682,7 @@ public:
       .Load(block_itr, items, valid_items, oob_default);
   }
 
-  //@}  end member group
+  //! @} end member group
 };
 
 

--- a/cub/warp/warp_merge_sort.cuh
+++ b/cub/warp/warp_merge_sort.cuh
@@ -32,9 +32,7 @@
 #include <cub/util_ptx.cuh>
 #include <cub/util_type.cuh>
 
-
 CUB_NAMESPACE_BEGIN
-
 
 //! @rst
 //! The WarpMergeSort class provides methods for sorting items partitioned across a CUDA warp
@@ -46,7 +44,7 @@ CUB_NAMESPACE_BEGIN
 //!   WarpMergeSort arranges items into ascending order using a comparison
 //!   functor with less-than semantics. Merge sort can handle arbitrary types
 //!   and comparison functors.
-//! 
+//!
 //! A Simple Example
 //! ++++++++++++++++
 //!
@@ -56,7 +54,7 @@ CUB_NAMESPACE_BEGIN
 //! .. code-block:: c++
 //!
 //!    #include <cub/cub.cuh>  // or equivalently <cub/warp/warp_merge_sort.cuh>
-//! 
+//!
 //!    struct CustomLess
 //!    {
 //!      template <typename DataType>
@@ -65,7 +63,7 @@ CUB_NAMESPACE_BEGIN
 //!        return lhs < rhs;
 //!      }
 //!    };
-//! 
+//!
 //!    __global__ void ExampleKernel(...)
 //!    {
 //!        constexpr int warp_threads = 16;
@@ -73,19 +71,19 @@ CUB_NAMESPACE_BEGIN
 //!        constexpr int items_per_thread = 4;
 //!        constexpr int warps_per_block = block_threads / warp_threads;
 //!        const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
-//! 
+//!
 //!        // Specialize WarpMergeSort for a virtual warp of 16 threads
 //!        // owning 4 integer items each
 //!        using WarpMergeSortT =
 //!          cub::WarpMergeSort<int, items_per_thread, warp_threads>;
-//! 
+//!
 //!        // Allocate shared memory for WarpMergeSort
 //!        __shared__ typename WarpMergeSortT::TempStorage temp_storage[warps_per_block];
-//! 
+//!
 //!        // Obtain a segment of consecutive items that are blocked across threads
 //!        int thread_keys[items_per_thread];
 //!        // ...
-//! 
+//!
 //!        WarpMergeSortT(temp_storage[warp_id]).Sort(thread_keys, CustomLess());
 //!        // ...
 //!    }
@@ -95,32 +93,31 @@ CUB_NAMESPACE_BEGIN
 //! The corresponding output ``thread_keys`` in those threads will be
 //! ``{ [0,1,2,3], [4,5,6,7], [8,9,10,11], ..., [31,32,33,34] }``.
 //! @endrst
-//! 
+//!
 //! @tparam KeyT
 //!   Key type
-//! 
+//!
 //! @tparam ITEMS_PER_THREAD
 //!   The number of items per thread
-//! 
+//!
 //! @tparam LOGICAL_WARP_THREADS
 //!   <b>[optional]</b> The number of threads per "logical" warp (may be less
 //!   than the number of hardware warp threads). Default is the warp size of the
 //!   targeted CUDA compute-capability (e.g., 32 threads for SM86). Must be a
 //!   power of two.
-//! 
+//!
 //! @tparam ValueT
 //!   <b>[optional]</b> Value type (default: cub::NullType, which indicates a
 //!   keys-only sort)
-//! 
+//!
 //! @tparam LEGACY_PTX_ARCH
 //!   Unused.
-//! 
-template <
-  typename    KeyT,
-  int         ITEMS_PER_THREAD,
-  int         LOGICAL_WARP_THREADS    = CUB_WARP_THREADS(0),
-  typename    ValueT                  = NullType,
-  int         LEGACY_PTX_ARCH         = 0>
+//!
+template <typename KeyT,
+          int ITEMS_PER_THREAD,
+          int LOGICAL_WARP_THREADS = CUB_WARP_THREADS(0),
+          typename ValueT          = NullType,
+          int LEGACY_PTX_ARCH      = 0>
 class WarpMergeSort
     : public BlockMergeSortStrategy<
         KeyT,
@@ -131,14 +128,11 @@ class WarpMergeSort
 {
 private:
   constexpr static bool IS_ARCH_WARP = LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0);
-  constexpr static bool KEYS_ONLY = std::is_same<ValueT, NullType>::value;
-  constexpr static int TILE_SIZE = ITEMS_PER_THREAD * LOGICAL_WARP_THREADS;
+  constexpr static bool KEYS_ONLY    = std::is_same<ValueT, NullType>::value;
+  constexpr static int TILE_SIZE     = ITEMS_PER_THREAD * LOGICAL_WARP_THREADS;
 
-  using BlockMergeSortStrategyT = BlockMergeSortStrategy<KeyT,
-                                                         ValueT,
-                                                         LOGICAL_WARP_THREADS,
-                                                         ITEMS_PER_THREAD,
-                                                         WarpMergeSort>;
+  using BlockMergeSortStrategyT =
+    BlockMergeSortStrategy<KeyT, ValueT, LOGICAL_WARP_THREADS, ITEMS_PER_THREAD, WarpMergeSort>;
 
   const unsigned int warp_id;
   const unsigned int member_mask;
@@ -149,27 +143,17 @@ public:
   __device__ __forceinline__
   WarpMergeSort(typename BlockMergeSortStrategyT::TempStorage &temp_storage)
       : BlockMergeSortStrategyT(temp_storage,
-                                IS_ARCH_WARP
-                                  ? LaneId()
-                                  : (LaneId() % LOGICAL_WARP_THREADS))
+                                IS_ARCH_WARP ? LaneId() : (LaneId() % LOGICAL_WARP_THREADS))
       , warp_id(IS_ARCH_WARP ? 0 : (LaneId() / LOGICAL_WARP_THREADS))
       , member_mask(WarpMask<LOGICAL_WARP_THREADS>(warp_id))
-  {
-  }
+  {}
 
-  __device__ __forceinline__ unsigned int get_member_mask() const
-  {
-    return member_mask;
-  }
+  __device__ __forceinline__ unsigned int get_member_mask() const { return member_mask; }
 
 private:
-  __device__ __forceinline__ void SyncImplementation() const
-  {
-    WARP_SYNC(member_mask);
-  }
+  __device__ __forceinline__ void SyncImplementation() const { WARP_SYNC(member_mask); }
 
   friend BlockMergeSortStrategyT;
 };
-
 
 CUB_NAMESPACE_END

--- a/cub/warp/warp_merge_sort.cuh
+++ b/cub/warp/warp_merge_sort.cuh
@@ -36,82 +36,85 @@
 CUB_NAMESPACE_BEGIN
 
 
-/**
- * @brief The WarpMergeSort class provides methods for sorting items partitioned
- *        across a CUDA warp using a merge sorting method.
- * @ingroup WarpModule
- *
- * @tparam KeyT
- *   Key type
- *
- * @tparam ITEMS_PER_THREAD
- *   The number of items per thread
- *
- * @tparam LOGICAL_WARP_THREADS
- *   <b>[optional]</b> The number of threads per "logical" warp (may be less
- *   than the number of hardware warp threads). Default is the warp size of the
- *   targeted CUDA compute-capability (e.g., 32 threads for SM86). Must be a
- *   power of two.
- *
- * @tparam ValueT
- *   <b>[optional]</b> Value type (default: cub::NullType, which indicates a
- *   keys-only sort)
- *
- * @tparam LEGACY_PTX_ARCH
- *   Unused.
- *
- * @par Overview
- *   WarpMergeSort arranges items into ascending order using a comparison
- *   functor with less-than semantics. Merge sort can handle arbitrary types
- *   and comparison functors.
- *
- * @par A Simple Example
- * @par
- * The code snippet below illustrates a sort of 64 integer keys that are
- * partitioned across 16 threads where each thread owns 4 consecutive items.
- * @par
- * @code
- * #include <cub/cub.cuh>  // or equivalently <cub/warp/warp_merge_sort.cuh>
- *
- * struct CustomLess
- * {
- *   template <typename DataType>
- *   __device__ bool operator()(const DataType &lhs, const DataType &rhs)
- *   {
- *     return lhs < rhs;
- *   }
- * };
- *
- * __global__ void ExampleKernel(...)
- * {
- *     constexpr int warp_threads = 16;
- *     constexpr int block_threads = 256;
- *     constexpr int items_per_thread = 4;
- *     constexpr int warps_per_block = block_threads / warp_threads;
- *     const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
- *
- *     // Specialize WarpMergeSort for a virtual warp of 16 threads
- *     // owning 4 integer items each
- *     using WarpMergeSortT =
- *       cub::WarpMergeSort<int, items_per_thread, warp_threads>;
- *
- *     // Allocate shared memory for WarpMergeSort
- *     __shared__ typename WarpMergeSortT::TempStorage temp_storage[warps_per_block];
- *
- *     // Obtain a segment of consecutive items that are blocked across threads
- *     int thread_keys[items_per_thread];
- *     // ...
- *
- *     WarpMergeSortT(temp_storage[warp_id]).Sort(thread_keys, CustomLess());
- *     // ...
- * }
- * @endcode
- * @par
- * Suppose the set of input @p thread_keys across a warp of threads is
- * `{ [0,64,1,63], [2,62,3,61], [4,60,5,59], ..., [31,34,32,33] }`.
- * The corresponding output @p thread_keys in those threads will be
- * `{ [0,1,2,3], [4,5,6,7], [8,9,10,11], ..., [31,32,33,34] }`.
- */
+//! @rst
+//! The WarpMergeSort class provides methods for sorting items partitioned across a CUDA warp
+//! using a merge sorting method.
+//!
+//! Overview
+//! ++++++++++++++++
+//!
+//!   WarpMergeSort arranges items into ascending order using a comparison
+//!   functor with less-than semantics. Merge sort can handle arbitrary types
+//!   and comparison functors.
+//! 
+//! A Simple Example
+//! ++++++++++++++++
+//!
+//! The code snippet below illustrates a sort of 64 integer keys that are
+//! partitioned across 16 threads where each thread owns 4 consecutive items.
+//!
+//! .. code-block:: c++
+//!
+//!    #include <cub/cub.cuh>  // or equivalently <cub/warp/warp_merge_sort.cuh>
+//! 
+//!    struct CustomLess
+//!    {
+//!      template <typename DataType>
+//!      __device__ bool operator()(const DataType &lhs, const DataType &rhs)
+//!      {
+//!        return lhs < rhs;
+//!      }
+//!    };
+//! 
+//!    __global__ void ExampleKernel(...)
+//!    {
+//!        constexpr int warp_threads = 16;
+//!        constexpr int block_threads = 256;
+//!        constexpr int items_per_thread = 4;
+//!        constexpr int warps_per_block = block_threads / warp_threads;
+//!        const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
+//! 
+//!        // Specialize WarpMergeSort for a virtual warp of 16 threads
+//!        // owning 4 integer items each
+//!        using WarpMergeSortT =
+//!          cub::WarpMergeSort<int, items_per_thread, warp_threads>;
+//! 
+//!        // Allocate shared memory for WarpMergeSort
+//!        __shared__ typename WarpMergeSortT::TempStorage temp_storage[warps_per_block];
+//! 
+//!        // Obtain a segment of consecutive items that are blocked across threads
+//!        int thread_keys[items_per_thread];
+//!        // ...
+//! 
+//!        WarpMergeSortT(temp_storage[warp_id]).Sort(thread_keys, CustomLess());
+//!        // ...
+//!    }
+//!
+//! Suppose the set of input ``thread_keys`` across a warp of threads is
+//! ``{ [0,64,1,63], [2,62,3,61], [4,60,5,59], ..., [31,34,32,33] }``.
+//! The corresponding output ``thread_keys`` in those threads will be
+//! ``{ [0,1,2,3], [4,5,6,7], [8,9,10,11], ..., [31,32,33,34] }``.
+//! @endrst
+//! 
+//! @tparam KeyT
+//!   Key type
+//! 
+//! @tparam ITEMS_PER_THREAD
+//!   The number of items per thread
+//! 
+//! @tparam LOGICAL_WARP_THREADS
+//!   <b>[optional]</b> The number of threads per "logical" warp (may be less
+//!   than the number of hardware warp threads). Default is the warp size of the
+//!   targeted CUDA compute-capability (e.g., 32 threads for SM86). Must be a
+//!   power of two.
+//! 
+//! @tparam ValueT
+//!   <b>[optional]</b> Value type (default: cub::NullType, which indicates a
+//!   keys-only sort)
+//! 
+//! @tparam LEGACY_PTX_ARCH
+//!   Unused.
+//! 
 template <
   typename    KeyT,
   int         ITEMS_PER_THREAD,

--- a/cub/warp/warp_reduce.cuh
+++ b/cub/warp/warp_reduce.cuh
@@ -214,7 +214,7 @@ public:
     /**
      * \brief Computes a warp-wide sum in the calling warp.  The output is valid in warp <em>lane</em><sub>0</sub>.
      *
-     * \smemreuse
+     * @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates four concurrent warp sum reductions within a block of
@@ -256,7 +256,7 @@ public:
      *
      * All threads across the calling warp must agree on the same value for \p valid_items.  Otherwise the result is undefined.
      *
-     * \smemreuse
+     * @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates a sum reduction within a single, partially-full
@@ -301,7 +301,7 @@ public:
     /**
      * \brief Computes a segmented sum in the calling warp where segments are defined by head-flags.  The sum of each segment is returned to the first lane in that segment (which always includes <em>lane</em><sub>0</sub>).
      *
-     * \smemreuse
+     * @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates a head-segmented warp sum
@@ -349,7 +349,7 @@ public:
     /**
      * \brief Computes a segmented sum in the calling warp where segments are defined by tail-flags.  The sum of each segment is returned to the first lane in that segment (which always includes <em>lane</em><sub>0</sub>).
      *
-     * \smemreuse
+     * @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates a tail-segmented warp sum
@@ -405,7 +405,7 @@ public:
      *
      * Supports non-commutative reduction operators
      *
-     * \smemreuse
+     * @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates four concurrent warp max reductions within a block of
@@ -453,7 +453,7 @@ public:
      *
      * Supports non-commutative reduction operators
      *
-     * \smemreuse
+     * @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates a max reduction within a single, partially-full
@@ -502,7 +502,7 @@ public:
      *
      * Supports non-commutative reduction operators
      *
-     * \smemreuse
+     * @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates a head-segmented warp max
@@ -553,7 +553,7 @@ public:
      *
      * Supports non-commutative reduction operators
      *
-     * \smemreuse
+     * @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates a tail-segmented warp max

--- a/cub/warp/warp_reduce.cuh
+++ b/cub/warp/warp_reduce.cuh
@@ -26,109 +26,120 @@
  *
  ******************************************************************************/
 
-/**
- * \file
- * The cub::WarpReduce class provides [<em>collective</em>](index.html#sec0) methods for computing a parallel reduction of items partitioned across a CUDA thread warp.
- */
+//! @file 
+//! @rst
+//! The ``cub::WarpReduce`` class provides :ref:`collective <collective-primitives>` methods for 
+//! computing a parallel reduction of items partitioned across a CUDA thread warp.
+//! @endrst
 
 #pragma once
 
-#include "../config.cuh"
-#include "specializations/warp_reduce_shfl.cuh"
-#include "specializations/warp_reduce_smem.cuh"
-#include "../thread/thread_operators.cuh"
-#include "../util_type.cuh"
+#include <cub/config.cuh>
+#include <cub/thread/thread_operators.cuh>
+#include <cub/util_type.cuh>
+#include <cub/warp/specializations/warp_reduce_shfl.cuh>
+#include <cub/warp/specializations/warp_reduce_smem.cuh>
 
 CUB_NAMESPACE_BEGIN
 
-
-/**
- * \addtogroup WarpModule
- * @{
- */
-
-/**
- * \brief The WarpReduce class provides [<em>collective</em>](index.html#sec0) methods for computing a parallel reduction of items partitioned across a CUDA thread warp. ![](warp_reduce_logo.png)
- *
- * \tparam T                        The reduction input/output element type
- * \tparam LOGICAL_WARP_THREADS     <b>[optional]</b> The number of threads per "logical" warp (may be less than the number of hardware warp threads).  Default is the warp size of the targeted CUDA compute-capability (e.g., 32 threads for SM20).
- * \tparam LEGACY_PTX_ARCH          <b>[optional]</b> Unused.
- *
- * \par Overview
- * - A <a href="http://en.wikipedia.org/wiki/Reduce_(higher-order_function)"><em>reduction</em></a> (or <em>fold</em>)
- *   uses a binary combining operator to compute a single aggregate from a list of input elements.
- * - Supports "logical" warps smaller than the physical warp size (e.g., logical warps of 8 threads)
- * - The number of entrant threads must be an multiple of \p LOGICAL_WARP_THREADS
- *
- * \par Performance Considerations
- * - Uses special instructions when applicable (e.g., warp \p SHFL instructions)
- * - Uses synchronization-free communication between warp lanes when applicable
- * - Incurs zero bank conflicts for most types
- * - Computation is slightly more efficient (i.e., having lower instruction overhead) for:
- *     - Summation (<b><em>vs.</em></b> generic reduction)
- *     - The architecture's warp size is a whole multiple of \p LOGICAL_WARP_THREADS
- *
- * \par Simple Examples
- * \warpcollective{WarpReduce}
- * \par
- * The code snippet below illustrates four concurrent warp sum reductions within a block of
- * 128 threads (one per each of the 32-thread warps).
- * \par
- * \code
- * #include <cub/cub.cuh>
- *
- * __global__ void ExampleKernel(...)
- * {
- *     // Specialize WarpReduce for type int
- *     typedef cub::WarpReduce<int> WarpReduce;
- *
- *     // Allocate WarpReduce shared memory for 4 warps
- *     __shared__ typename WarpReduce::TempStorage temp_storage[4];
- *
- *     // Obtain one input item per thread
- *     int thread_data = ...
- *
- *     // Return the warp-wide sums to each lane0 (threads 0, 32, 64, and 96)
- *     int warp_id = threadIdx.x / 32;
- *     int aggregate = WarpReduce(temp_storage[warp_id]).Sum(thread_data);
- *
- * \endcode
- * \par
- * Suppose the set of input \p thread_data across the block of threads is <tt>{0, 1, 2, 3, ..., 127}</tt>.
- * The corresponding output \p aggregate in threads 0, 32, 64, and 96 will \p 496, \p 1520,
- * \p 2544, and \p 3568, respectively (and is undefined in other threads).
- *
- * \par
- * The code snippet below illustrates a single warp sum reduction within a block of
- * 128 threads.
- * \par
- * \code
- * #include <cub/cub.cuh>
- *
- * __global__ void ExampleKernel(...)
- * {
- *     // Specialize WarpReduce for type int
- *     typedef cub::WarpReduce<int> WarpReduce;
- *
- *     // Allocate WarpReduce shared memory for one warp
- *     __shared__ typename WarpReduce::TempStorage temp_storage;
- *     ...
- *
- *     // Only the first warp performs a reduction
- *     if (threadIdx.x < 32)
- *     {
- *         // Obtain one input item per thread
- *         int thread_data = ...
- *
- *         // Return the warp-wide sum to lane0
- *         int aggregate = WarpReduce(temp_storage).Sum(thread_data);
- *
- * \endcode
- * \par
- * Suppose the set of input \p thread_data across the warp of threads is <tt>{0, 1, 2, 3, ..., 31}</tt>.
- * The corresponding output \p aggregate in thread0 will be \p 496 (and is undefined in other threads).
- *
- */
+//! @rst
+//! The ``WarpReduce`` class provides :ref:`collective <collective-primitives>` methods for 
+//! computing a parallel reduction of items partitioned across a CUDA thread warp. 
+//!
+//! .. image:: ../img/warp_reduce_logo.png
+//!     :align: center
+//! 
+//! Overview
+//! ++++++++++++++++++++++++++
+//!
+//! - A `reduction <http://en.wikipedia.org/wiki/Reduce_(higher-order_function)>`__ (or *fold*)
+//!   uses a binary combining operator to compute a single aggregate from a list of input elements.
+//! - Supports "logical" warps smaller than the physical warp size (e.g., logical warps of 8 threads)
+//! - The number of entrant threads must be an multiple of ``LOGICAL_WARP_THREADS``
+//! 
+//! Performance Considerations
+//! ++++++++++++++++++++++++++
+//!
+//! - Uses special instructions when applicable (e.g., warp ``SHFL`` instructions)
+//! - Uses synchronization-free communication between warp lanes when applicable
+//! - Incurs zero bank conflicts for most types
+//! - Computation is slightly more efficient (i.e., having lower instruction overhead) for:
+//!
+//!   - Summation (**vs.** generic reduction)
+//!   - The architecture's warp size is a whole multiple of ``LOGICAL_WARP_THREADS``
+//! 
+//! Simple Examples
+//! ++++++++++++++++++++++++++
+//!
+//! @warpcollective{WarpReduce}
+//!
+//! The code snippet below illustrates four concurrent warp sum reductions within a block of
+//! 128 threads (one per each of the 32-thread warps).
+//!
+//! .. code-block:: c++
+//!
+//!    #include <cub/cub.cuh>
+//! 
+//!    __global__ void ExampleKernel(...)
+//!    {
+//!        // Specialize WarpReduce for type int
+//!        typedef cub::WarpReduce<int> WarpReduce;
+//! 
+//!        // Allocate WarpReduce shared memory for 4 warps
+//!        __shared__ typename WarpReduce::TempStorage temp_storage[4];
+//! 
+//!        // Obtain one input item per thread
+//!        int thread_data = ...
+//! 
+//!        // Return the warp-wide sums to each lane0 (threads 0, 32, 64, and 96)
+//!        int warp_id = threadIdx.x / 32;
+//!        int aggregate = WarpReduce(temp_storage[warp_id]).Sum(thread_data);
+//! 
+//! Suppose the set of input ``thread_data`` across the block of threads is 
+//! ``{0, 1, 2, 3, ..., 127}``. The corresponding output ``aggregate`` in threads 0, 32, 64, and 96 
+//! will be ``496``, ``1520``, ``2544``, and ``3568``, respectively 
+//! (and is undefined in other threads).
+//! 
+//! The code snippet below illustrates a single warp sum reduction within a block of
+//! 128 threads.
+//!
+//! .. code-block:: c++
+//!
+//!    #include <cub/cub.cuh>
+//! 
+//!    __global__ void ExampleKernel(...)
+//!    {
+//!        // Specialize WarpReduce for type int
+//!        typedef cub::WarpReduce<int> WarpReduce;
+//! 
+//!        // Allocate WarpReduce shared memory for one warp
+//!        __shared__ typename WarpReduce::TempStorage temp_storage;
+//!        ...
+//! 
+//!        // Only the first warp performs a reduction
+//!        if (threadIdx.x < 32)
+//!        {
+//!            // Obtain one input item per thread
+//!            int thread_data = ...
+//! 
+//!            // Return the warp-wide sum to lane0
+//!            int aggregate = WarpReduce(temp_storage).Sum(thread_data);
+//! 
+//! Suppose the set of input ``thread_data`` across the warp of threads is 
+//! ``{0, 1, 2, 3, ..., 31}``. The corresponding output ``aggregate`` in thread0 will be ``496`` 
+//! (and is undefined in other threads).
+//! @endrst
+//!
+//! @tparam T                        
+//!   The reduction input/output element type
+//!
+//! @tparam LOGICAL_WARP_THREADS     
+//!   <b>[optional]</b> The number of threads per "logical" warp (may be less than the number of 
+//!   hardware warp threads).  Default is the warp size of the targeted CUDA compute-capability 
+//!   (e.g., 32 threads for SM20).
+//!
+//! @tparam LEGACY_PTX_ARCH          
+//!   <b>[optional]</b> Unused.
 template <
     typename    T,
     int         LOGICAL_WARP_THREADS    = CUB_PTX_WARP_THREADS,
@@ -188,421 +199,480 @@ public:
     struct TempStorage : Uninitialized<_TempStorage> {};
 
 
-    /******************************************************************//**
-     * \name Collective constructors
-     *********************************************************************/
-    //@{
+    //! @name Collective constructors
+    //! @{
 
 
-    /**
-     * \brief Collective constructor using the specified memory allocation as temporary storage.  Logical warp and lane identifiers are constructed from <tt>threadIdx.x</tt>.
-     */
-    __device__ __forceinline__ WarpReduce(
-        TempStorage &temp_storage)             ///< [in] Reference to memory allocation having layout type TempStorage
-    :
-        temp_storage(temp_storage.Alias())
+    //! @rst
+    //! Collective constructor using the specified memory allocation as temporary storage.  
+    //! Logical warp and lane identifiers are constructed from ``threadIdx.x``.
+    //! @endrst
+    //!
+    //! @param[in] temp_storage Reference to memory allocation having layout type TempStorage
+    __device__ __forceinline__ WarpReduce(TempStorage &temp_storage)
+        : temp_storage(temp_storage.Alias())
     {}
 
+    //! @}  end member group
+    //! @name Summation reductions
+    //! @{
 
-    //@}  end member group
-    /******************************************************************//**
-     * \name Summation reductions
-     *********************************************************************/
-    //@{
-
-
-    /**
-     * \brief Computes a warp-wide sum in the calling warp.  The output is valid in warp <em>lane</em><sub>0</sub>.
-     *
-     * @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates four concurrent warp sum reductions within a block of
-     * 128 threads (one per each of the 32-thread warps).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpReduce for type int
-     *     typedef cub::WarpReduce<int> WarpReduce;
-     *
-     *     // Allocate WarpReduce shared memory for 4 warps
-     *     __shared__ typename WarpReduce::TempStorage temp_storage[4];
-     *
-     *     // Obtain one input item per thread
-     *     int thread_data = ...
-     *
-     *     // Return the warp-wide sums to each lane0
-     *     int warp_id = threadIdx.x / 32;
-     *     int aggregate = WarpReduce(temp_storage[warp_id]).Sum(thread_data);
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data across the block of threads is <tt>{0, 1, 2, 3, ..., 127}</tt>.
-     * The corresponding output \p aggregate in threads 0, 32, 64, and 96 will \p 496, \p 1520,
-     * \p 2544, and \p 3568, respectively (and is undefined in other threads).
-     *
-     */
-    __device__ __forceinline__ T Sum(
-        T                   input)              ///< [in] Calling thread's input
+    //! @rst
+    //! Computes a warp-wide sum in the calling warp. 
+    //! The output is valid in warp *lane*\ :sub:`0`.
+    //!
+    //! @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates four concurrent warp sum reductions within a block of
+    //! 128 threads (one per each of the 32-thread warps).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpReduce for type int
+    //!        typedef cub::WarpReduce<int> WarpReduce;
+    //!
+    //!        // Allocate WarpReduce shared memory for 4 warps
+    //!        __shared__ typename WarpReduce::TempStorage temp_storage[4];
+    //!
+    //!        // Obtain one input item per thread
+    //!        int thread_data = ...
+    //!
+    //!        // Return the warp-wide sums to each lane0
+    //!        int warp_id = threadIdx.x / 32;
+    //!        int aggregate = WarpReduce(temp_storage[warp_id]).Sum(thread_data);
+    //!
+    //! Suppose the set of input ``thread_data`` across the block of threads is 
+    //! ``{0, 1, 2, 3, ..., 127}``.
+    //! The corresponding output ``aggregate`` in threads 0, 32, 64, and 96 will ``496``, ``1520``,
+    //! ``2544``, and ``3568``, respectively (and is undefined in other threads).
+    //! @endrst
+    //!
+    //! @param[in] input Calling thread's input
+    __device__ __forceinline__ T Sum(T input)
     {
-        return InternalWarpReduce(temp_storage).template Reduce<true>(input, LOGICAL_WARP_THREADS, cub::Sum());
+      return InternalWarpReduce(temp_storage)
+        .template Reduce<true>(input, LOGICAL_WARP_THREADS, cub::Sum());
     }
 
-    /**
-     * \brief Computes a partially-full warp-wide sum in the calling warp.  The output is valid in warp <em>lane</em><sub>0</sub>.
-     *
-     * All threads across the calling warp must agree on the same value for \p valid_items.  Otherwise the result is undefined.
-     *
-     * @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates a sum reduction within a single, partially-full
-     * block of 32 threads (one warp).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(int *d_data, int valid_items)
-     * {
-     *     // Specialize WarpReduce for type int
-     *     typedef cub::WarpReduce<int> WarpReduce;
-     *
-     *     // Allocate WarpReduce shared memory for one warp
-     *     __shared__ typename WarpReduce::TempStorage temp_storage;
-     *
-     *     // Obtain one input item per thread if in range
-     *     int thread_data;
-     *     if (threadIdx.x < valid_items)
-     *         thread_data = d_data[threadIdx.x];
-     *
-     *     // Return the warp-wide sums to each lane0
-     *     int aggregate = WarpReduce(temp_storage).Sum(
-     *         thread_data, valid_items);
-     *
-     * \endcode
-     * \par
-     * Suppose the input \p d_data is <tt>{0, 1, 2, 3, 4, ...</tt> and \p valid_items
-     * is \p 4.  The corresponding output \p aggregate in thread0 is \p 6 (and is
-     * undefined in other threads).
-     *
-     */
-    __device__ __forceinline__ T Sum(
-        T                   input,              ///< [in] Calling thread's input
-        int                 valid_items)        ///< [in] Total number of valid items in the calling thread's logical warp (may be less than \p LOGICAL_WARP_THREADS)
+    //! @rst
+    //! Computes a partially-full warp-wide sum in the calling warp.  
+    //! The output is valid in warp *lane*\ :sub:`0`.
+    //!
+    //! All threads across the calling warp must agree on the same value for ``valid_items``.  
+    //! Otherwise the result is undefined.
+    //!
+    //! @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates a sum reduction within a single, partially-full
+    //! block of 32 threads (one warp).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(int *d_data, int valid_items)
+    //!    {
+    //!        // Specialize WarpReduce for type int
+    //!        typedef cub::WarpReduce<int> WarpReduce;
+    //!
+    //!        // Allocate WarpReduce shared memory for one warp
+    //!        __shared__ typename WarpReduce::TempStorage temp_storage;
+    //!
+    //!        // Obtain one input item per thread if in range
+    //!        int thread_data;
+    //!        if (threadIdx.x < valid_items)
+    //!            thread_data = d_data[threadIdx.x];
+    //!
+    //!        // Return the warp-wide sums to each lane0
+    //!        int aggregate = WarpReduce(temp_storage).Sum(
+    //!            thread_data, valid_items);
+    //!
+    //! Suppose the input ``d_data`` is ``{0, 1, 2, 3, 4, ...`` and ``valid_items`` is ``4``. 
+    //! The corresponding output ``aggregate`` in *lane*\ :sub:`0` is ``6`` 
+    //! (and is undefined in other threads).
+    //! @endrst
+    //!
+    //! @param[in] input 
+    //!   Calling thread's input
+    //!
+    //! @param[in] valid_items 
+    //!   Total number of valid items in the calling thread's logical warp 
+    //!   (may be less than ``LOGICAL_WARP_THREADS``)
+    __device__ __forceinline__ T Sum(T input, int valid_items)
     {
-        // Determine if we don't need bounds checking
-        return InternalWarpReduce(temp_storage).template Reduce<false>(input, valid_items, cub::Sum());
+      // Determine if we don't need bounds checking
+      return InternalWarpReduce(temp_storage).template Reduce<false>(input, valid_items, cub::Sum());
     }
 
-
-    /**
-     * \brief Computes a segmented sum in the calling warp where segments are defined by head-flags.  The sum of each segment is returned to the first lane in that segment (which always includes <em>lane</em><sub>0</sub>).
-     *
-     * @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates a head-segmented warp sum
-     * reduction within a block of 32 threads (one warp).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpReduce for type int
-     *     typedef cub::WarpReduce<int> WarpReduce;
-     *
-     *     // Allocate WarpReduce shared memory for one warp
-     *     __shared__ typename WarpReduce::TempStorage temp_storage;
-     *
-     *     // Obtain one input item and flag per thread
-     *     int thread_data = ...
-     *     int head_flag = ...
-     *
-     *     // Return the warp-wide sums to each lane0
-     *     int aggregate = WarpReduce(temp_storage).HeadSegmentedSum(
-     *         thread_data, head_flag);
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data and \p head_flag across the block of threads
-     * is <tt>{0, 1, 2, 3, ..., 31</tt> and is <tt>{1, 0, 0, 0, 1, 0, 0, 0, ..., 1, 0, 0, 0</tt>,
-     * respectively.  The corresponding output \p aggregate in threads 0, 4, 8, etc. will be
-     * \p 6, \p 22, \p 38, etc. (and is undefined in other threads).
-     *
-     * \tparam ReductionOp     <b>[inferred]</b> Binary reduction operator type having member <tt>T operator()(const T &a, const T &b)</tt>
-     *
-     */
-    template <
-        typename            FlagT>
-    __device__ __forceinline__ T HeadSegmentedSum(
-        T                   input,              ///< [in] Calling thread's input
-        FlagT                head_flag)          ///< [in] Head flag denoting whether or not \p input is the start of a new segment
+    //! @rst
+    //! Computes a segmented sum in the calling warp where segments are defined by head-flags.  
+    //! The sum of each segment is returned to the first lane in that segment 
+    //! (which always includes *lane*\ :sub:`0`).
+    //!
+    //! @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates a head-segmented warp sum
+    //! reduction within a block of 32 threads (one warp).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpReduce for type int
+    //!        typedef cub::WarpReduce<int> WarpReduce;
+    //!
+    //!        // Allocate WarpReduce shared memory for one warp
+    //!        __shared__ typename WarpReduce::TempStorage temp_storage;
+    //!
+    //!        // Obtain one input item and flag per thread
+    //!        int thread_data = ...
+    //!        int head_flag = ...
+    //!
+    //!        // Return the warp-wide sums to each lane0
+    //!        int aggregate = WarpReduce(temp_storage).HeadSegmentedSum(
+    //!            thread_data, head_flag);
+    //!
+    //! Suppose the set of input ``thread_data`` and ``head_flag`` across the block of threads
+    //! is ``{0, 1, 2, 3, ..., 31`` and is ``{1, 0, 0, 0, 1, 0, 0, 0, ..., 1, 0, 0, 0``,
+    //! respectively. The corresponding output ``aggregate`` in threads 0, 4, 8, etc. will be
+    //! ``6``, ``22``, ``38``, etc. (and is undefined in other threads).
+    //! @endrst
+    //!
+    //! @tparam ReductionOp     
+    //!   **[inferred]** Binary reduction operator type having member 
+    //!   `T operator()(const T &a, const T &b)`
+    //! 
+    //! @param[in] input 
+    //!   Calling thread's input
+    //!
+    //! @param[in] head_flag
+    //!   Head flag denoting whether or not `input` is the start of a new segment
+    template <typename FlagT>
+    __device__ __forceinline__ T HeadSegmentedSum(T input, FlagT head_flag)
     {
-        return HeadSegmentedReduce(input, head_flag, cub::Sum());
+      return HeadSegmentedReduce(input, head_flag, cub::Sum());
     }
 
-
-    /**
-     * \brief Computes a segmented sum in the calling warp where segments are defined by tail-flags.  The sum of each segment is returned to the first lane in that segment (which always includes <em>lane</em><sub>0</sub>).
-     *
-     * @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates a tail-segmented warp sum
-     * reduction within a block of 32 threads (one warp).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpReduce for type int
-     *     typedef cub::WarpReduce<int> WarpReduce;
-     *
-     *     // Allocate WarpReduce shared memory for one warp
-     *     __shared__ typename WarpReduce::TempStorage temp_storage;
-     *
-     *     // Obtain one input item and flag per thread
-     *     int thread_data = ...
-     *     int tail_flag = ...
-     *
-     *     // Return the warp-wide sums to each lane0
-     *     int aggregate = WarpReduce(temp_storage).TailSegmentedSum(
-     *         thread_data, tail_flag);
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data and \p tail_flag across the block of threads
-     * is <tt>{0, 1, 2, 3, ..., 31</tt> and is <tt>{0, 0, 0, 1, 0, 0, 0, 1, ..., 0, 0, 0, 1</tt>,
-     * respectively.  The corresponding output \p aggregate in threads 0, 4, 8, etc. will be
-     * \p 6, \p 22, \p 38, etc. (and is undefined in other threads).
-     *
-     * \tparam ReductionOp     <b>[inferred]</b> Binary reduction operator type having member <tt>T operator()(const T &a, const T &b)</tt>
-     */
-    template <
-        typename            FlagT>
-    __device__ __forceinline__ T TailSegmentedSum(
-        T                   input,              ///< [in] Calling thread's input
-        FlagT                tail_flag)          ///< [in] Head flag denoting whether or not \p input is the start of a new segment
+    //! @rst
+    //! Computes a segmented sum in the calling warp where segments are defined by tail-flags.  
+    //! The sum of each segment is returned to the first lane in that segment 
+    //! (which always includes *lane*\ :sub:`0`).
+    //!
+    //! @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates a tail-segmented warp sum reduction within a block of 32 
+    //! threads (one warp).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpReduce for type int
+    //!        typedef cub::WarpReduce<int> WarpReduce;
+    //!
+    //!        // Allocate WarpReduce shared memory for one warp
+    //!        __shared__ typename WarpReduce::TempStorage temp_storage;
+    //!
+    //!        // Obtain one input item and flag per thread
+    //!        int thread_data = ...
+    //!        int tail_flag = ...
+    //!
+    //!        // Return the warp-wide sums to each lane0
+    //!        int aggregate = WarpReduce(temp_storage).TailSegmentedSum(
+    //!            thread_data, tail_flag);
+    //!
+    //! Suppose the set of input ``thread_data`` and ``tail_flag`` across the block of threads
+    //! is ``{0, 1, 2, 3, ..., 31}`` and is ``{0, 0, 0, 1, 0, 0, 0, 1, ..., 0, 0, 0, 1}``,
+    //! respectively. The corresponding output ``aggregate`` in threads 0, 4, 8, etc. will be
+    //! ``6``, ``22``, ``38``, etc. (and is undefined in other threads).
+    //! @endrst
+    //!
+    //! @tparam ReductionOp     
+    //!   **[inferred]** Binary reduction operator type having member 
+    //!   `T operator()(const T &a, const T &b)`
+    //!
+    //! @param[in] input
+    //!   Calling thread's input
+    //! 
+    //! @param[in] tail_flag
+    //!   Head flag denoting whether or not \p input is the start of a new segment
+    template <typename FlagT>
+    __device__ __forceinline__ T TailSegmentedSum(T input, FlagT tail_flag)
     {
-        return TailSegmentedReduce(input, tail_flag, cub::Sum());
+      return TailSegmentedReduce(input, tail_flag, cub::Sum());
     }
 
+    //! @}  end member group
+    //! @name Generic reductions
+    //! @{
 
-
-    //@}  end member group
-    /******************************************************************//**
-     * \name Generic reductions
-     *********************************************************************/
-    //@{
-
-    /**
-     * \brief Computes a warp-wide reduction in the calling warp using the specified binary reduction functor.  The output is valid in warp <em>lane</em><sub>0</sub>.
-     *
-     * Supports non-commutative reduction operators
-     *
-     * @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates four concurrent warp max reductions within a block of
-     * 128 threads (one per each of the 32-thread warps).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpReduce for type int
-     *     typedef cub::WarpReduce<int> WarpReduce;
-     *
-     *     // Allocate WarpReduce shared memory for 4 warps
-     *     __shared__ typename WarpReduce::TempStorage temp_storage[4];
-     *
-     *     // Obtain one input item per thread
-     *     int thread_data = ...
-     *
-     *     // Return the warp-wide reductions to each lane0
-     *     int warp_id = threadIdx.x / 32;
-     *     int aggregate = WarpReduce(temp_storage[warp_id]).Reduce(
-     *         thread_data, cub::Max());
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data across the block of threads is <tt>{0, 1, 2, 3, ..., 127}</tt>.
-     * The corresponding output \p aggregate in threads 0, 32, 64, and 96 will \p 31, \p 63,
-     * \p 95, and \p 127, respectively  (and is undefined in other threads).
-     *
-     * \tparam ReductionOp     <b>[inferred]</b> Binary reduction operator type having member <tt>T operator()(const T &a, const T &b)</tt>
-     */
+    //! @rst
+    //! Computes a warp-wide reduction in the calling warp using the specified binary reduction 
+    //! functor. The output is valid in warp *lane*\ :sub:`0`.
+    //!
+    //! Supports non-commutative reduction operators
+    //!
+    //! @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates four concurrent warp max reductions within a block of
+    //! 128 threads (one per each of the 32-thread warps).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpReduce for type int
+    //!        typedef cub::WarpReduce<int> WarpReduce;
+    //!
+    //!        // Allocate WarpReduce shared memory for 4 warps
+    //!        __shared__ typename WarpReduce::TempStorage temp_storage[4];
+    //!
+    //!        // Obtain one input item per thread
+    //!        int thread_data = ...
+    //!
+    //!        // Return the warp-wide reductions to each lane0
+    //!        int warp_id = threadIdx.x / 32;
+    //!        int aggregate = WarpReduce(temp_storage[warp_id]).Reduce(
+    //!            thread_data, cub::Max());
+    //!
+    //! Suppose the set of input ``thread_data`` across the block of threads is 
+    //! ``{0, 1, 2, 3, ..., 127}``. The corresponding output ``aggregate`` in threads 0, 32, 64, and 
+    //! 96 will be ``31``, ``63``, ``95``, and ``127``, respectively  
+    //! (and is undefined in other threads).
+    //! @endrst
+    //!
+    //! @tparam ReductionOp     
+    //!   **[inferred]** Binary reduction operator type having member 
+    //!   `T operator()(const T &a, const T &b)`
+    //!
+    //! @param[in] input
+    //!   Calling thread's input
+    //!
+    //! @param[in] reduction_op 
+    //!   Binary reduction operator
     template <typename ReductionOp>
-    __device__ __forceinline__ T Reduce(
-        T                   input,              ///< [in] Calling thread's input
-        ReductionOp         reduction_op)       ///< [in] Binary reduction operator
+    __device__ __forceinline__ T Reduce(T input, ReductionOp reduction_op)
     {
-        return InternalWarpReduce(temp_storage).template Reduce<true>(input, LOGICAL_WARP_THREADS, reduction_op);
+      return InternalWarpReduce(temp_storage)
+        .template Reduce<true>(input, LOGICAL_WARP_THREADS, reduction_op);
     }
 
-    /**
-     * \brief Computes a partially-full warp-wide reduction in the calling warp using the specified binary reduction functor.  The output is valid in warp <em>lane</em><sub>0</sub>.
-     *
-     * All threads across the calling warp must agree on the same value for \p valid_items.  Otherwise the result is undefined.
-     *
-     * Supports non-commutative reduction operators
-     *
-     * @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates a max reduction within a single, partially-full
-     * block of 32 threads (one warp).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(int *d_data, int valid_items)
-     * {
-     *     // Specialize WarpReduce for type int
-     *     typedef cub::WarpReduce<int> WarpReduce;
-     *
-     *     // Allocate WarpReduce shared memory for one warp
-     *     __shared__ typename WarpReduce::TempStorage temp_storage;
-     *
-     *     // Obtain one input item per thread if in range
-     *     int thread_data;
-     *     if (threadIdx.x < valid_items)
-     *         thread_data = d_data[threadIdx.x];
-     *
-     *     // Return the warp-wide reductions to each lane0
-     *     int aggregate = WarpReduce(temp_storage).Reduce(
-     *         thread_data, cub::Max(), valid_items);
-     *
-     * \endcode
-     * \par
-     * Suppose the input \p d_data is <tt>{0, 1, 2, 3, 4, ...</tt> and \p valid_items
-     * is \p 4.  The corresponding output \p aggregate in thread0 is \p 3 (and is
-     * undefined in other threads).
-     *
-     * \tparam ReductionOp     <b>[inferred]</b> Binary reduction operator type having member <tt>T operator()(const T &a, const T &b)</tt>
-     */
+    //! @rst
+    //! Computes a partially-full warp-wide reduction in the calling warp using the specified binary 
+    //! reduction functor. The output is valid in warp *lane*\ :sub:`0`.
+    //!
+    //! All threads across the calling warp must agree on the same value for ``valid_items``.  
+    //! Otherwise the result is undefined.
+    //!
+    //! Supports non-commutative reduction operators
+    //!
+    //! @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates a max reduction within a single, partially-full
+    //! block of 32 threads (one warp).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(int *d_data, int valid_items)
+    //!    {
+    //!        // Specialize WarpReduce for type int
+    //!        typedef cub::WarpReduce<int> WarpReduce;
+    //!
+    //!        // Allocate WarpReduce shared memory for one warp
+    //!        __shared__ typename WarpReduce::TempStorage temp_storage;
+    //!
+    //!        // Obtain one input item per thread if in range
+    //!        int thread_data;
+    //!        if (threadIdx.x < valid_items)
+    //!            thread_data = d_data[threadIdx.x];
+    //!
+    //!        // Return the warp-wide reductions to each lane0
+    //!        int aggregate = WarpReduce(temp_storage).Reduce(
+    //!            thread_data, cub::Max(), valid_items);
+    //!
+    //! Suppose the input ``d_data`` is ``{0, 1, 2, 3, 4, ... }`` and ``valid_items``
+    //! is ``4``. The corresponding output ``aggregate`` in thread0 is ``3`` (and is
+    //! undefined in other threads).
+    //! @endrst
+    //!
+    //! @tparam ReductionOp     
+    //!   **[inferred]** Binary reduction operator type having member 
+    //!   `T operator()(const T &a, const T &b)`
+    //!
+    //! @param[in] input
+    //!   Calling thread's input
+    //! 
+    //! @param[in] reduction_op
+    //!   Binary reduction operator
+    //!
+    //! @param[in] valid_items
+    //!   Total number of valid items in the calling thread's logical warp 
+    //!   (may be less than ``LOGICAL_WARP_THREADS``)
     template <typename ReductionOp>
-    __device__ __forceinline__ T Reduce(
-        T                   input,              ///< [in] Calling thread's input
-        ReductionOp         reduction_op,       ///< [in] Binary reduction operator
-        int                 valid_items)        ///< [in] Total number of valid items in the calling thread's logical warp (may be less than \p LOGICAL_WARP_THREADS)
+    __device__ __forceinline__ T Reduce(T input, ReductionOp reduction_op, int valid_items)
     {
-        return InternalWarpReduce(temp_storage).template Reduce<false>(input, valid_items, reduction_op);
+      return InternalWarpReduce(temp_storage)
+        .template Reduce<false>(input, valid_items, reduction_op);
     }
 
-
-    /**
-     * \brief Computes a segmented reduction in the calling warp where segments are defined by head-flags.  The reduction of each segment is returned to the first lane in that segment (which always includes <em>lane</em><sub>0</sub>).
-     *
-     * Supports non-commutative reduction operators
-     *
-     * @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates a head-segmented warp max
-     * reduction within a block of 32 threads (one warp).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpReduce for type int
-     *     typedef cub::WarpReduce<int> WarpReduce;
-     *
-     *     // Allocate WarpReduce shared memory for one warp
-     *     __shared__ typename WarpReduce::TempStorage temp_storage;
-     *
-     *     // Obtain one input item and flag per thread
-     *     int thread_data = ...
-     *     int head_flag = ...
-     *
-     *     // Return the warp-wide reductions to each lane0
-     *     int aggregate = WarpReduce(temp_storage).HeadSegmentedReduce(
-     *         thread_data, head_flag, cub::Max());
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data and \p head_flag across the block of threads
-     * is <tt>{0, 1, 2, 3, ..., 31</tt> and is <tt>{1, 0, 0, 0, 1, 0, 0, 0, ..., 1, 0, 0, 0</tt>,
-     * respectively.  The corresponding output \p aggregate in threads 0, 4, 8, etc. will be
-     * \p 3, \p 7, \p 11, etc. (and is undefined in other threads).
-     *
-     * \tparam ReductionOp     <b>[inferred]</b> Binary reduction operator type having member <tt>T operator()(const T &a, const T &b)</tt>
-     */
-    template <
-        typename            ReductionOp,
-        typename            FlagT>
-    __device__ __forceinline__ T HeadSegmentedReduce(
-        T                   input,              ///< [in] Calling thread's input
-        FlagT               head_flag,          ///< [in] Head flag denoting whether or not \p input is the start of a new segment
-        ReductionOp         reduction_op)       ///< [in] Reduction operator
+    //! @rst
+    //! Computes a segmented reduction in the calling warp where segments are defined by head-flags.  
+    //! The reduction of each segment is returned to the first lane in that segment 
+    //! (which always includes *lane*\ :sub:`0`).
+    //!
+    //! Supports non-commutative reduction operators
+    //!
+    //! @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates a head-segmented warp max
+    //! reduction within a block of 32 threads (one warp).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpReduce for type int
+    //!        typedef cub::WarpReduce<int> WarpReduce;
+    //!
+    //!        // Allocate WarpReduce shared memory for one warp
+    //!        __shared__ typename WarpReduce::TempStorage temp_storage;
+    //!
+    //!        // Obtain one input item and flag per thread
+    //!        int thread_data = ...
+    //!        int head_flag = ...
+    //!
+    //!        // Return the warp-wide reductions to each lane0
+    //!        int aggregate = WarpReduce(temp_storage).HeadSegmentedReduce(
+    //!            thread_data, head_flag, cub::Max());
+    //!
+    //! Suppose the set of input ``thread_data`` and ``head_flag`` across the block of threads
+    //! is ``{0, 1, 2, 3, ..., 31}`` and is ``{1, 0, 0, 0, 1, 0, 0, 0, ..., 1, 0, 0, 0}``,
+    //! respectively. The corresponding output ``aggregate`` in threads 0, 4, 8, etc. will be
+    //! ``3``, ``7``, ``11``, etc. (and is undefined in other threads).
+    //! @endrst
+    //!
+    //! @tparam ReductionOp     
+    //!   **[inferred]** Binary reduction operator type having member 
+    //!   `T operator()(const T &a, const T &b)`
+    //!
+    //! @param[in] input
+    //!   Calling thread's input
+    //!
+    //! @param[in] head_flag
+    //!   Head flag denoting whether or not `input` is the start of a new segment
+    //!
+    //! @param[in] reduction_op
+    //!   Reduction operator
+    template <typename ReductionOp, typename FlagT>
+    __device__ __forceinline__ T HeadSegmentedReduce(T input,
+                                                     FlagT head_flag,
+                                                     ReductionOp reduction_op)
     {
-        return InternalWarpReduce(temp_storage).template SegmentedReduce<true>(input, head_flag, reduction_op);
+      return InternalWarpReduce(temp_storage)
+        .template SegmentedReduce<true>(input, head_flag, reduction_op);
     }
 
-
-    /**
-     * \brief Computes a segmented reduction in the calling warp where segments are defined by tail-flags.  The reduction of each segment is returned to the first lane in that segment (which always includes <em>lane</em><sub>0</sub>).
-     *
-     * Supports non-commutative reduction operators
-     *
-     * @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates a tail-segmented warp max
-     * reduction within a block of 32 threads (one warp).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpReduce for type int
-     *     typedef cub::WarpReduce<int> WarpReduce;
-     *
-     *     // Allocate WarpReduce shared memory for one warp
-     *     __shared__ typename WarpReduce::TempStorage temp_storage;
-     *
-     *     // Obtain one input item and flag per thread
-     *     int thread_data = ...
-     *     int tail_flag = ...
-     *
-     *     // Return the warp-wide reductions to each lane0
-     *     int aggregate = WarpReduce(temp_storage).TailSegmentedReduce(
-     *         thread_data, tail_flag, cub::Max());
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data and \p tail_flag across the block of threads
-     * is <tt>{0, 1, 2, 3, ..., 31</tt> and is <tt>{0, 0, 0, 1, 0, 0, 0, 1, ..., 0, 0, 0, 1</tt>,
-     * respectively.  The corresponding output \p aggregate in threads 0, 4, 8, etc. will be
-     * \p 3, \p 7, \p 11, etc. (and is undefined in other threads).
-     *
-     * \tparam ReductionOp     <b>[inferred]</b> Binary reduction operator type having member <tt>T operator()(const T &a, const T &b)</tt>
-     */
-    template <
-        typename            ReductionOp,
-        typename            FlagT>
-    __device__ __forceinline__ T TailSegmentedReduce(
-        T                   input,              ///< [in] Calling thread's input
-        FlagT               tail_flag,          ///< [in] Tail flag denoting whether or not \p input is the end of the current segment
-        ReductionOp         reduction_op)       ///< [in] Reduction operator
+    //! @rst
+    //! Computes a segmented reduction in the calling warp where segments are defined by tail-flags.  
+    //! The reduction of each segment is returned to the first lane in that segment 
+    //! (which always includes *lane*\ :sub:`0`).
+    //!
+    //! Supports non-commutative reduction operators
+    //!
+    //! @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates a tail-segmented warp max
+    //! reduction within a block of 32 threads (one warp).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpReduce for type int
+    //!        typedef cub::WarpReduce<int> WarpReduce;
+    //!
+    //!        // Allocate WarpReduce shared memory for one warp
+    //!        __shared__ typename WarpReduce::TempStorage temp_storage;
+    //!
+    //!        // Obtain one input item and flag per thread
+    //!        int thread_data = ...
+    //!        int tail_flag = ...
+    //!
+    //!        // Return the warp-wide reductions to each lane0
+    //!        int aggregate = WarpReduce(temp_storage).TailSegmentedReduce(
+    //!            thread_data, tail_flag, cub::Max());
+    //!
+    //! Suppose the set of input ``thread_data`` and ``tail_flag`` across the block of threads
+    //! is ``{0, 1, 2, 3, ..., 31}`` and is ``{0, 0, 0, 1, 0, 0, 0, 1, ..., 0, 0, 0, 1}``,
+    //! respectively. The corresponding output ``aggregate`` in threads 0, 4, 8, etc. will be
+    //! ``3``, ``7``, ``11``, etc. (and is undefined in other threads).
+    //! @endrst
+    //!
+    //! @tparam ReductionOp     
+    //!   **[inferred]** Binary reduction operator type having member 
+    //!   `T operator()(const T &a, const T &b)`
+    //!
+    //! @param[in] input
+    //!   Calling thread's input
+    //!
+    //! @param[in] tail_flag
+    //!   Tail flag denoting whether or not \p input is the end of the current segment
+    //!
+    //! @param[in] reduction_op
+    //!   Reduction operator
+    template <typename ReductionOp, typename FlagT>
+    __device__ __forceinline__ T TailSegmentedReduce(T input,
+                                                     FlagT tail_flag,
+                                                     ReductionOp reduction_op)
     {
-        return InternalWarpReduce(temp_storage).template SegmentedReduce<false>(input, tail_flag, reduction_op);
+      return InternalWarpReduce(temp_storage)
+        .template SegmentedReduce<false>(input, tail_flag, reduction_op);
     }
 
-
-
-    //@}  end member group
+    //! @}  end member group
 };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS // Do not document
 template <typename T, int LEGACY_PTX_ARCH>
 class WarpReduce<T, 1, LEGACY_PTX_ARCH>
 {
@@ -667,7 +737,6 @@ public:
     return input;
   }
 };
-
-/** @} */       // end group WarpModule
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 CUB_NAMESPACE_END

--- a/cub/warp/warp_scan.cuh
+++ b/cub/warp/warp_scan.cuh
@@ -218,7 +218,7 @@ public:
      * \brief Computes an inclusive prefix sum across the calling warp.
      *
      * \par
-     * - \smemreuse
+     * - @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates four concurrent warp-wide inclusive prefix sums within a block of
@@ -260,7 +260,7 @@ public:
      * \brief Computes an inclusive prefix sum across the calling warp.  Also provides every thread with the warp-wide \p warp_aggregate of all inputs.
      *
      * \par
-     * - \smemreuse
+     * - @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates four concurrent warp-wide inclusive prefix sums within a block of
@@ -312,7 +312,7 @@ public:
      *
      * \par
      *  - \identityzero
-     *  - \smemreuse
+     * - @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates four concurrent warp-wide exclusive prefix sums within a block of
@@ -357,7 +357,7 @@ public:
      *
      * \par
      *  - \identityzero
-     *  - \smemreuse
+     * - @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates four concurrent warp-wide exclusive prefix sums within a block of
@@ -408,7 +408,7 @@ public:
      * \brief Computes an inclusive prefix scan using the specified binary scan functor across the calling warp.
      *
      * \par
-     *  - \smemreuse
+     * - @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates four concurrent warp-wide inclusive prefix max scans within a block of
@@ -454,7 +454,7 @@ public:
      * \brief Computes an inclusive prefix scan using the specified binary scan functor across the calling warp.  Also provides every thread with the warp-wide \p warp_aggregate of all inputs.
      *
      * \par
-     * - \smemreuse
+     * - @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates four concurrent warp-wide inclusive prefix max scans within a block of
@@ -511,7 +511,7 @@ public:
      * \brief Computes an exclusive prefix scan using the specified binary scan functor across the calling warp.  Because no initial value is supplied, the \p output computed for <em>warp-lane</em><sub>0</sub> is undefined.
      *
      * \par
-     * - \smemreuse
+     * - @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans within a block of
@@ -568,7 +568,7 @@ public:
      * \brief Computes an exclusive prefix scan using the specified binary scan functor across the calling warp.
      *
      * \par
-     * - \smemreuse
+     * - @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans within a block of
@@ -626,7 +626,7 @@ public:
      * \brief Computes an exclusive prefix scan using the specified binary scan functor across the calling warp.  Because no initial value is supplied, the \p output computed for <em>warp-lane</em><sub>0</sub> is undefined.  Also provides every thread with the warp-wide \p warp_aggregate of all inputs.
      *
      * \par
-     * - \smemreuse
+     * - @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans within a block of
@@ -687,7 +687,7 @@ public:
      * \brief Computes an exclusive prefix scan using the specified binary scan functor across the calling warp.  Also provides every thread with the warp-wide \p warp_aggregate of all inputs.
      *
      * \par
-     * - \smemreuse
+     * - @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans within a block of
@@ -757,7 +757,7 @@ public:
      * \brief Computes both inclusive and exclusive prefix scans using the specified binary scan functor across the calling warp.  Because no initial value is supplied, the \p exclusive_output computed for <em>warp-lane</em><sub>0</sub> is undefined.
      *
      * \par
-     * - \smemreuse
+     * - @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans within a block of
@@ -816,7 +816,7 @@ public:
      * \brief Computes both inclusive and exclusive prefix scans using the specified binary scan functor across the calling warp.
      *
      * \par
-     *  - \smemreuse
+     * - @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates four concurrent warp-wide prefix max scans within a block of
@@ -884,7 +884,7 @@ public:
      * \brief Broadcast the value \p input from <em>warp-lane</em><sub><tt>src_lane</tt></sub> to all lanes in the warp
      *
      * \par
-     * - \smemreuse
+     * - @smemwarpreuse
      *
      * \par Snippet
      * The code snippet below illustrates the warp-wide broadcasts of values from

--- a/cub/warp/warp_scan.cuh
+++ b/cub/warp/warp_scan.cuh
@@ -1,7 +1,7 @@
 /******************************************************************************
  * Copyright (c) 2011, Duane Merrill.  All rights reserved.
  * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -12,7 +12,7 @@
  *     * Neither the name of the NVIDIA CORPORATION nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -27,7 +27,7 @@
  ******************************************************************************/
 
 //! @file
-//! @rst 
+//! @rst
 //! The ``cub::WarpScan`` class provides :ref:`collective <collective-primitives>` methods for
 //! computing a parallel prefix scan of items partitioned across a CUDA thread warp.
 //! @endrst
@@ -44,26 +44,26 @@ CUB_NAMESPACE_BEGIN
 
 //! @rst
 //! The WarpScan class provides :ref:`collective <collective-primitives>` methods for computing a
-//! parallel prefix scan of items partitioned across a CUDA thread warp.  
+//! parallel prefix scan of items partitioned across a CUDA thread warp.
 //!
 //! .. image:: ../img/warp_scan_logo.png
 //!     :align: center
-//! 
+//!
 //! Overview
 //! ++++++++++++++++++++++++++
 //!
 //! * Given a list of input elements and a binary reduction operator, a
 //!   `prefix scan <http://en.wikipedia.org/wiki/Prefix_sum>`__ produces an output list where each
 //!   element is computed to be the reduction of the elements occurring earlier in the input list.
-//!   *Prefix sum* connotes a prefix scan with the addition operator. The term *inclusive* 
+//!   *Prefix sum* connotes a prefix scan with the addition operator. The term *inclusive*
 //!   indicates that the *i*\ :sup:`th` output reduction incorporates the *i*\ :sup:`th` input.
 //!   The term *exclusive* indicates the *i*\ :sup:`th` input is not incorporated into
 //!   the *i*\ :sup:`th` output reduction.
 //! * Supports non-commutative scan operators
-//! * Supports "logical" warps smaller than the physical warp size 
+//! * Supports "logical" warps smaller than the physical warp size
 //!   (e.g., a logical warp of 8 threads)
 //! * The number of entrant threads must be an multiple of ``LOGICAL_WARP_THREADS``
-//! 
+//!
 //! Performance Considerations
 //! ++++++++++++++++++++++++++
 //!
@@ -74,7 +74,7 @@ CUB_NAMESPACE_BEGIN
 //!
 //!   * Summation (**vs.** generic scan)
 //!   * The architecture's warp size is a whole multiple of ``LOGICAL_WARP_THREADS``
-//! 
+//!
 //! Simple Examples
 //! ++++++++++++++++++++++++++
 //!
@@ -86,977 +86,958 @@ CUB_NAMESPACE_BEGIN
 //! .. code-block:: c++
 //!
 //!    #include <cub/cub.cuh>
-//! 
+//!
 //!    __global__ void ExampleKernel(...)
 //!    {
 //!        // Specialize WarpScan for type int
 //!        typedef cub::WarpScan<int> WarpScan;
-//! 
+//!
 //!        // Allocate WarpScan shared memory for 4 warps
 //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
-//! 
+//!
 //!        // Obtain one input item per thread
 //!        int thread_data = ...
-//! 
+//!
 //!        // Compute warp-wide prefix sums
 //!        int warp_id = threadIdx.x / 32;
 //!        WarpScan(temp_storage[warp_id]).ExclusiveSum(thread_data, thread_data);
-//! 
-//! Suppose the set of input ``thread_data`` across the block of threads is 
+//!
+//! Suppose the set of input ``thread_data`` across the block of threads is
 //! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` in each of the four warps of
 //! threads will be ``0, 1, 2, 3, ..., 31}``.
-//! 
+//!
 //! The code snippet below illustrates a single warp prefix sum within a block of
 //! 128 threads.
 //!
 //! .. code-block:: c++
 //!
 //!    #include <cub/cub.cuh>
-//! 
+//!
 //!    __global__ void ExampleKernel(...)
 //!    {
 //!        // Specialize WarpScan for type int
 //!        typedef cub::WarpScan<int> WarpScan;
-//! 
+//!
 //!        // Allocate WarpScan shared memory for one warp
 //!        __shared__ typename WarpScan::TempStorage temp_storage;
 //!        ...
-//! 
+//!
 //!        // Only the first warp performs a prefix sum
 //!        if (threadIdx.x < 32)
 //!        {
 //!            // Obtain one input item per thread
 //!            int thread_data = ...
-//! 
+//!
 //!            // Compute warp-wide prefix sums
 //!            WarpScan(temp_storage).ExclusiveSum(thread_data, thread_data);
-//! 
-//! Suppose the set of input ``thread_data`` across the warp of threads is 
-//! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` will be 
+//!
+//! Suppose the set of input ``thread_data`` across the warp of threads is
+//! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` will be
 //! ``{0, 1, 2, 3, ..., 31}``.
 //! @endrst
-//! 
+//!
 //! @tparam T
 //!   The scan input/output element type
 //!
-//! @tparam LOGICAL_WARP_THREADS     
-//!   **[optional]** The number of threads per "logical" warp (may be less than the number of 
+//! @tparam LOGICAL_WARP_THREADS
+//!   **[optional]** The number of threads per "logical" warp (may be less than the number of
 //!   hardware warp threads). Default is the warp size associated with the CUDA Compute Capability
 //!   targeted by the compiler (e.g., 32 threads for SM20).
 //!
-//! @tparam LEGACY_PTX_ARCH          
+//! @tparam LEGACY_PTX_ARCH
 //!   **[optional]** Unused.
 template <typename T, int LOGICAL_WARP_THREADS = CUB_PTX_WARP_THREADS, int LEGACY_PTX_ARCH = 0>
 class WarpScan
 {
 private:
+  /******************************************************************************
+   * Constants and type definitions
+   ******************************************************************************/
 
-    /******************************************************************************
-     * Constants and type definitions
-     ******************************************************************************/
+  enum
+  {
+    /// Whether the logical warp size and the PTX warp size coincide
+    IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0)),
 
-    enum
-    {
-        /// Whether the logical warp size and the PTX warp size coincide
-        IS_ARCH_WARP = (LOGICAL_WARP_THREADS == CUB_WARP_THREADS(0)),
+    /// Whether the logical warp size is a power-of-two
+    IS_POW_OF_TWO = ((LOGICAL_WARP_THREADS & (LOGICAL_WARP_THREADS - 1)) == 0),
 
-        /// Whether the logical warp size is a power-of-two
-        IS_POW_OF_TWO = ((LOGICAL_WARP_THREADS & (LOGICAL_WARP_THREADS - 1)) == 0),
+    /// Whether the data type is an integer (which has fully-associative addition)
+    IS_INTEGER = ((Traits<T>::CATEGORY == SIGNED_INTEGER) ||
+                  (Traits<T>::CATEGORY == UNSIGNED_INTEGER))
+  };
 
-        /// Whether the data type is an integer (which has fully-associative addition)
-        IS_INTEGER = ((Traits<T>::CATEGORY == SIGNED_INTEGER) || (Traits<T>::CATEGORY == UNSIGNED_INTEGER))
-    };
+  /// Internal specialization.
+  /// Use SHFL-based scan if LOGICAL_WARP_THREADS is a power-of-two
+  using InternalWarpScan = cub::detail::conditional_t<IS_POW_OF_TWO,
+                                                      WarpScanShfl<T, LOGICAL_WARP_THREADS>,
+                                                      WarpScanSmem<T, LOGICAL_WARP_THREADS>>;
 
-    /// Internal specialization.
-    /// Use SHFL-based scan if LOGICAL_WARP_THREADS is a power-of-two
-    using InternalWarpScan = cub::detail::conditional_t<
-      IS_POW_OF_TWO,
-      WarpScanShfl<T, LOGICAL_WARP_THREADS>,
-      WarpScanSmem<T, LOGICAL_WARP_THREADS>>;
+  /// Shared memory storage layout type for WarpScan
+  using _TempStorage = typename InternalWarpScan::TempStorage;
 
-    /// Shared memory storage layout type for WarpScan
-    using _TempStorage = typename InternalWarpScan::TempStorage;
+  /******************************************************************************
+   * Thread fields
+   ******************************************************************************/
 
+  /// Shared storage reference
+  _TempStorage &temp_storage;
+  unsigned int lane_id;
 
-    /******************************************************************************
-     * Thread fields
-     ******************************************************************************/
-
-    /// Shared storage reference
-    _TempStorage    &temp_storage;
-    unsigned int    lane_id;
-
-
-
-    /******************************************************************************
-     * Public types
-     ******************************************************************************/
+  /******************************************************************************
+   * Public types
+   ******************************************************************************/
 
 public:
+  /// @smemstorage{WarpScan}
+  struct TempStorage : Uninitialized<_TempStorage>
+  {};
 
-    /// @smemstorage{WarpScan}
-    struct TempStorage : Uninitialized<_TempStorage> {};
+  //! @name Collective constructors
+  //! @{
 
+  //! @brief Collective constructor using the specified memory allocation as temporary storage.
+  //!        Logical warp and lane identifiers are constructed from `threadIdx.x`.
+  //!
+  //! @param[in] temp_storage
+  //!   Reference to memory allocation having layout type TempStorage
+  __device__ __forceinline__ WarpScan(TempStorage &temp_storage)
+      : temp_storage(temp_storage.Alias())
+      , lane_id(IS_ARCH_WARP ? LaneId() : LaneId() % LOGICAL_WARP_THREADS)
+  {}
 
-    //! @name Collective constructors
-    //! @{
+  //! @}  end member group
+  //! @name Inclusive prefix sums
+  //! @{
 
-    //! @brief Collective constructor using the specified memory allocation as temporary storage.
-    //!        Logical warp and lane identifiers are constructed from `threadIdx.x`.
-    //!
-    //! @param[in] temp_storage
-    //!   Reference to memory allocation having layout type TempStorage
-    __device__ __forceinline__ WarpScan(TempStorage &temp_storage)
-        : temp_storage(temp_storage.Alias())
-        , lane_id(IS_ARCH_WARP ? LaneId() : LaneId() % LOGICAL_WARP_THREADS)
-    {}
+  //! @rst
+  //! Computes an inclusive prefix sum across the calling warp.
+  //!
+  //! * @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates four concurrent warp-wide inclusive prefix sums within a
+  //! block of 128 threads (one per each of the 32-thread warps).
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize WarpScan for type int
+  //!        typedef cub::WarpScan<int> WarpScan;
+  //!
+  //!        // Allocate WarpScan shared memory for 4 warps
+  //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+  //!
+  //!        // Obtain one input item per thread
+  //!        int thread_data = ...
+  //!
+  //!        // Compute inclusive warp-wide prefix sums
+  //!        int warp_id = threadIdx.x / 32;
+  //!        WarpScan(temp_storage[warp_id]).InclusiveSum(thread_data, thread_data);
+  //!
+  //! Suppose the set of input ``thread_data`` across the block of threads is
+  //! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` in each of the four warps
+  //! of threads will be ``1, 2, 3, ..., 32}``.
+  //! @endrst
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item.
+  //!
+  //! @param[out] inclusive_output
+  //!   Calling thread's output item. May be aliased with `input`.
+  __device__ __forceinline__ void InclusiveSum(T input, T &inclusive_output)
+  {
+    InclusiveScan(input, inclusive_output, cub::Sum());
+  }
 
-    //! @}  end member group
-    //! @name Inclusive prefix sums
-    //! @{
+  //! @rst
+  //! Computes an inclusive prefix sum across the calling warp.
+  //! Also provides every thread with the warp-wide ``warp_aggregate`` of all inputs.
+  //!
+  //! * @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates four concurrent warp-wide inclusive prefix sums within a
+  //! block of 128 threads (one per each of the 32-thread warps).
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize WarpScan for type int
+  //!        typedef cub::WarpScan<int> WarpScan;
+  //!
+  //!        // Allocate WarpScan shared memory for 4 warps
+  //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+  //!
+  //!        // Obtain one input item per thread
+  //!        int thread_data = ...
+  //!
+  //!        // Compute inclusive warp-wide prefix sums
+  //!        int warp_aggregate;
+  //!        int warp_id = threadIdx.x / 32;
+  //!        WarpScan(temp_storage[warp_id]).InclusiveSum(thread_data,
+  //!                                                     thread_data,
+  //!                                                     warp_aggregate);
+  //!
+  //! Suppose the set of input ``thread_data`` across the block of threads is
+  //! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` in each of the four warps
+  //! of threads will be ``1, 2, 3, ..., 32}``. Furthermore, ``warp_aggregate`` for all threads
+  //! in all warps will be ``32``.
+  //! @endrst
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item
+  //!
+  //! @param[out] inclusive_output
+  //!   Calling thread's output item. May be aliased with `input`
+  //!
+  //! @param[out] warp_aggregate
+  //!   Warp-wide aggregate reduction of input items
+  __device__ __forceinline__ void InclusiveSum(T input, T &inclusive_output, T &warp_aggregate)
+  {
+    InclusiveScan(input, inclusive_output, cub::Sum(), warp_aggregate);
+  }
 
-    //! @rst
-    //! Computes an inclusive prefix sum across the calling warp.
-    //!
-    //! * @smemwarpreuse
-    //!
-    //! Snippet
-    //! +++++++
-    //!
-    //! The code snippet below illustrates four concurrent warp-wide inclusive prefix sums within a
-    //! block of 128 threads (one per each of the 32-thread warps).
-    //!
-    //! .. code-block:: c++
-    //!
-    //!    #include <cub/cub.cuh>
-    //!
-    //!    __global__ void ExampleKernel(...)
-    //!    {
-    //!        // Specialize WarpScan for type int
-    //!        typedef cub::WarpScan<int> WarpScan;
-    //!
-    //!        // Allocate WarpScan shared memory for 4 warps
-    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
-    //!
-    //!        // Obtain one input item per thread
-    //!        int thread_data = ...
-    //!
-    //!        // Compute inclusive warp-wide prefix sums
-    //!        int warp_id = threadIdx.x / 32;
-    //!        WarpScan(temp_storage[warp_id]).InclusiveSum(thread_data, thread_data);
-    //!
-    //! Suppose the set of input ``thread_data`` across the block of threads is 
-    //! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` in each of the four warps 
-    //! of threads will be ``1, 2, 3, ..., 32}``.
-    //! @endrst
-    //!
-    //! @param[in] input
-    //!   Calling thread's input item.
-    //!
-    //! @param[out] inclusive_output
-    //!   Calling thread's output item. May be aliased with `input`.
-    __device__ __forceinline__ void InclusiveSum(T input, T &inclusive_output)
-    {
-      InclusiveScan(input, inclusive_output, cub::Sum());
-    }
+  //! @}  end member group
+  //! @name Exclusive prefix sums
+  //! @{
 
-    //! @rst
-    //! Computes an inclusive prefix sum across the calling warp.  
-    //! Also provides every thread with the warp-wide ``warp_aggregate`` of all inputs.
-    //!
-    //! * @smemwarpreuse
-    //!
-    //! Snippet
-    //! +++++++
-    //!
-    //! The code snippet below illustrates four concurrent warp-wide inclusive prefix sums within a
-    //! block of 128 threads (one per each of the 32-thread warps).
-    //!
-    //! .. code-block:: c++
-    //!
-    //!    #include <cub/cub.cuh>
-    //!
-    //!    __global__ void ExampleKernel(...)
-    //!    {
-    //!        // Specialize WarpScan for type int
-    //!        typedef cub::WarpScan<int> WarpScan;
-    //!
-    //!        // Allocate WarpScan shared memory for 4 warps
-    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
-    //!
-    //!        // Obtain one input item per thread
-    //!        int thread_data = ...
-    //!
-    //!        // Compute inclusive warp-wide prefix sums
-    //!        int warp_aggregate;
-    //!        int warp_id = threadIdx.x / 32;
-    //!        WarpScan(temp_storage[warp_id]).InclusiveSum(thread_data, 
-    //!                                                     thread_data, 
-    //!                                                     warp_aggregate);
-    //!
-    //! Suppose the set of input ``thread_data`` across the block of threads is 
-    //! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` in each of the four warps 
-    //! of threads will be ``1, 2, 3, ..., 32}``. Furthermore, ``warp_aggregate`` for all threads 
-    //! in all warps will be ``32``.
-    //! @endrst
-    //!
-    //! @param[in] input
-    //!   Calling thread's input item
-    //!
-    //! @param[out] inclusive_output
-    //!   Calling thread's output item. May be aliased with `input`
-    //!
-    //! @param[out] warp_aggregate
-    //!   Warp-wide aggregate reduction of input items
-    __device__ __forceinline__ void InclusiveSum(T input, T &inclusive_output, T &warp_aggregate)
-    {
-      InclusiveScan(input, inclusive_output, cub::Sum(), warp_aggregate);
-    }
+  //! @rst
+  //! Computes an exclusive prefix sum across the calling warp. The value of 0 is applied as the
+  //! initial value, and is assigned to ``exclusive_output`` in *lane*\ :sub:`0`.
+  //!
+  //! * @identityzero
+  //! * @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates four concurrent warp-wide exclusive prefix sums within a
+  //! block of 128 threads (one per each of the 32-thread warps).
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize WarpScan for type int
+  //!        typedef cub::WarpScan<int> WarpScan;
+  //!
+  //!        // Allocate WarpScan shared memory for 4 warps
+  //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+  //!
+  //!        // Obtain one input item per thread
+  //!        int thread_data = ...
+  //!
+  //!        // Compute exclusive warp-wide prefix sums
+  //!        int warp_id = threadIdx.x / 32;
+  //!        WarpScan(temp_storage[warp_id]).ExclusiveSum(thread_data, thread_data);
+  //!
+  //! Suppose the set of input ``thread_data`` across the block of threads is
+  //! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` in each of the four warps
+  //! of threads will be ``0, 1, 2, ..., 31}``.
+  //! @endrst
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item.
+  //!
+  //! @param[out] exclusive_output
+  //!   Calling thread's output item. May be aliased with `input`.
+  __device__ __forceinline__ void ExclusiveSum(T input, T &exclusive_output)
+  {
+    T initial_value{};
+    ExclusiveScan(input, exclusive_output, initial_value, cub::Sum());
+  }
 
-    //! @}  end member group
-    //! @name Exclusive prefix sums
-    //! @{
-    
-    //! @rst
-    //! Computes an exclusive prefix sum across the calling warp. The value of 0 is applied as the
-    //! initial value, and is assigned to ``exclusive_output`` in *lane*\ :sub:`0`.
-    //!
-    //! * @identityzero
-    //! * @smemwarpreuse
-    //!
-    //! Snippet
-    //! +++++++
-    //!
-    //! The code snippet below illustrates four concurrent warp-wide exclusive prefix sums within a
-    //! block of 128 threads (one per each of the 32-thread warps).
-    //!
-    //! .. code-block:: c++
-    //!
-    //!    #include <cub/cub.cuh>
-    //!
-    //!    __global__ void ExampleKernel(...)
-    //!    {
-    //!        // Specialize WarpScan for type int
-    //!        typedef cub::WarpScan<int> WarpScan;
-    //!
-    //!        // Allocate WarpScan shared memory for 4 warps
-    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
-    //!
-    //!        // Obtain one input item per thread
-    //!        int thread_data = ...
-    //!
-    //!        // Compute exclusive warp-wide prefix sums
-    //!        int warp_id = threadIdx.x / 32;
-    //!        WarpScan(temp_storage[warp_id]).ExclusiveSum(thread_data, thread_data);
-    //!
-    //! Suppose the set of input ``thread_data`` across the block of threads is 
-    //! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` in each of the four warps 
-    //! of threads will be ``0, 1, 2, ..., 31}``.
-    //! @endrst
-    //!
-    //! @param[in] input
-    //!   Calling thread's input item.
-    //!
-    //! @param[out] exclusive_output
-    //!   Calling thread's output item. May be aliased with `input`.
-    __device__ __forceinline__ void ExclusiveSum(T input, T &exclusive_output)
-    {
-      T initial_value{};
-      ExclusiveScan(input, exclusive_output, initial_value, cub::Sum());
-    }
+  //! @rst
+  //! Computes an exclusive prefix sum across the calling warp. The value of 0 is applied as the
+  //! initial value, and is assigned to ``exclusive_output`` in *lane*\ :sub:`0`.
+  //! Also provides every thread with the warp-wide ``warp_aggregate`` of all inputs.
+  //!
+  //! * @identityzero
+  //! * @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates four concurrent warp-wide exclusive prefix sums within a
+  //! block of 128 threads (one per each of the 32-thread warps).
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize WarpScan for type int
+  //!        typedef cub::WarpScan<int> WarpScan;
+  //!
+  //!        // Allocate WarpScan shared memory for 4 warps
+  //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+  //!
+  //!        // Obtain one input item per thread
+  //!        int thread_data = ...
+  //!
+  //!        // Compute exclusive warp-wide prefix sums
+  //!        int warp_aggregate;
+  //!        int warp_id = threadIdx.x / 32;
+  //!        WarpScan(temp_storage[warp_id]).ExclusiveSum(thread_data,
+  //!                                                     thread_data,
+  //!                                                     warp_aggregate);
+  //!
+  //! Suppose the set of input ``thread_data`` across the block of threads is
+  //! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` in each of the four warps
+  //! of threads will be ``0, 1, 2, ..., 31}``. Furthermore, ``warp_aggregate`` for all threads
+  //! in all warps will be ``32``.
+  //! @endrst
+  //!
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item
+  //!
+  //! @param[out] exclusive_output
+  //!   Calling thread's output item. May be aliased with `input`
+  //!
+  //! @param[out] warp_aggregate
+  //!   Warp-wide aggregate reduction of input items
+  __device__ __forceinline__ void ExclusiveSum(T input, T &exclusive_output, T &warp_aggregate)
+  {
+    T initial_value{};
+    ExclusiveScan(input, exclusive_output, initial_value, cub::Sum(), warp_aggregate);
+  }
 
-    //! @rst
-    //! Computes an exclusive prefix sum across the calling warp. The value of 0 is applied as the
-    //! initial value, and is assigned to ``exclusive_output`` in *lane*\ :sub:`0`.  
-    //! Also provides every thread with the warp-wide ``warp_aggregate`` of all inputs.
-    //!
-    //! * @identityzero
-    //! * @smemwarpreuse
-    //!
-    //! Snippet
-    //! +++++++
-    //!
-    //! The code snippet below illustrates four concurrent warp-wide exclusive prefix sums within a
-    //! block of 128 threads (one per each of the 32-thread warps).
-    //!
-    //! .. code-block:: c++
-    //!
-    //!    #include <cub/cub.cuh>
-    //!
-    //!    __global__ void ExampleKernel(...)
-    //!    {
-    //!        // Specialize WarpScan for type int
-    //!        typedef cub::WarpScan<int> WarpScan;
-    //!
-    //!        // Allocate WarpScan shared memory for 4 warps
-    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
-    //!
-    //!        // Obtain one input item per thread
-    //!        int thread_data = ...
-    //!
-    //!        // Compute exclusive warp-wide prefix sums
-    //!        int warp_aggregate;
-    //!        int warp_id = threadIdx.x / 32;
-    //!        WarpScan(temp_storage[warp_id]).ExclusiveSum(thread_data, 
-    //!                                                     thread_data, 
-    //!                                                     warp_aggregate);
-    //!
-    //! Suppose the set of input ``thread_data`` across the block of threads is 
-    //! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` in each of the four warps 
-    //! of threads will be ``0, 1, 2, ..., 31}``. Furthermore, ``warp_aggregate`` for all threads 
-    //! in all warps will be ``32``.
-    //! @endrst
-    //!
-    //! 
-    //! @param[in] input
-    //!   Calling thread's input item
-    //!
-    //! @param[out] exclusive_output
-    //!   Calling thread's output item. May be aliased with `input`
-    //!
-    //! @param[out] warp_aggregate    
-    //!   Warp-wide aggregate reduction of input items
-    __device__ __forceinline__ void ExclusiveSum(T input, T &exclusive_output, T &warp_aggregate)
-    {
-      T initial_value{};
-      ExclusiveScan(input, exclusive_output, initial_value, cub::Sum(), warp_aggregate);
-    }
+  //! @}  end member group
+  //! @name Inclusive prefix scans
+  //! @{
 
-    //! @}  end member group
-    //! @name Inclusive prefix scans
-    //! @{
+  //! @rst
+  //! Computes an inclusive prefix scan using the specified binary scan functor across the
+  //! calling warp.
+  //!
+  //! * @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates four concurrent warp-wide inclusive prefix max scans
+  //! within a block of 128 threads (one per each of the 32-thread warps).
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize WarpScan for type int
+  //!        typedef cub::WarpScan<int> WarpScan;
+  //!
+  //!        // Allocate WarpScan shared memory for 4 warps
+  //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+  //!
+  //!        // Obtain one input item per thread
+  //!        int thread_data = ...
+  //!
+  //!        // Compute inclusive warp-wide prefix max scans
+  //!        int warp_id = threadIdx.x / 32;
+  //!        WarpScan(temp_storage[warp_id]).InclusiveScan(thread_data, thread_data, cub::Max());
+  //!
+  //! Suppose the set of input ``thread_data`` across the block of threads is
+  //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first
+  //! warp would be ``0, 0, 2, 2, ..., 30, 30``, the output for the second warp would be
+  //! ``32, 32, 34, 34, ..., 62, 62``, etc.
+  //! @endrst
+  //!
+  //! @tparam ScanOp
+  //!   **[inferred]** Binary scan operator type having member
+  //!   `T operator()(const T &a, const T &b)`
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item
+  //!
+  //! @param[out] inclusive_output
+  //!   Calling thread's output item. May be aliased with `input`
+  //!
+  //! @param[in] can_op
+  //!   Binary scan operator
+  template <typename ScanOp>
+  __device__ __forceinline__ void InclusiveScan(T input, T &inclusive_output, ScanOp scan_op)
+  {
+    InternalWarpScan(temp_storage).InclusiveScan(input, inclusive_output, scan_op);
+  }
 
-    //! @rst
-    //! Computes an inclusive prefix scan using the specified binary scan functor across the 
-    //! calling warp.
-    //!
-    //! * @smemwarpreuse
-    //!
-    //! Snippet
-    //! +++++++
-    //!
-    //! The code snippet below illustrates four concurrent warp-wide inclusive prefix max scans 
-    //! within a block of 128 threads (one per each of the 32-thread warps).
-    //!
-    //! .. code-block:: c++
-    //!
-    //!    #include <cub/cub.cuh>
-    //!
-    //!    __global__ void ExampleKernel(...)
-    //!    {
-    //!        // Specialize WarpScan for type int
-    //!        typedef cub::WarpScan<int> WarpScan;
-    //!
-    //!        // Allocate WarpScan shared memory for 4 warps
-    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
-    //!
-    //!        // Obtain one input item per thread
-    //!        int thread_data = ...
-    //!
-    //!        // Compute inclusive warp-wide prefix max scans
-    //!        int warp_id = threadIdx.x / 32;
-    //!        WarpScan(temp_storage[warp_id]).InclusiveScan(thread_data, thread_data, cub::Max());
-    //!
-    //! Suppose the set of input ``thread_data`` across the block of threads is 
-    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first 
-    //! warp would be ``0, 0, 2, 2, ..., 30, 30``, the output for the second warp would be 
-    //! ``32, 32, 34, 34, ..., 62, 62``, etc.
-    //! @endrst
-    //!
-    //! @tparam ScanOp     
-    //!   **[inferred]** Binary scan operator type having member 
-    //!   `T operator()(const T &a, const T &b)`
-    //!
-    //! @param[in] input
-    //!   Calling thread's input item
-    //!
-    //! @param[out] inclusive_output
-    //!   Calling thread's output item. May be aliased with `input`
-    //!
-    //! @param[in] can_op
-    //!   Binary scan operator
-    template <typename ScanOp>
-    __device__ __forceinline__ void InclusiveScan(T input, T &inclusive_output, ScanOp scan_op)
-    {
-      InternalWarpScan(temp_storage).InclusiveScan(input, inclusive_output, scan_op);
-    }
+  //! @rst
+  //! Computes an inclusive prefix scan using the specified binary scan functor across the
+  //! calling warp. Also provides every thread with the warp-wide ``warp_aggregate`` of
+  //! all inputs.
+  //!
+  //! * @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates four concurrent warp-wide inclusive prefix max scans
+  //! within a block of 128 threads (one per each of the 32-thread warps).
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize WarpScan for type int
+  //!        typedef cub::WarpScan<int> WarpScan;
+  //!
+  //!        // Allocate WarpScan shared memory for 4 warps
+  //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+  //!
+  //!        // Obtain one input item per thread
+  //!        int thread_data = ...
+  //!
+  //!        // Compute inclusive warp-wide prefix max scans
+  //!        int warp_aggregate;
+  //!        int warp_id = threadIdx.x / 32;
+  //!        WarpScan(temp_storage[warp_id]).InclusiveScan(
+  //!            thread_data, thread_data, cub::Max(), warp_aggregate);
+  //!
+  //! Suppose the set of input ``thread_data`` across the block of threads is
+  //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first
+  //! warp would be ``0, 0, 2, 2, ..., 30, 30``, the output for the second warp would be
+  //! ``32, 32, 34, 34, ..., 62, 62``, etc.  Furthermore, ``warp_aggregate`` would be assigned
+  //! ``30`` for threads in the first warp, ``62`` for threads in the second warp, etc.
+  //! @endrst
+  //!
+  //! @tparam ScanOp
+  //!   **[inferred]** Binary scan operator type having member
+  //!   `T operator()(const T &a, const T &b)`
+  //! @param[in] input
+  //!   Calling thread's input item
+  //!
+  //! @param[out] inclusive_output
+  //!   Calling thread's output item. May be aliased with ``input``
+  //!
+  //! @param[in] scan_op
+  //!   Binary scan operator
+  //!
+  //! @param[out] warp_aggregate
+  //!   Warp-wide aggregate reduction of input items.
+  template <typename ScanOp>
+  __device__ __forceinline__ void
+  InclusiveScan(T input, T &inclusive_output, ScanOp scan_op, T &warp_aggregate)
+  {
+    InternalWarpScan(temp_storage).InclusiveScan(input, inclusive_output, scan_op, warp_aggregate);
+  }
 
-    //! @rst
-    //! Computes an inclusive prefix scan using the specified binary scan functor across the 
-    //! calling warp. Also provides every thread with the warp-wide ``warp_aggregate`` of 
-    //! all inputs.
-    //!
-    //! * @smemwarpreuse
-    //!
-    //! Snippet
-    //! +++++++
-    //!
-    //! The code snippet below illustrates four concurrent warp-wide inclusive prefix max scans 
-    //! within a block of 128 threads (one per each of the 32-thread warps).
-    //!
-    //! .. code-block:: c++
-    //!
-    //!    #include <cub/cub.cuh>
-    //!
-    //!    __global__ void ExampleKernel(...)
-    //!    {
-    //!        // Specialize WarpScan for type int
-    //!        typedef cub::WarpScan<int> WarpScan;
-    //!
-    //!        // Allocate WarpScan shared memory for 4 warps
-    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
-    //!
-    //!        // Obtain one input item per thread
-    //!        int thread_data = ...
-    //!
-    //!        // Compute inclusive warp-wide prefix max scans
-    //!        int warp_aggregate;
-    //!        int warp_id = threadIdx.x / 32;
-    //!        WarpScan(temp_storage[warp_id]).InclusiveScan(
-    //!            thread_data, thread_data, cub::Max(), warp_aggregate);
-    //!
-    //! Suppose the set of input ``thread_data`` across the block of threads is 
-    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first 
-    //! warp would be ``0, 0, 2, 2, ..., 30, 30``, the output for the second warp would be 
-    //! ``32, 32, 34, 34, ..., 62, 62``, etc.  Furthermore, ``warp_aggregate`` would be assigned 
-    //! ``30`` for threads in the first warp, ``62`` for threads in the second warp, etc.
-    //! @endrst
-    //!
-    //! @tparam ScanOp     
-    //!   **[inferred]** Binary scan operator type having member 
-    //!   `T operator()(const T &a, const T &b)`
-    //! @param[in] input
-    //!   Calling thread's input item
-    //!
-    //! @param[out] inclusive_output
-    //!   Calling thread's output item. May be aliased with ``input``
-    //!
-    //! @param[in] scan_op
-    //!   Binary scan operator
-    //!
-    //! @param[out] warp_aggregate    
-    //!   Warp-wide aggregate reduction of input items.
-    template <typename ScanOp>
-    __device__ __forceinline__ void
-    InclusiveScan(T input, T &inclusive_output, ScanOp scan_op, T &warp_aggregate)
-    {
-      InternalWarpScan(temp_storage).InclusiveScan(input, inclusive_output, scan_op, warp_aggregate);
-    }
+  //! @}  end member group
+  //! @name Exclusive prefix scans
+  //! @{
 
-    //! @}  end member group
-    //! @name Exclusive prefix scans
-    //! @{
+  //! @rst
+  //! Computes an exclusive prefix scan using the specified binary scan functor across the
+  //! calling warp. Because no initial value is supplied, the ``output`` computed for
+  //! *lane*\ :sub:`0` is undefined.
+  //!
+  //! * @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans
+  //! within a block of 128 threads (one per each of the 32-thread warps).
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize WarpScan for type int
+  //!        typedef cub::WarpScan<int> WarpScan;
+  //!
+  //!        // Allocate WarpScan shared memory for 4 warps
+  //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+  //!
+  //!        // Obtain one input item per thread
+  //!        int thread_data = ...
+  //!
+  //!        // Compute exclusive warp-wide prefix max scans
+  //!        int warp_id = threadIdx.x / 32;
+  //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data, thread_data, cub::Max());
+  //!
+  //! Suppose the set of input ``thread_data`` across the block of threads is
+  //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first
+  //! warp would be ``?, 0, 0, 2, ..., 28, 30``, the output for the second warp would be
+  //! ``?, 32, 32, 34, ..., 60, 62``, etc.
+  //! (The output ``thread_data`` in warp *lane*\ :sub:`0` is undefined.)
+  //! @endrst
+  //!
+  //! @tparam ScanOp
+  //!   **[inferred]** Binary scan operator type having member
+  //!   `T operator()(const T &a, const T &b)`
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item
+  //!
+  //! @param[out] exclusive_output
+  //!   Calling thread's output item. May be aliased with `input`
+  //!
+  //! @param[in] scan_op
+  //!   Binary scan operator
+  template <typename ScanOp>
+  __device__ __forceinline__ void ExclusiveScan(T input, T &exclusive_output, ScanOp scan_op)
+  {
+    InternalWarpScan internal(temp_storage);
 
-    //! @rst
-    //! Computes an exclusive prefix scan using the specified binary scan functor across the 
-    //! calling warp. Because no initial value is supplied, the ``output`` computed for 
-    //! *lane*\ :sub:`0` is undefined.
-    //!
-    //! * @smemwarpreuse
-    //!
-    //! Snippet
-    //! +++++++
-    //!
-    //! The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans 
-    //! within a block of 128 threads (one per each of the 32-thread warps).
-    //!
-    //! .. code-block:: c++
-    //!
-    //!    #include <cub/cub.cuh>
-    //!
-    //!    __global__ void ExampleKernel(...)
-    //!    {
-    //!        // Specialize WarpScan for type int
-    //!        typedef cub::WarpScan<int> WarpScan;
-    //!
-    //!        // Allocate WarpScan shared memory for 4 warps
-    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
-    //!
-    //!        // Obtain one input item per thread
-    //!        int thread_data = ...
-    //!
-    //!        // Compute exclusive warp-wide prefix max scans
-    //!        int warp_id = threadIdx.x / 32;
-    //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data, thread_data, cub::Max());
-    //!
-    //! Suppose the set of input ``thread_data`` across the block of threads is 
-    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first 
-    //! warp would be ``?, 0, 0, 2, ..., 28, 30``, the output for the second warp would be 
-    //! ``?, 32, 32, 34, ..., 60, 62``, etc.
-    //! (The output ``thread_data`` in warp *lane*\ :sub:`0` is undefined.)
-    //! @endrst
-    //!
-    //! @tparam ScanOp     
-    //!   **[inferred]** Binary scan operator type having member 
-    //!   `T operator()(const T &a, const T &b)`
-    //!
-    //! @param[in] input
-    //!   Calling thread's input item
-    //!
-    //! @param[out] exclusive_output
-    //!   Calling thread's output item. May be aliased with `input`
-    //!
-    //! @param[in] scan_op
-    //!   Binary scan operator
-    template <typename ScanOp>
-    __device__ __forceinline__ void ExclusiveScan(T input, T &exclusive_output, ScanOp scan_op)
-    {
-      InternalWarpScan internal(temp_storage);
+    T inclusive_output;
+    internal.InclusiveScan(input, inclusive_output, scan_op);
 
-      T inclusive_output;
-      internal.InclusiveScan(input, inclusive_output, scan_op);
+    internal.Update(input, inclusive_output, exclusive_output, scan_op, Int2Type<IS_INTEGER>());
+  }
 
-      internal.Update(input, inclusive_output, exclusive_output, scan_op, Int2Type<IS_INTEGER>());
-    }
+  //! @rst
+  //! Computes an exclusive prefix scan using the specified binary scan functor across the
+  //! calling warp.
+  //!
+  //! * @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans
+  //! within a block of 128 threads (one per each of the 32-thread warps).
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize WarpScan for type int
+  //!        typedef cub::WarpScan<int> WarpScan;
+  //!
+  //!        // Allocate WarpScan shared memory for 4 warps
+  //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+  //!
+  //!        // Obtain one input item per thread
+  //!        int thread_data = ...
+  //!
+  //!        // Compute exclusive warp-wide prefix max scans
+  //!        int warp_id = threadIdx.x / 32;
+  //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data,
+  //!                                                      thread_data,
+  //!                                                      INT_MIN,
+  //!                                                      cub::Max());
+  //!
+  //! Suppose the set of input ``thread_data`` across the block of threads is
+  //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first
+  //! warp would be ``INT_MIN, 0, 0, 2, ..., 28, 30``, the output for the second warp would be
+  //! ``30, 32, 32, 34, ..., 60, 62``, etc.
+  //! @endrst
+  //!
+  //! @tparam ScanOp
+  //!   **[inferred]** Binary scan operator type having member
+  //!   `T operator()(const T &a, const T &b)`
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item
+  //!
+  //! @param[out] exclusive_output
+  //!   Calling thread's output item. May be aliased with `input`
+  //!
+  //! @param[in] initial_value
+  //!   Initial value to seed the exclusive scan
+  //!
+  //! @param[in] scan_op
+  //!   Binary scan operator
+  template <typename ScanOp>
+  __device__ __forceinline__ void
+  ExclusiveScan(T input, T &exclusive_output, T initial_value, ScanOp scan_op)
+  {
+    InternalWarpScan internal(temp_storage);
 
-    //! @rst
-    //! Computes an exclusive prefix scan using the specified binary scan functor across the 
-    //! calling warp.
-    //!
-    //! * @smemwarpreuse
-    //!
-    //! Snippet
-    //! +++++++
-    //!
-    //! The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans 
-    //! within a block of 128 threads (one per each of the 32-thread warps).
-    //!
-    //! .. code-block:: c++
-    //!
-    //!    #include <cub/cub.cuh>
-    //!
-    //!    __global__ void ExampleKernel(...)
-    //!    {
-    //!        // Specialize WarpScan for type int
-    //!        typedef cub::WarpScan<int> WarpScan;
-    //!
-    //!        // Allocate WarpScan shared memory for 4 warps
-    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
-    //!
-    //!        // Obtain one input item per thread
-    //!        int thread_data = ...
-    //!
-    //!        // Compute exclusive warp-wide prefix max scans
-    //!        int warp_id = threadIdx.x / 32;
-    //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data, 
-    //!                                                      thread_data, 
-    //!                                                      INT_MIN, 
-    //!                                                      cub::Max());
-    //!
-    //! Suppose the set of input ``thread_data`` across the block of threads is 
-    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first 
-    //! warp would be ``INT_MIN, 0, 0, 2, ..., 28, 30``, the output for the second warp would be 
-    //! ``30, 32, 32, 34, ..., 60, 62``, etc.
-    //! @endrst
-    //!
-    //! @tparam ScanOp     
-    //!   **[inferred]** Binary scan operator type having member 
-    //!   `T operator()(const T &a, const T &b)`
-    //!
-    //! @param[in] input
-    //!   Calling thread's input item
-    //!
-    //! @param[out] exclusive_output
-    //!   Calling thread's output item. May be aliased with `input`
-    //!
-    //! @param[in] initial_value
-    //!   Initial value to seed the exclusive scan
-    //!
-    //! @param[in] scan_op
-    //!   Binary scan operator
-    template <typename ScanOp>
-    __device__ __forceinline__ void
-    ExclusiveScan(T input, T &exclusive_output, T initial_value, ScanOp scan_op)
-    {
-        InternalWarpScan internal(temp_storage);
+    T inclusive_output;
+    internal.InclusiveScan(input, inclusive_output, scan_op);
 
-        T inclusive_output;
-        internal.InclusiveScan(input, inclusive_output, scan_op);
+    internal.Update(input,
+                    inclusive_output,
+                    exclusive_output,
+                    scan_op,
+                    initial_value,
+                    Int2Type<IS_INTEGER>());
+  }
 
-        internal.Update(
-            input,
-            inclusive_output,
-            exclusive_output,
-            scan_op,
-            initial_value,
-            Int2Type<IS_INTEGER>());
-    }
+  //! @rst
+  //! Computes an exclusive prefix scan using the specified binary scan functor across the
+  //! calling warp. Because no initial value is supplied, the ``output`` computed for
+  //! *lane*\ :sub:`0` is undefined. Also provides every thread with the warp-wide
+  //! ``warp_aggregate`` of all inputs.
+  //!
+  //! * @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans
+  //! within a block of 128 threads (one per each of the 32-thread warps).
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize WarpScan for type int
+  //!        typedef cub::WarpScan<int> WarpScan;
+  //!
+  //!        // Allocate WarpScan shared memory for 4 warps
+  //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+  //!
+  //!        // Obtain one input item per thread
+  //!        int thread_data = ...
+  //!
+  //!        // Compute exclusive warp-wide prefix max scans
+  //!        int warp_aggregate;
+  //!        int warp_id = threadIdx.x / 32;
+  //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data,
+  //!                                                      thread_data,
+  //!                                                      cub::Max(),
+  //!                                                      warp_aggregate);
+  //!
+  //! Suppose the set of input ``thread_data`` across the block of threads is
+  //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first
+  //! warp would be ``?, 0, 0, 2, ..., 28, 30``, the output for the second warp would be
+  //! ``?, 32, 32, 34, ..., 60, 62``, etc. (The output ``thread_data`` in warp *lane*\ :sub:`0`
+  //! is undefined). Furthermore, ``warp_aggregate`` would be assigned ``30`` for threads in the
+  //! first warp, \p 62 for threads in the second warp, etc.
+  //! @endrst
+  //!
+  //! @tparam ScanOp
+  //!   **[inferred]** Binary scan operator type having member
+  //!   `T operator()(const T &a, const T &b)`
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item
+  //!
+  //! @param[out] exclusive_output
+  //!   Calling thread's output item. May be aliased with `input`
+  //!
+  //! @param[in] scan_op
+  //!   Binary scan operator
+  //!
+  //! @param[out] warp_aggregate
+  //!   Warp-wide aggregate reduction of input items
+  template <typename ScanOp>
+  __device__ __forceinline__ void
+  ExclusiveScan(T input, T &exclusive_output, ScanOp scan_op, T &warp_aggregate)
+  {
+    InternalWarpScan internal(temp_storage);
 
+    T inclusive_output;
+    internal.InclusiveScan(input, inclusive_output, scan_op);
 
-    //! @rst
-    //! Computes an exclusive prefix scan using the specified binary scan functor across the 
-    //! calling warp. Because no initial value is supplied, the ``output`` computed for 
-    //! *lane*\ :sub:`0` is undefined. Also provides every thread with the warp-wide 
-    //! ``warp_aggregate`` of all inputs.
-    //!
-    //! * @smemwarpreuse
-    //!
-    //! Snippet
-    //! +++++++
-    //!
-    //! The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans 
-    //! within a block of 128 threads (one per each of the 32-thread warps).
-    //!
-    //! .. code-block:: c++
-    //!
-    //!    #include <cub/cub.cuh>
-    //!
-    //!    __global__ void ExampleKernel(...)
-    //!    {
-    //!        // Specialize WarpScan for type int
-    //!        typedef cub::WarpScan<int> WarpScan;
-    //!
-    //!        // Allocate WarpScan shared memory for 4 warps
-    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
-    //!
-    //!        // Obtain one input item per thread
-    //!        int thread_data = ...
-    //!
-    //!        // Compute exclusive warp-wide prefix max scans
-    //!        int warp_aggregate;
-    //!        int warp_id = threadIdx.x / 32;
-    //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data, 
-    //!                                                      thread_data, 
-    //!                                                      cub::Max(), 
-    //!                                                      warp_aggregate);
-    //!
-    //! Suppose the set of input ``thread_data`` across the block of threads is 
-    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first 
-    //! warp would be ``?, 0, 0, 2, ..., 28, 30``, the output for the second warp would be 
-    //! ``?, 32, 32, 34, ..., 60, 62``, etc. (The output ``thread_data`` in warp *lane*\ :sub:`0` 
-    //! is undefined). Furthermore, ``warp_aggregate`` would be assigned ``30`` for threads in the 
-    //! first warp, \p 62 for threads in the second warp, etc.
-    //! @endrst
-    //!
-    //! @tparam ScanOp     
-    //!   **[inferred]** Binary scan operator type having member 
-    //!   `T operator()(const T &a, const T &b)`
-    //!
-    //! @param[in] input
-    //!   Calling thread's input item
-    //!
-    //! @param[out] exclusive_output
-    //!   Calling thread's output item. May be aliased with `input`
-    //!
-    //! @param[in] scan_op
-    //!   Binary scan operator
-    //!
-    //! @param[out] warp_aggregate
-    //!   Warp-wide aggregate reduction of input items
-    template <typename ScanOp>
-    __device__ __forceinline__ void
-    ExclusiveScan(T input, T &exclusive_output, ScanOp scan_op, T &warp_aggregate)
-    {
-        InternalWarpScan internal(temp_storage);
+    internal.Update(input,
+                    inclusive_output,
+                    exclusive_output,
+                    warp_aggregate,
+                    scan_op,
+                    Int2Type<IS_INTEGER>());
+  }
 
-        T inclusive_output;
-        internal.InclusiveScan(input, inclusive_output, scan_op);
+  //! @rst
+  //! Computes an exclusive prefix scan using the specified binary scan functor across the
+  //! calling warp. Also provides every thread with the warp-wide ``warp_aggregate`` of
+  //! all inputs.
+  //!
+  //! * @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans
+  //! within a block of 128 threads (one per each of the 32-thread warps).
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize WarpScan for type int
+  //!        typedef cub::WarpScan<int> WarpScan;
+  //!
+  //!        // Allocate WarpScan shared memory for 4 warps
+  //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+  //!
+  //!        // Obtain one input item per thread
+  //!        int thread_data = ...
+  //!
+  //!        // Compute exclusive warp-wide prefix max scans
+  //!        int warp_aggregate;
+  //!        int warp_id = threadIdx.x / 32;
+  //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data,
+  //!                                                      thread_data,
+  //!                                                      INT_MIN,
+  //!                                                      cub::Max(),
+  //!                                                      warp_aggregate);
+  //!
+  //! Suppose the set of input ``thread_data`` across the block of threads is
+  //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first
+  //! warp would be ``INT_MIN, 0, 0, 2, ..., 28, 30``, the output for the second warp would be
+  //! ``30, 32, 32, 34, ..., 60, 62``, etc. Furthermore, ``warp_aggregate`` would be assigned
+  //! ``30`` for threads in the first warp, ``62`` for threads in the second warp, etc.
+  //! @endrst
+  //!
+  //! @tparam ScanOp
+  //!   **[inferred]** Binary scan operator type having member
+  //!   `T operator()(const T &a, const T &b)`
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item
+  //!
+  //! @param[out] exclusive_output
+  //!   Calling thread's output item.  May be aliased with `input`
+  //!
+  //! @param[in] initial_value
+  //!   Initial value to seed the exclusive scan
+  //!
+  //! @param[in] scan_op
+  //!   Binary scan operator
+  //!
+  //! @param[out] warp_aggregate
+  //!   Warp-wide aggregate reduction of input items
+  //!
+  template <typename ScanOp>
+  __device__ __forceinline__ void
+  ExclusiveScan(T input, T &exclusive_output, T initial_value, ScanOp scan_op, T &warp_aggregate)
+  {
+    InternalWarpScan internal(temp_storage);
 
-        internal.Update(
-            input,
-            inclusive_output,
-            exclusive_output,
-            warp_aggregate,
-            scan_op,
-            Int2Type<IS_INTEGER>());
-    }
+    T inclusive_output;
+    internal.InclusiveScan(input, inclusive_output, scan_op);
 
-    //! @rst
-    //! Computes an exclusive prefix scan using the specified binary scan functor across the 
-    //! calling warp. Also provides every thread with the warp-wide ``warp_aggregate`` of 
-    //! all inputs.
-    //!
-    //! * @smemwarpreuse
-    //!
-    //! Snippet
-    //! +++++++
-    //!
-    //! The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans 
-    //! within a block of 128 threads (one per each of the 32-thread warps).
-    //!
-    //! .. code-block:: c++
-    //!
-    //!    #include <cub/cub.cuh>
-    //!
-    //!    __global__ void ExampleKernel(...)
-    //!    {
-    //!        // Specialize WarpScan for type int
-    //!        typedef cub::WarpScan<int> WarpScan;
-    //!
-    //!        // Allocate WarpScan shared memory for 4 warps
-    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
-    //!
-    //!        // Obtain one input item per thread
-    //!        int thread_data = ...
-    //!
-    //!        // Compute exclusive warp-wide prefix max scans
-    //!        int warp_aggregate;
-    //!        int warp_id = threadIdx.x / 32;
-    //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data, 
-    //!                                                      thread_data, 
-    //!                                                      INT_MIN, 
-    //!                                                      cub::Max(), 
-    //!                                                      warp_aggregate);
-    //!
-    //! Suppose the set of input ``thread_data`` across the block of threads is 
-    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first 
-    //! warp would be ``INT_MIN, 0, 0, 2, ..., 28, 30``, the output for the second warp would be
-    //! ``30, 32, 32, 34, ..., 60, 62``, etc. Furthermore, ``warp_aggregate`` would be assigned 
-    //! ``30`` for threads in the first warp, ``62`` for threads in the second warp, etc.
-    //! @endrst
-    //!
-    //! @tparam ScanOp     
-    //!   **[inferred]** Binary scan operator type having member 
-    //!   `T operator()(const T &a, const T &b)`
-    //!
-    //! @param[in] input
-    //!   Calling thread's input item
-    //!
-    //! @param[out] exclusive_output
-    //!   Calling thread's output item.  May be aliased with `input`
-    //!
-    //! @param[in] initial_value
-    //!   Initial value to seed the exclusive scan
-    //!
-    //! @param[in] scan_op
-    //!   Binary scan operator
-    //!
-    //! @param[out] warp_aggregate
-    //!   Warp-wide aggregate reduction of input items
-    //!
-    template <typename ScanOp>
-    __device__ __forceinline__ void
-    ExclusiveScan(T input, T &exclusive_output, T initial_value, ScanOp scan_op, T &warp_aggregate)
-    {
-        InternalWarpScan internal(temp_storage);
+    internal.Update(input,
+                    inclusive_output,
+                    exclusive_output,
+                    warp_aggregate,
+                    scan_op,
+                    initial_value,
+                    Int2Type<IS_INTEGER>());
+  }
 
-        T inclusive_output;
-        internal.InclusiveScan(input, inclusive_output, scan_op);
+  //! @}  end member group
+  //! @name Combination (inclusive & exclusive) prefix scans
+  //! @{
 
-        internal.Update(
-            input,
-            inclusive_output,
-            exclusive_output,
-            warp_aggregate,
-            scan_op,
-            initial_value,
-            Int2Type<IS_INTEGER>());
-    }
+  //! @rst
+  //! Computes both inclusive and exclusive prefix scans using the specified binary scan functor
+  //! across the calling warp. Because no initial value is supplied, the ``exclusive_output``
+  //! computed for *lane*\ :sub:`0` is undefined.
+  //!
+  //! * @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans
+  //! within a block of 128 threads (one per each of the 32-thread warps).
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize WarpScan for type int
+  //!        typedef cub::WarpScan<int> WarpScan;
+  //!
+  //!        // Allocate WarpScan shared memory for 4 warps
+  //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+  //!
+  //!        // Obtain one input item per thread
+  //!        int thread_data = ...
+  //!
+  //!        // Compute exclusive warp-wide prefix max scans
+  //!        int inclusive_partial, exclusive_partial;
+  //!        WarpScan(temp_storage[warp_id]).Scan(thread_data,
+  //!                                             inclusive_partial,
+  //!                                             exclusive_partial,
+  //!                                             cub::Max());
+  //!
+  //! Suppose the set of input ``thread_data`` across the block of threads is
+  //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``inclusive_partial`` in the
+  //! first warp would be ``0, 0, 2, 2, ..., 30, 30``, the output for the second warp would be
+  //! ``32, 32, 34, 34, ..., 62, 62``, etc. The corresponding output ``exclusive_partial`` in the
+  //! first warp would be ``?, 0, 0, 2, ..., 28, 30``, the output for the second warp would be
+  //! ``?, 32, 32, 34, ..., 60, 62``, etc.
+  //! (The output ``thread_data`` in warp *lane*\ :sub:`0` is undefined.)
+  //! @endrst
+  //!
+  //! @tparam ScanOp
+  //!   **[inferred]** Binary scan operator type having member
+  //!   `T operator()(const T &a, const T &b)`
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item
+  //!
+  //! @param[out] inclusive_output
+  //!   Calling thread's inclusive-scan output item
+  //!
+  //! @param[out] exclusive_output
+  //!   Calling thread's exclusive-scan output item
+  //!
+  //! @param[in] scan_op
+  //!   Binary scan operator
+  template <typename ScanOp>
+  __device__ __forceinline__ void
+  Scan(T input, T &inclusive_output, T &exclusive_output, ScanOp scan_op)
+  {
+    InternalWarpScan internal(temp_storage);
 
+    internal.InclusiveScan(input, inclusive_output, scan_op);
 
-    //! @}  end member group
-    //! @name Combination (inclusive & exclusive) prefix scans
-    //! @{
+    internal.Update(input, inclusive_output, exclusive_output, scan_op, Int2Type<IS_INTEGER>());
+  }
 
+  //! @rst
+  //! Computes both inclusive and exclusive prefix scans using the specified binary scan functor
+  //! across the calling warp.
+  //!
+  //! * @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates four concurrent warp-wide prefix max scans within a
+  //! block of 128 threads (one per each of the 32-thread warps).
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize WarpScan for type int
+  //!        typedef cub::WarpScan<int> WarpScan;
+  //!
+  //!        // Allocate WarpScan shared memory for 4 warps
+  //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+  //!
+  //!        // Obtain one input item per thread
+  //!        int thread_data = ...
+  //!
+  //!        // Compute inclusive warp-wide prefix max scans
+  //!        int warp_id = threadIdx.x / 32;
+  //!        int inclusive_partial, exclusive_partial;
+  //!        WarpScan(temp_storage[warp_id]).Scan(thread_data,
+  //!                                             inclusive_partial,
+  //!                                             exclusive_partial,
+  //!                                             INT_MIN,
+  //!                                             cub::Max());
+  //!
+  //! Suppose the set of input ``thread_data`` across the block of threads is
+  //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``inclusive_partial`` in the
+  //! first warp would be ``0, 0, 2, 2, ..., 30, 30``, the output for the second warp would be
+  //! ``32, 32, 34, 34, ..., 62, 62``, etc. The corresponding output ``exclusive_partial`` in the
+  //! first warp would be ``INT_MIN, 0, 0, 2, ..., 28, 30``, the output for the second warp would
+  //! be ``30, 32, 32, 34, ..., 60, 62``, etc.
+  //! @endrst
+  //!
+  //! @tparam ScanOp
+  //!   **[inferred]** Binary scan operator type having member
+  //!   `T operator()(const T &a, const T &b)`
+  //!
+  //! @param[in] input
+  //!   Calling thread's input item
+  //!
+  //! @param[out] inclusive_output
+  //!   Calling thread's inclusive-scan output item
+  //!
+  //! @param[out] exclusive_output
+  //!   Calling thread's exclusive-scan output item
+  //!
+  //! @param[in] initial_value
+  //!   Initial value to seed the exclusive scan
+  //!
+  //! @param[in] scan_op
+  //!   Binary scan operator
+  template <typename ScanOp>
+  __device__ __forceinline__ void
+  Scan(T input, T &inclusive_output, T &exclusive_output, T initial_value, ScanOp scan_op)
+  {
+    InternalWarpScan internal(temp_storage);
 
-    //! @rst
-    //! Computes both inclusive and exclusive prefix scans using the specified binary scan functor
-    //! across the calling warp. Because no initial value is supplied, the ``exclusive_output``
-    //! computed for *lane*\ :sub:`0` is undefined.
-    //!
-    //! * @smemwarpreuse
-    //!
-    //! Snippet
-    //! +++++++
-    //!
-    //! The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans 
-    //! within a block of 128 threads (one per each of the 32-thread warps).
-    //!
-    //! .. code-block:: c++
-    //!
-    //!    #include <cub/cub.cuh>
-    //!
-    //!    __global__ void ExampleKernel(...)
-    //!    {
-    //!        // Specialize WarpScan for type int
-    //!        typedef cub::WarpScan<int> WarpScan;
-    //!
-    //!        // Allocate WarpScan shared memory for 4 warps
-    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
-    //!
-    //!        // Obtain one input item per thread
-    //!        int thread_data = ...
-    //!
-    //!        // Compute exclusive warp-wide prefix max scans
-    //!        int inclusive_partial, exclusive_partial;
-    //!        WarpScan(temp_storage[warp_id]).Scan(thread_data, 
-    //!                                             inclusive_partial, 
-    //!                                             exclusive_partial, 
-    //!                                             cub::Max());
-    //!
-    //! Suppose the set of input ``thread_data`` across the block of threads is 
-    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``inclusive_partial`` in the 
-    //! first warp would be ``0, 0, 2, 2, ..., 30, 30``, the output for the second warp would be
-    //! ``32, 32, 34, 34, ..., 62, 62``, etc. The corresponding output ``exclusive_partial`` in the
-    //! first warp would be ``?, 0, 0, 2, ..., 28, 30``, the output for the second warp would be 
-    //! ``?, 32, 32, 34, ..., 60, 62``, etc. 
-    //! (The output ``thread_data`` in warp *lane*\ :sub:`0` is undefined.)
-    //! @endrst
-    //!
-    //! @tparam ScanOp     
-    //!   **[inferred]** Binary scan operator type having member 
-    //!   `T operator()(const T &a, const T &b)`
-    //!
-    //! @param[in] input
-    //!   Calling thread's input item
-    //!
-    //! @param[out] inclusive_output
-    //!   Calling thread's inclusive-scan output item
-    //!
-    //! @param[out] exclusive_output
-    //!   Calling thread's exclusive-scan output item
-    //!
-    //! @param[in] scan_op
-    //!   Binary scan operator
-    template <typename ScanOp>
-    __device__ __forceinline__ void
-    Scan(T input, T &inclusive_output, T &exclusive_output, ScanOp scan_op)
-    {
-        InternalWarpScan internal(temp_storage);
+    internal.InclusiveScan(input, inclusive_output, scan_op);
 
-        internal.InclusiveScan(input, inclusive_output, scan_op);
+    internal.Update(input,
+                    inclusive_output,
+                    exclusive_output,
+                    scan_op,
+                    initial_value,
+                    Int2Type<IS_INTEGER>());
+  }
 
-        internal.Update(
-            input,
-            inclusive_output,
-            exclusive_output,
-            scan_op,
-            Int2Type<IS_INTEGER>());
-    }
+  //! @}  end member group
+  //! @name Data exchange
+  //! @{
 
+  //! @rst
+  //! Broadcast the value ``input`` from *lane*\ :sub:`src_lane` to all lanes in the warp
+  //!
+  //! * @smemwarpreuse
+  //!
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates the warp-wide broadcasts of values from *lane*\ :sub:`0`
+  //! in each of four warps to all other threads in those warps.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>
+  //!
+  //!    __global__ void ExampleKernel(...)
+  //!    {
+  //!        // Specialize WarpScan for type int
+  //!        typedef cub::WarpScan<int> WarpScan;
+  //!
+  //!        // Allocate WarpScan shared memory for 4 warps
+  //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+  //!
+  //!        // Obtain one input item per thread
+  //!        int thread_data = ...
+  //!
+  //!        // Broadcast from lane0 in each warp to all other threads in the warp
+  //!        int warp_id = threadIdx.x / 32;
+  //!        thread_data = WarpScan(temp_storage[warp_id]).Broadcast(thread_data, 0);
+  //!
+  //! Suppose the set of input ``thread_data`` across the block of threads is
+  //! ``{0, 1, 2, 3, ..., 127}``. The corresponding output ``thread_data`` will be
+  //! ``{0, 0, ..., 0}`` in warp\ :sub:`0`,
+  //! ``{32, 32, ..., 32}`` in warp\ :sub:`1`,
+  //! ``{64, 64, ..., 64}`` in warp\ :sub:`2`, etc.
+  //! @endrst
+  //!
+  //! @param[in] input
+  //!   The value to broadcast
+  //!
+  //! @param[in] src_lane
+  //!   Which warp lane is to do the broadcasting
+  __device__ __forceinline__ T Broadcast(T input, unsigned int src_lane)
+  {
+    return InternalWarpScan(temp_storage).Broadcast(input, src_lane);
+  }
 
-    //! @rst
-    //! Computes both inclusive and exclusive prefix scans using the specified binary scan functor
-    //! across the calling warp.
-    //!
-    //! * @smemwarpreuse
-    //!
-    //! Snippet
-    //! +++++++
-    //!
-    //! The code snippet below illustrates four concurrent warp-wide prefix max scans within a 
-    //! block of 128 threads (one per each of the 32-thread warps).
-    //!
-    //! .. code-block:: c++
-    //!
-    //!    #include <cub/cub.cuh>
-    //!
-    //!    __global__ void ExampleKernel(...)
-    //!    {
-    //!        // Specialize WarpScan for type int
-    //!        typedef cub::WarpScan<int> WarpScan;
-    //!
-    //!        // Allocate WarpScan shared memory for 4 warps
-    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
-    //!
-    //!        // Obtain one input item per thread
-    //!        int thread_data = ...
-    //!
-    //!        // Compute inclusive warp-wide prefix max scans
-    //!        int warp_id = threadIdx.x / 32;
-    //!        int inclusive_partial, exclusive_partial;
-    //!        WarpScan(temp_storage[warp_id]).Scan(thread_data, 
-    //!                                             inclusive_partial, 
-    //!                                             exclusive_partial, 
-    //!                                             INT_MIN, 
-    //!                                             cub::Max());
-    //!
-    //! Suppose the set of input ``thread_data`` across the block of threads is 
-    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``inclusive_partial`` in the 
-    //! first warp would be ``0, 0, 2, 2, ..., 30, 30``, the output for the second warp would be
-    //! ``32, 32, 34, 34, ..., 62, 62``, etc. The corresponding output ``exclusive_partial`` in the
-    //! first warp would be ``INT_MIN, 0, 0, 2, ..., 28, 30``, the output for the second warp would 
-    //! be ``30, 32, 32, 34, ..., 60, 62``, etc.
-    //! @endrst
-    //!
-    //! @tparam ScanOp     
-    //!   **[inferred]** Binary scan operator type having member 
-    //!   `T operator()(const T &a, const T &b)`
-    //!
-    //! @param[in] input 
-    //!   Calling thread's input item
-    //!
-    //! @param[out] inclusive_output 
-    //!   Calling thread's inclusive-scan output item
-    //!
-    //! @param[out] exclusive_output 
-    //!   Calling thread's exclusive-scan output item
-    //!
-    //! @param[in] initial_value
-    //!   Initial value to seed the exclusive scan
-    //!
-    //! @param[in] scan_op
-    //!   Binary scan operator
-    template <typename ScanOp>
-    __device__ __forceinline__ void
-    Scan(T input, T &inclusive_output, T &exclusive_output, T initial_value, ScanOp scan_op)
-    {
-        InternalWarpScan internal(temp_storage);
-
-        internal.InclusiveScan(input, inclusive_output, scan_op);
-
-        internal.Update(
-            input,
-            inclusive_output,
-            exclusive_output,
-            scan_op,
-            initial_value,
-            Int2Type<IS_INTEGER>());
-    }
-
-    //! @}  end member group
-    //! @name Data exchange
-    //! @{
-
-    //! @rst
-    //! Broadcast the value ``input`` from *lane*\ :sub:`src_lane` to all lanes in the warp
-    //!
-    //! * @smemwarpreuse
-    //!
-    //! Snippet
-    //! +++++++
-    //!
-    //! The code snippet below illustrates the warp-wide broadcasts of values from *lane*\ :sub:`0`
-    //! in each of four warps to all other threads in those warps.
-    //!
-    //! .. code-block:: c++
-    //!
-    //!    #include <cub/cub.cuh>
-    //!
-    //!    __global__ void ExampleKernel(...)
-    //!    {
-    //!        // Specialize WarpScan for type int
-    //!        typedef cub::WarpScan<int> WarpScan;
-    //!
-    //!        // Allocate WarpScan shared memory for 4 warps
-    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
-    //!
-    //!        // Obtain one input item per thread
-    //!        int thread_data = ...
-    //!
-    //!        // Broadcast from lane0 in each warp to all other threads in the warp
-    //!        int warp_id = threadIdx.x / 32;
-    //!        thread_data = WarpScan(temp_storage[warp_id]).Broadcast(thread_data, 0);
-    //!
-    //! Suppose the set of input ``thread_data`` across the block of threads is 
-    //! ``{0, 1, 2, 3, ..., 127}``. The corresponding output ``thread_data`` will be
-    //! ``{0, 0, ..., 0}`` in warp\ :sub:`0`,
-    //! ``{32, 32, ..., 32}`` in warp\ :sub:`1`,
-    //! ``{64, 64, ..., 64}`` in warp\ :sub:`2`, etc.
-    //! @endrst
-    //!
-    //! @param[in] input
-    //!   The value to broadcast
-    //!
-    //! @param[in] src_lane
-    //!   Which warp lane is to do the broadcasting
-    __device__ __forceinline__ T Broadcast(T input, unsigned int src_lane)
-    {
-        return InternalWarpScan(temp_storage).Broadcast(input, src_lane);
-    }
-
-    //@}  end member group
-
+  //@}  end member group
 };
 
 CUB_NAMESPACE_END

--- a/cub/warp/warp_scan.cuh
+++ b/cub/warp/warp_scan.cuh
@@ -26,118 +26,127 @@
  *
  ******************************************************************************/
 
-/**
- * \file
- * The cub::WarpScan class provides [<em>collective</em>](index.html#sec0) methods for computing a parallel prefix scan of items partitioned across a CUDA thread warp.
- */
+//! @file
+//! @rst 
+//! The ``cub::WarpScan`` class provides :ref:`collective <collective-primitives>` methods for
+//! computing a parallel prefix scan of items partitioned across a CUDA thread warp.
+//! @endrst
 
 #pragma once
 
-#include "../config.cuh"
-#include "specializations/warp_scan_shfl.cuh"
-#include "specializations/warp_scan_smem.cuh"
-#include "../thread/thread_operators.cuh"
-#include "../util_type.cuh"
+#include <cub/config.cuh>
+#include <cub/thread/thread_operators.cuh>
+#include <cub/util_type.cuh>
+#include <cub/warp/specializations/warp_scan_shfl.cuh>
+#include <cub/warp/specializations/warp_scan_smem.cuh>
 
 CUB_NAMESPACE_BEGIN
 
-/**
- * \addtogroup WarpModule
- * @{
- */
-
-/**
- * \brief The WarpScan class provides [<em>collective</em>](index.html#sec0) methods for computing a parallel prefix scan of items partitioned across a CUDA thread warp.  ![](warp_scan_logo.png)
- *
- * \tparam T                        The scan input/output element type
- * \tparam LOGICAL_WARP_THREADS     <b>[optional]</b> The number of threads per "logical" warp (may be less than the number of hardware warp threads).  Default is the warp size associated with the CUDA Compute Capability targeted by the compiler (e.g., 32 threads for SM20).
- * \tparam LEGACY_PTX_ARCH          <b>[optional]</b> Unused.
- *
- * \par Overview
- * - Given a list of input elements and a binary reduction operator, a [<em>prefix scan</em>](http://en.wikipedia.org/wiki/Prefix_sum)
- *   produces an output list where each element is computed to be the reduction
- *   of the elements occurring earlier in the input list.  <em>Prefix sum</em>
- *   connotes a prefix scan with the addition operator. The term \em inclusive indicates
- *   that the <em>i</em><sup>th</sup> output reduction incorporates the <em>i</em><sup>th</sup> input.
- *   The term \em exclusive indicates the <em>i</em><sup>th</sup> input is not incorporated into
- *   the <em>i</em><sup>th</sup> output reduction.
- * - Supports non-commutative scan operators
- * - Supports "logical" warps smaller than the physical warp size (e.g., a logical warp of 8 threads)
- * - The number of entrant threads must be an multiple of \p LOGICAL_WARP_THREADS
- *
- * \par Performance Considerations
- * - Uses special instructions when applicable (e.g., warp \p SHFL)
- * - Uses synchronization-free communication between warp lanes when applicable
- * - Incurs zero bank conflicts for most types
- * - Computation is slightly more efficient (i.e., having lower instruction overhead) for:
- *     - Summation (<b><em>vs.</em></b> generic scan)
- *     - The architecture's warp size is a whole multiple of \p LOGICAL_WARP_THREADS
- *
- * \par Simple Examples
- * \warpcollective{WarpScan}
- * \par
- * The code snippet below illustrates four concurrent warp prefix sums within a block of
- * 128 threads (one per each of the 32-thread warps).
- * \par
- * \code
- * #include <cub/cub.cuh>
- *
- * __global__ void ExampleKernel(...)
- * {
- *     // Specialize WarpScan for type int
- *     typedef cub::WarpScan<int> WarpScan;
- *
- *     // Allocate WarpScan shared memory for 4 warps
- *     __shared__ typename WarpScan::TempStorage temp_storage[4];
- *
- *     // Obtain one input item per thread
- *     int thread_data = ...
- *
- *     // Compute warp-wide prefix sums
- *     int warp_id = threadIdx.x / 32;
- *     WarpScan(temp_storage[warp_id]).ExclusiveSum(thread_data, thread_data);
- *
- * \endcode
- * \par
- * Suppose the set of input \p thread_data across the block of threads is <tt>{1, 1, 1, 1, ...}</tt>.
- * The corresponding output \p thread_data in each of the four warps of threads will be
- * <tt>0, 1, 2, 3, ..., 31}</tt>.
- *
- * \par
- * The code snippet below illustrates a single warp prefix sum within a block of
- * 128 threads.
- * \par
- * \code
- * #include <cub/cub.cuh>
- *
- * __global__ void ExampleKernel(...)
- * {
- *     // Specialize WarpScan for type int
- *     typedef cub::WarpScan<int> WarpScan;
- *
- *     // Allocate WarpScan shared memory for one warp
- *     __shared__ typename WarpScan::TempStorage temp_storage;
- *     ...
- *
- *     // Only the first warp performs a prefix sum
- *     if (threadIdx.x < 32)
- *     {
- *         // Obtain one input item per thread
- *         int thread_data = ...
- *
- *         // Compute warp-wide prefix sums
- *         WarpScan(temp_storage).ExclusiveSum(thread_data, thread_data);
- *
- * \endcode
- * \par
- * Suppose the set of input \p thread_data across the warp of threads is <tt>{1, 1, 1, 1, ...}</tt>.
- * The corresponding output \p thread_data will be <tt>{0, 1, 2, 3, ..., 31}</tt>.
- *
- */
-template <
-    typename    T,
-    int         LOGICAL_WARP_THREADS    = CUB_PTX_WARP_THREADS,
-    int         LEGACY_PTX_ARCH         = 0>
+//! @rst
+//! The WarpScan class provides :ref:`collective <collective-primitives>` methods for computing a
+//! parallel prefix scan of items partitioned across a CUDA thread warp.  
+//!
+//! .. image:: ../img/warp_scan_logo.png
+//!     :align: center
+//! 
+//! Overview
+//! ++++++++++++++++++++++++++
+//!
+//! * Given a list of input elements and a binary reduction operator, a
+//!   `prefix scan <http://en.wikipedia.org/wiki/Prefix_sum>`__ produces an output list where each
+//!   element is computed to be the reduction of the elements occurring earlier in the input list.
+//!   *Prefix sum* connotes a prefix scan with the addition operator. The term *inclusive* 
+//!   indicates that the *i*\ :sup:`th` output reduction incorporates the *i*\ :sup:`th` input.
+//!   The term *exclusive* indicates the *i*\ :sup:`th` input is not incorporated into
+//!   the *i*\ :sup:`th` output reduction.
+//! * Supports non-commutative scan operators
+//! * Supports "logical" warps smaller than the physical warp size 
+//!   (e.g., a logical warp of 8 threads)
+//! * The number of entrant threads must be an multiple of ``LOGICAL_WARP_THREADS``
+//! 
+//! Performance Considerations
+//! ++++++++++++++++++++++++++
+//!
+//! * Uses special instructions when applicable (e.g., warp ``SHFL``)
+//! * Uses synchronization-free communication between warp lanes when applicable
+//! * Incurs zero bank conflicts for most types
+//! * Computation is slightly more efficient (i.e., having lower instruction overhead) for:
+//!
+//!   * Summation (**vs.** generic scan)
+//!   * The architecture's warp size is a whole multiple of ``LOGICAL_WARP_THREADS``
+//! 
+//! Simple Examples
+//! ++++++++++++++++++++++++++
+//!
+//! @warpcollective{WarpScan}
+//!
+//! The code snippet below illustrates four concurrent warp prefix sums within a block of
+//! 128 threads (one per each of the 32-thread warps).
+//!
+//! .. code-block:: c++
+//!
+//!    #include <cub/cub.cuh>
+//! 
+//!    __global__ void ExampleKernel(...)
+//!    {
+//!        // Specialize WarpScan for type int
+//!        typedef cub::WarpScan<int> WarpScan;
+//! 
+//!        // Allocate WarpScan shared memory for 4 warps
+//!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+//! 
+//!        // Obtain one input item per thread
+//!        int thread_data = ...
+//! 
+//!        // Compute warp-wide prefix sums
+//!        int warp_id = threadIdx.x / 32;
+//!        WarpScan(temp_storage[warp_id]).ExclusiveSum(thread_data, thread_data);
+//! 
+//! Suppose the set of input ``thread_data`` across the block of threads is 
+//! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` in each of the four warps of
+//! threads will be ``0, 1, 2, 3, ..., 31}``.
+//! 
+//! The code snippet below illustrates a single warp prefix sum within a block of
+//! 128 threads.
+//!
+//! .. code-block:: c++
+//!
+//!    #include <cub/cub.cuh>
+//! 
+//!    __global__ void ExampleKernel(...)
+//!    {
+//!        // Specialize WarpScan for type int
+//!        typedef cub::WarpScan<int> WarpScan;
+//! 
+//!        // Allocate WarpScan shared memory for one warp
+//!        __shared__ typename WarpScan::TempStorage temp_storage;
+//!        ...
+//! 
+//!        // Only the first warp performs a prefix sum
+//!        if (threadIdx.x < 32)
+//!        {
+//!            // Obtain one input item per thread
+//!            int thread_data = ...
+//! 
+//!            // Compute warp-wide prefix sums
+//!            WarpScan(temp_storage).ExclusiveSum(thread_data, thread_data);
+//! 
+//! Suppose the set of input ``thread_data`` across the warp of threads is 
+//! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` will be 
+//! ``{0, 1, 2, 3, ..., 31}``.
+//! @endrst
+//! 
+//! @tparam T
+//!   The scan input/output element type
+//!
+//! @tparam LOGICAL_WARP_THREADS     
+//!   **[optional]** The number of threads per "logical" warp (may be less than the number of 
+//!   hardware warp threads). Default is the warp size associated with the CUDA Compute Capability
+//!   targeted by the compiler (e.g., 32 threads for SM20).
+//!
+//! @tparam LEGACY_PTX_ARCH          
+//!   **[optional]** Unused.
+template <typename T, int LOGICAL_WARP_THREADS = CUB_PTX_WARP_THREADS, int LEGACY_PTX_ARCH = 0>
 class WarpScan
 {
 private:
@@ -166,7 +175,7 @@ private:
       WarpScanSmem<T, LOGICAL_WARP_THREADS>>;
 
     /// Shared memory storage layout type for WarpScan
-    typedef typename InternalWarpScan::TempStorage _TempStorage;
+    using _TempStorage = typename InternalWarpScan::TempStorage;
 
 
     /******************************************************************************
@@ -185,427 +194,479 @@ private:
 
 public:
 
-    /// \smemstorage{WarpScan}
+    /// @smemstorage{WarpScan}
     struct TempStorage : Uninitialized<_TempStorage> {};
 
 
-    /******************************************************************//**
-     * \name Collective constructors
-     *********************************************************************/
-    //@{
+    //! @name Collective constructors
+    //! @{
 
-    /**
-     * \brief Collective constructor using the specified memory allocation as temporary storage.  Logical warp and lane identifiers are constructed from <tt>threadIdx.x</tt>.
-     */
-    __device__ __forceinline__ WarpScan(
-        TempStorage &temp_storage)             ///< [in] Reference to memory allocation having layout type TempStorage
-    :
-        temp_storage(temp_storage.Alias()),
-        lane_id(IS_ARCH_WARP ?
-            LaneId() :
-            LaneId() % LOGICAL_WARP_THREADS)
+    //! @brief Collective constructor using the specified memory allocation as temporary storage.
+    //!        Logical warp and lane identifiers are constructed from `threadIdx.x`.
+    //!
+    //! @param[in] temp_storage
+    //!   Reference to memory allocation having layout type TempStorage
+    __device__ __forceinline__ WarpScan(TempStorage &temp_storage)
+        : temp_storage(temp_storage.Alias())
+        , lane_id(IS_ARCH_WARP ? LaneId() : LaneId() % LOGICAL_WARP_THREADS)
     {}
 
+    //! @}  end member group
+    //! @name Inclusive prefix sums
+    //! @{
 
-    //@}  end member group
-    /******************************************************************//**
-     * \name Inclusive prefix sums
-     *********************************************************************/
-    //@{
-
-
-    /**
-     * \brief Computes an inclusive prefix sum across the calling warp.
-     *
-     * \par
-     * - @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates four concurrent warp-wide inclusive prefix sums within a block of
-     * 128 threads (one per each of the 32-thread warps).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpScan for type int
-     *     typedef cub::WarpScan<int> WarpScan;
-     *
-     *     // Allocate WarpScan shared memory for 4 warps
-     *     __shared__ typename WarpScan::TempStorage temp_storage[4];
-     *
-     *     // Obtain one input item per thread
-     *     int thread_data = ...
-     *
-     *     // Compute inclusive warp-wide prefix sums
-     *     int warp_id = threadIdx.x / 32;
-     *     WarpScan(temp_storage[warp_id]).InclusiveSum(thread_data, thread_data);
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data across the block of threads is <tt>{1, 1, 1, 1, ...}</tt>.
-     * The corresponding output \p thread_data in each of the four warps of threads will be
-     * <tt>1, 2, 3, ..., 32}</tt>.
-     */
-    __device__ __forceinline__ void InclusiveSum(
-        T               input,              ///< [in] Calling thread's input item.
-        T               &inclusive_output)  ///< [out] Calling thread's output item.  May be aliased with \p input.
+    //! @rst
+    //! Computes an inclusive prefix sum across the calling warp.
+    //!
+    //! * @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates four concurrent warp-wide inclusive prefix sums within a
+    //! block of 128 threads (one per each of the 32-thread warps).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpScan for type int
+    //!        typedef cub::WarpScan<int> WarpScan;
+    //!
+    //!        // Allocate WarpScan shared memory for 4 warps
+    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+    //!
+    //!        // Obtain one input item per thread
+    //!        int thread_data = ...
+    //!
+    //!        // Compute inclusive warp-wide prefix sums
+    //!        int warp_id = threadIdx.x / 32;
+    //!        WarpScan(temp_storage[warp_id]).InclusiveSum(thread_data, thread_data);
+    //!
+    //! Suppose the set of input ``thread_data`` across the block of threads is 
+    //! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` in each of the four warps 
+    //! of threads will be ``1, 2, 3, ..., 32}``.
+    //! @endrst
+    //!
+    //! @param[in] input
+    //!   Calling thread's input item.
+    //!
+    //! @param[out] inclusive_output
+    //!   Calling thread's output item. May be aliased with `input`.
+    __device__ __forceinline__ void InclusiveSum(T input, T &inclusive_output)
     {
-        InclusiveScan(input, inclusive_output, cub::Sum());
+      InclusiveScan(input, inclusive_output, cub::Sum());
     }
 
-
-    /**
-     * \brief Computes an inclusive prefix sum across the calling warp.  Also provides every thread with the warp-wide \p warp_aggregate of all inputs.
-     *
-     * \par
-     * - @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates four concurrent warp-wide inclusive prefix sums within a block of
-     * 128 threads (one per each of the 32-thread warps).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpScan for type int
-     *     typedef cub::WarpScan<int> WarpScan;
-     *
-     *     // Allocate WarpScan shared memory for 4 warps
-     *     __shared__ typename WarpScan::TempStorage temp_storage[4];
-     *
-     *     // Obtain one input item per thread
-     *     int thread_data = ...
-     *
-     *     // Compute inclusive warp-wide prefix sums
-     *     int warp_aggregate;
-     *     int warp_id = threadIdx.x / 32;
-     *     WarpScan(temp_storage[warp_id]).InclusiveSum(thread_data, thread_data, warp_aggregate);
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data across the block of threads is <tt>{1, 1, 1, 1, ...}</tt>.
-     * The corresponding output \p thread_data in each of the four warps of threads will be
-     * <tt>1, 2, 3, ..., 32}</tt>.  Furthermore, \p warp_aggregate for all threads in all warps will be \p 32.
-     */
-    __device__ __forceinline__ void InclusiveSum(
-        T               input,              ///< [in] Calling thread's input item.
-        T               &inclusive_output,  ///< [out] Calling thread's output item.  May be aliased with \p input.
-        T               &warp_aggregate)    ///< [out] Warp-wide aggregate reduction of input items.
+    //! @rst
+    //! Computes an inclusive prefix sum across the calling warp.  
+    //! Also provides every thread with the warp-wide ``warp_aggregate`` of all inputs.
+    //!
+    //! * @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates four concurrent warp-wide inclusive prefix sums within a
+    //! block of 128 threads (one per each of the 32-thread warps).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpScan for type int
+    //!        typedef cub::WarpScan<int> WarpScan;
+    //!
+    //!        // Allocate WarpScan shared memory for 4 warps
+    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+    //!
+    //!        // Obtain one input item per thread
+    //!        int thread_data = ...
+    //!
+    //!        // Compute inclusive warp-wide prefix sums
+    //!        int warp_aggregate;
+    //!        int warp_id = threadIdx.x / 32;
+    //!        WarpScan(temp_storage[warp_id]).InclusiveSum(thread_data, 
+    //!                                                     thread_data, 
+    //!                                                     warp_aggregate);
+    //!
+    //! Suppose the set of input ``thread_data`` across the block of threads is 
+    //! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` in each of the four warps 
+    //! of threads will be ``1, 2, 3, ..., 32}``. Furthermore, ``warp_aggregate`` for all threads 
+    //! in all warps will be ``32``.
+    //! @endrst
+    //!
+    //! @param[in] input
+    //!   Calling thread's input item
+    //!
+    //! @param[out] inclusive_output
+    //!   Calling thread's output item. May be aliased with `input`
+    //!
+    //! @param[out] warp_aggregate
+    //!   Warp-wide aggregate reduction of input items
+    __device__ __forceinline__ void InclusiveSum(T input, T &inclusive_output, T &warp_aggregate)
     {
-        InclusiveScan(input, inclusive_output, cub::Sum(), warp_aggregate);
+      InclusiveScan(input, inclusive_output, cub::Sum(), warp_aggregate);
     }
 
-
-    //@}  end member group
-    /******************************************************************//**
-     * \name Exclusive prefix sums
-     *********************************************************************/
-    //@{
-
-
-    /**
-     * \brief Computes an exclusive prefix sum across the calling warp.  The value of 0 is applied as the initial value, and is assigned to \p exclusive_output in <em>thread</em><sub>0</sub>.
-     *
-     * \par
-     *  - \identityzero
-     * - @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates four concurrent warp-wide exclusive prefix sums within a block of
-     * 128 threads (one per each of the 32-thread warps).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpScan for type int
-     *     typedef cub::WarpScan<int> WarpScan;
-     *
-     *     // Allocate WarpScan shared memory for 4 warps
-     *     __shared__ typename WarpScan::TempStorage temp_storage[4];
-     *
-     *     // Obtain one input item per thread
-     *     int thread_data = ...
-     *
-     *     // Compute exclusive warp-wide prefix sums
-     *     int warp_id = threadIdx.x / 32;
-     *     WarpScan(temp_storage[warp_id]).ExclusiveSum(thread_data, thread_data);
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data across the block of threads is <tt>{1, 1, 1, 1, ...}</tt>.
-     * The corresponding output \p thread_data in each of the four warps of threads will be
-     * <tt>0, 1, 2, ..., 31}</tt>.
-     *
-     */
-    __device__ __forceinline__ void ExclusiveSum(
-        T               input,              ///< [in] Calling thread's input item.
-        T               &exclusive_output)  ///< [out] Calling thread's output item.  May be aliased with \p input.
+    //! @}  end member group
+    //! @name Exclusive prefix sums
+    //! @{
+    
+    //! @rst
+    //! Computes an exclusive prefix sum across the calling warp. The value of 0 is applied as the
+    //! initial value, and is assigned to ``exclusive_output`` in *lane*\ :sub:`0`.
+    //!
+    //! * @identityzero
+    //! * @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates four concurrent warp-wide exclusive prefix sums within a
+    //! block of 128 threads (one per each of the 32-thread warps).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpScan for type int
+    //!        typedef cub::WarpScan<int> WarpScan;
+    //!
+    //!        // Allocate WarpScan shared memory for 4 warps
+    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+    //!
+    //!        // Obtain one input item per thread
+    //!        int thread_data = ...
+    //!
+    //!        // Compute exclusive warp-wide prefix sums
+    //!        int warp_id = threadIdx.x / 32;
+    //!        WarpScan(temp_storage[warp_id]).ExclusiveSum(thread_data, thread_data);
+    //!
+    //! Suppose the set of input ``thread_data`` across the block of threads is 
+    //! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` in each of the four warps 
+    //! of threads will be ``0, 1, 2, ..., 31}``.
+    //! @endrst
+    //!
+    //! @param[in] input
+    //!   Calling thread's input item.
+    //!
+    //! @param[out] exclusive_output
+    //!   Calling thread's output item. May be aliased with `input`.
+    __device__ __forceinline__ void ExclusiveSum(T input, T &exclusive_output)
     {
-        T initial_value {};
-        ExclusiveScan(input, exclusive_output, initial_value, cub::Sum());
+      T initial_value{};
+      ExclusiveScan(input, exclusive_output, initial_value, cub::Sum());
     }
 
-
-    /**
-     * \brief Computes an exclusive prefix sum across the calling warp.  The value of 0 is applied as the initial value, and is assigned to \p exclusive_output in <em>thread</em><sub>0</sub>.  Also provides every thread with the warp-wide \p warp_aggregate of all inputs.
-     *
-     * \par
-     *  - \identityzero
-     * - @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates four concurrent warp-wide exclusive prefix sums within a block of
-     * 128 threads (one per each of the 32-thread warps).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpScan for type int
-     *     typedef cub::WarpScan<int> WarpScan;
-     *
-     *     // Allocate WarpScan shared memory for 4 warps
-     *     __shared__ typename WarpScan::TempStorage temp_storage[4];
-     *
-     *     // Obtain one input item per thread
-     *     int thread_data = ...
-     *
-     *     // Compute exclusive warp-wide prefix sums
-     *     int warp_aggregate;
-     *     int warp_id = threadIdx.x / 32;
-     *     WarpScan(temp_storage[warp_id]).ExclusiveSum(thread_data, thread_data, warp_aggregate);
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data across the block of threads is <tt>{1, 1, 1, 1, ...}</tt>.
-     * The corresponding output \p thread_data in each of the four warps of threads will be
-     * <tt>0, 1, 2, ..., 31}</tt>.  Furthermore, \p warp_aggregate for all threads in all warps will be \p 32.
-     */
-    __device__ __forceinline__ void ExclusiveSum(
-        T               input,              ///< [in] Calling thread's input item.
-        T               &exclusive_output,  ///< [out] Calling thread's output item.  May be aliased with \p input.
-        T               &warp_aggregate)    ///< [out] Warp-wide aggregate reduction of input items.
+    //! @rst
+    //! Computes an exclusive prefix sum across the calling warp. The value of 0 is applied as the
+    //! initial value, and is assigned to ``exclusive_output`` in *lane*\ :sub:`0`.  
+    //! Also provides every thread with the warp-wide ``warp_aggregate`` of all inputs.
+    //!
+    //! * @identityzero
+    //! * @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates four concurrent warp-wide exclusive prefix sums within a
+    //! block of 128 threads (one per each of the 32-thread warps).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpScan for type int
+    //!        typedef cub::WarpScan<int> WarpScan;
+    //!
+    //!        // Allocate WarpScan shared memory for 4 warps
+    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+    //!
+    //!        // Obtain one input item per thread
+    //!        int thread_data = ...
+    //!
+    //!        // Compute exclusive warp-wide prefix sums
+    //!        int warp_aggregate;
+    //!        int warp_id = threadIdx.x / 32;
+    //!        WarpScan(temp_storage[warp_id]).ExclusiveSum(thread_data, 
+    //!                                                     thread_data, 
+    //!                                                     warp_aggregate);
+    //!
+    //! Suppose the set of input ``thread_data`` across the block of threads is 
+    //! ``{1, 1, 1, 1, ...}``. The corresponding output ``thread_data`` in each of the four warps 
+    //! of threads will be ``0, 1, 2, ..., 31}``. Furthermore, ``warp_aggregate`` for all threads 
+    //! in all warps will be ``32``.
+    //! @endrst
+    //!
+    //! 
+    //! @param[in] input
+    //!   Calling thread's input item
+    //!
+    //! @param[out] exclusive_output
+    //!   Calling thread's output item. May be aliased with `input`
+    //!
+    //! @param[out] warp_aggregate    
+    //!   Warp-wide aggregate reduction of input items
+    __device__ __forceinline__ void ExclusiveSum(T input, T &exclusive_output, T &warp_aggregate)
     {
-        T initial_value {};
-        ExclusiveScan(input, exclusive_output, initial_value, cub::Sum(), warp_aggregate);
+      T initial_value{};
+      ExclusiveScan(input, exclusive_output, initial_value, cub::Sum(), warp_aggregate);
     }
 
+    //! @}  end member group
+    //! @name Inclusive prefix scans
+    //! @{
 
-    //@}  end member group
-    /******************************************************************//**
-     * \name Inclusive prefix scans
-     *********************************************************************/
-    //@{
-
-    /**
-     * \brief Computes an inclusive prefix scan using the specified binary scan functor across the calling warp.
-     *
-     * \par
-     * - @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates four concurrent warp-wide inclusive prefix max scans within a block of
-     * 128 threads (one per each of the 32-thread warps).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpScan for type int
-     *     typedef cub::WarpScan<int> WarpScan;
-     *
-     *     // Allocate WarpScan shared memory for 4 warps
-     *     __shared__ typename WarpScan::TempStorage temp_storage[4];
-     *
-     *     // Obtain one input item per thread
-     *     int thread_data = ...
-     *
-     *     // Compute inclusive warp-wide prefix max scans
-     *     int warp_id = threadIdx.x / 32;
-     *     WarpScan(temp_storage[warp_id]).InclusiveScan(thread_data, thread_data, cub::Max());
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data across the block of threads is <tt>{0, -1, 2, -3, ..., 126, -127}</tt>.
-     * The corresponding output \p thread_data in the first warp would be
-     * <tt>0, 0, 2, 2, ..., 30, 30</tt>, the output for the second warp would be <tt>32, 32, 34, 34, ..., 62, 62</tt>, etc.
-     *
-     * \tparam ScanOp     <b>[inferred]</b> Binary scan operator type having member <tt>T operator()(const T &a, const T &b)</tt>
-     */
+    //! @rst
+    //! Computes an inclusive prefix scan using the specified binary scan functor across the 
+    //! calling warp.
+    //!
+    //! * @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates four concurrent warp-wide inclusive prefix max scans 
+    //! within a block of 128 threads (one per each of the 32-thread warps).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpScan for type int
+    //!        typedef cub::WarpScan<int> WarpScan;
+    //!
+    //!        // Allocate WarpScan shared memory for 4 warps
+    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+    //!
+    //!        // Obtain one input item per thread
+    //!        int thread_data = ...
+    //!
+    //!        // Compute inclusive warp-wide prefix max scans
+    //!        int warp_id = threadIdx.x / 32;
+    //!        WarpScan(temp_storage[warp_id]).InclusiveScan(thread_data, thread_data, cub::Max());
+    //!
+    //! Suppose the set of input ``thread_data`` across the block of threads is 
+    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first 
+    //! warp would be ``0, 0, 2, 2, ..., 30, 30``, the output for the second warp would be 
+    //! ``32, 32, 34, 34, ..., 62, 62``, etc.
+    //! @endrst
+    //!
+    //! @tparam ScanOp     
+    //!   **[inferred]** Binary scan operator type having member 
+    //!   `T operator()(const T &a, const T &b)`
+    //!
+    //! @param[in] input
+    //!   Calling thread's input item
+    //!
+    //! @param[out] inclusive_output
+    //!   Calling thread's output item. May be aliased with `input`
+    //!
+    //! @param[in] can_op
+    //!   Binary scan operator
     template <typename ScanOp>
-    __device__ __forceinline__ void InclusiveScan(
-        T               input,              ///< [in] Calling thread's input item.
-        T               &inclusive_output,  ///< [out] Calling thread's output item.  May be aliased with \p input.
-        ScanOp          scan_op)            ///< [in] Binary scan operator
+    __device__ __forceinline__ void InclusiveScan(T input, T &inclusive_output, ScanOp scan_op)
     {
-        InternalWarpScan(temp_storage).InclusiveScan(input, inclusive_output, scan_op);
+      InternalWarpScan(temp_storage).InclusiveScan(input, inclusive_output, scan_op);
     }
 
-
-    /**
-     * \brief Computes an inclusive prefix scan using the specified binary scan functor across the calling warp.  Also provides every thread with the warp-wide \p warp_aggregate of all inputs.
-     *
-     * \par
-     * - @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates four concurrent warp-wide inclusive prefix max scans within a block of
-     * 128 threads (one per each of the 32-thread warps).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpScan for type int
-     *     typedef cub::WarpScan<int> WarpScan;
-     *
-     *     // Allocate WarpScan shared memory for 4 warps
-     *     __shared__ typename WarpScan::TempStorage temp_storage[4];
-     *
-     *     // Obtain one input item per thread
-     *     int thread_data = ...
-     *
-     *     // Compute inclusive warp-wide prefix max scans
-     *     int warp_aggregate;
-     *     int warp_id = threadIdx.x / 32;
-     *     WarpScan(temp_storage[warp_id]).InclusiveScan(
-     *         thread_data, thread_data, cub::Max(), warp_aggregate);
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data across the block of threads is <tt>{0, -1, 2, -3, ..., 126, -127}</tt>.
-     * The corresponding output \p thread_data in the first warp would be
-     * <tt>0, 0, 2, 2, ..., 30, 30</tt>, the output for the second warp would be <tt>32, 32, 34, 34, ..., 62, 62</tt>, etc.
-     * Furthermore, \p warp_aggregate would be assigned \p 30 for threads in the first warp, \p 62 for threads
-     * in the second warp, etc.
-     *
-     * \tparam ScanOp     <b>[inferred]</b> Binary scan operator type having member <tt>T operator()(const T &a, const T &b)</tt>
-     */
+    //! @rst
+    //! Computes an inclusive prefix scan using the specified binary scan functor across the 
+    //! calling warp. Also provides every thread with the warp-wide ``warp_aggregate`` of 
+    //! all inputs.
+    //!
+    //! * @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates four concurrent warp-wide inclusive prefix max scans 
+    //! within a block of 128 threads (one per each of the 32-thread warps).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpScan for type int
+    //!        typedef cub::WarpScan<int> WarpScan;
+    //!
+    //!        // Allocate WarpScan shared memory for 4 warps
+    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+    //!
+    //!        // Obtain one input item per thread
+    //!        int thread_data = ...
+    //!
+    //!        // Compute inclusive warp-wide prefix max scans
+    //!        int warp_aggregate;
+    //!        int warp_id = threadIdx.x / 32;
+    //!        WarpScan(temp_storage[warp_id]).InclusiveScan(
+    //!            thread_data, thread_data, cub::Max(), warp_aggregate);
+    //!
+    //! Suppose the set of input ``thread_data`` across the block of threads is 
+    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first 
+    //! warp would be ``0, 0, 2, 2, ..., 30, 30``, the output for the second warp would be 
+    //! ``32, 32, 34, 34, ..., 62, 62``, etc.  Furthermore, ``warp_aggregate`` would be assigned 
+    //! ``30`` for threads in the first warp, ``62`` for threads in the second warp, etc.
+    //! @endrst
+    //!
+    //! @tparam ScanOp     
+    //!   **[inferred]** Binary scan operator type having member 
+    //!   `T operator()(const T &a, const T &b)`
+    //! @param[in] input
+    //!   Calling thread's input item
+    //!
+    //! @param[out] inclusive_output
+    //!   Calling thread's output item. May be aliased with ``input``
+    //!
+    //! @param[in] scan_op
+    //!   Binary scan operator
+    //!
+    //! @param[out] warp_aggregate    
+    //!   Warp-wide aggregate reduction of input items.
     template <typename ScanOp>
-    __device__ __forceinline__ void InclusiveScan(
-        T               input,              ///< [in] Calling thread's input item.
-        T               &inclusive_output,  ///< [out] Calling thread's output item.  May be aliased with \p input.
-        ScanOp          scan_op,            ///< [in] Binary scan operator
-        T               &warp_aggregate)    ///< [out] Warp-wide aggregate reduction of input items.
+    __device__ __forceinline__ void
+    InclusiveScan(T input, T &inclusive_output, ScanOp scan_op, T &warp_aggregate)
     {
-        InternalWarpScan(temp_storage).InclusiveScan(input, inclusive_output, scan_op, warp_aggregate);
+      InternalWarpScan(temp_storage).InclusiveScan(input, inclusive_output, scan_op, warp_aggregate);
     }
 
+    //! @}  end member group
+    //! @name Exclusive prefix scans
+    //! @{
 
-    //@}  end member group
-    /******************************************************************//**
-     * \name Exclusive prefix scans
-     *********************************************************************/
-    //@{
-
-    /**
-     * \brief Computes an exclusive prefix scan using the specified binary scan functor across the calling warp.  Because no initial value is supplied, the \p output computed for <em>warp-lane</em><sub>0</sub> is undefined.
-     *
-     * \par
-     * - @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans within a block of
-     * 128 threads (one per each of the 32-thread warps).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpScan for type int
-     *     typedef cub::WarpScan<int> WarpScan;
-     *
-     *     // Allocate WarpScan shared memory for 4 warps
-     *     __shared__ typename WarpScan::TempStorage temp_storage[4];
-     *
-     *     // Obtain one input item per thread
-     *     int thread_data = ...
-     *
-     *     // Compute exclusive warp-wide prefix max scans
-     *     int warp_id = threadIdx.x / 32;
-     *     WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data, thread_data, cub::Max());
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data across the block of threads is <tt>{0, -1, 2, -3, ..., 126, -127}</tt>.
-     * The corresponding output \p thread_data in the first warp would be
-     * <tt>?, 0, 0, 2, ..., 28, 30</tt>, the output for the second warp would be <tt>?, 32, 32, 34, ..., 60, 62</tt>, etc.
-     * (The output \p thread_data in warp lane<sub>0</sub> is undefined.)
-     *
-     * \tparam ScanOp     <b>[inferred]</b> Binary scan operator type having member <tt>T operator()(const T &a, const T &b)</tt>
-     */
+    //! @rst
+    //! Computes an exclusive prefix scan using the specified binary scan functor across the 
+    //! calling warp. Because no initial value is supplied, the ``output`` computed for 
+    //! *lane*\ :sub:`0` is undefined.
+    //!
+    //! * @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans 
+    //! within a block of 128 threads (one per each of the 32-thread warps).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpScan for type int
+    //!        typedef cub::WarpScan<int> WarpScan;
+    //!
+    //!        // Allocate WarpScan shared memory for 4 warps
+    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+    //!
+    //!        // Obtain one input item per thread
+    //!        int thread_data = ...
+    //!
+    //!        // Compute exclusive warp-wide prefix max scans
+    //!        int warp_id = threadIdx.x / 32;
+    //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data, thread_data, cub::Max());
+    //!
+    //! Suppose the set of input ``thread_data`` across the block of threads is 
+    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first 
+    //! warp would be ``?, 0, 0, 2, ..., 28, 30``, the output for the second warp would be 
+    //! ``?, 32, 32, 34, ..., 60, 62``, etc.
+    //! (The output ``thread_data`` in warp *lane*\ :sub:`0` is undefined.)
+    //! @endrst
+    //!
+    //! @tparam ScanOp     
+    //!   **[inferred]** Binary scan operator type having member 
+    //!   `T operator()(const T &a, const T &b)`
+    //!
+    //! @param[in] input
+    //!   Calling thread's input item
+    //!
+    //! @param[out] exclusive_output
+    //!   Calling thread's output item. May be aliased with `input`
+    //!
+    //! @param[in] scan_op
+    //!   Binary scan operator
     template <typename ScanOp>
-    __device__ __forceinline__ void ExclusiveScan(
-        T               input,              ///< [in] Calling thread's input item.
-        T               &exclusive_output,  ///< [out] Calling thread's output item.  May be aliased with \p input.
-        ScanOp          scan_op)            ///< [in] Binary scan operator
+    __device__ __forceinline__ void ExclusiveScan(T input, T &exclusive_output, ScanOp scan_op)
     {
-        InternalWarpScan internal(temp_storage);
+      InternalWarpScan internal(temp_storage);
 
-        T inclusive_output;
-        internal.InclusiveScan(input, inclusive_output, scan_op);
+      T inclusive_output;
+      internal.InclusiveScan(input, inclusive_output, scan_op);
 
-        internal.Update(
-            input,
-            inclusive_output,
-            exclusive_output,
-            scan_op,
-            Int2Type<IS_INTEGER>());
+      internal.Update(input, inclusive_output, exclusive_output, scan_op, Int2Type<IS_INTEGER>());
     }
 
-
-    /**
-     * \brief Computes an exclusive prefix scan using the specified binary scan functor across the calling warp.
-     *
-     * \par
-     * - @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans within a block of
-     * 128 threads (one per each of the 32-thread warps).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpScan for type int
-     *     typedef cub::WarpScan<int> WarpScan;
-     *
-     *     // Allocate WarpScan shared memory for 4 warps
-     *     __shared__ typename WarpScan::TempStorage temp_storage[4];
-     *
-     *     // Obtain one input item per thread
-     *     int thread_data = ...
-     *
-     *     // Compute exclusive warp-wide prefix max scans
-     *     int warp_id = threadIdx.x / 32;
-     *     WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data, thread_data, INT_MIN, cub::Max());
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data across the block of threads is <tt>{0, -1, 2, -3, ..., 126, -127}</tt>.
-     * The corresponding output \p thread_data in the first warp would be
-     * <tt>INT_MIN, 0, 0, 2, ..., 28, 30</tt>, the output for the second warp would be <tt>30, 32, 32, 34, ..., 60, 62</tt>, etc.
-     *
-     * \tparam ScanOp     <b>[inferred]</b> Binary scan operator type having member <tt>T operator()(const T &a, const T &b)</tt>
-     */
+    //! @rst
+    //! Computes an exclusive prefix scan using the specified binary scan functor across the 
+    //! calling warp.
+    //!
+    //! * @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans 
+    //! within a block of 128 threads (one per each of the 32-thread warps).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpScan for type int
+    //!        typedef cub::WarpScan<int> WarpScan;
+    //!
+    //!        // Allocate WarpScan shared memory for 4 warps
+    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+    //!
+    //!        // Obtain one input item per thread
+    //!        int thread_data = ...
+    //!
+    //!        // Compute exclusive warp-wide prefix max scans
+    //!        int warp_id = threadIdx.x / 32;
+    //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data, 
+    //!                                                      thread_data, 
+    //!                                                      INT_MIN, 
+    //!                                                      cub::Max());
+    //!
+    //! Suppose the set of input ``thread_data`` across the block of threads is 
+    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first 
+    //! warp would be ``INT_MIN, 0, 0, 2, ..., 28, 30``, the output for the second warp would be 
+    //! ``30, 32, 32, 34, ..., 60, 62``, etc.
+    //! @endrst
+    //!
+    //! @tparam ScanOp     
+    //!   **[inferred]** Binary scan operator type having member 
+    //!   `T operator()(const T &a, const T &b)`
+    //!
+    //! @param[in] input
+    //!   Calling thread's input item
+    //!
+    //! @param[out] exclusive_output
+    //!   Calling thread's output item. May be aliased with `input`
+    //!
+    //! @param[in] initial_value
+    //!   Initial value to seed the exclusive scan
+    //!
+    //! @param[in] scan_op
+    //!   Binary scan operator
     template <typename ScanOp>
-    __device__ __forceinline__ void ExclusiveScan(
-        T               input,              ///< [in] Calling thread's input item.
-        T               &exclusive_output,  ///< [out] Calling thread's output item.  May be aliased with \p input.
-        T               initial_value,      ///< [in] Initial value to seed the exclusive scan
-        ScanOp          scan_op)            ///< [in] Binary scan operator
+    __device__ __forceinline__ void
+    ExclusiveScan(T input, T &exclusive_output, T initial_value, ScanOp scan_op)
     {
         InternalWarpScan internal(temp_storage);
 
@@ -622,51 +683,69 @@ public:
     }
 
 
-    /**
-     * \brief Computes an exclusive prefix scan using the specified binary scan functor across the calling warp.  Because no initial value is supplied, the \p output computed for <em>warp-lane</em><sub>0</sub> is undefined.  Also provides every thread with the warp-wide \p warp_aggregate of all inputs.
-     *
-     * \par
-     * - @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans within a block of
-     * 128 threads (one per each of the 32-thread warps).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpScan for type int
-     *     typedef cub::WarpScan<int> WarpScan;
-     *
-     *     // Allocate WarpScan shared memory for 4 warps
-     *     __shared__ typename WarpScan::TempStorage temp_storage[4];
-     *
-     *     // Obtain one input item per thread
-     *     int thread_data = ...
-     *
-     *     // Compute exclusive warp-wide prefix max scans
-     *     int warp_aggregate;
-     *     int warp_id = threadIdx.x / 32;
-     *     WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data, thread_data, cub::Max(), warp_aggregate);
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data across the block of threads is <tt>{0, -1, 2, -3, ..., 126, -127}</tt>.
-     * The corresponding output \p thread_data in the first warp would be
-     * <tt>?, 0, 0, 2, ..., 28, 30</tt>, the output for the second warp would be <tt>?, 32, 32, 34, ..., 60, 62</tt>, etc.
-     * (The output \p thread_data in warp lane<sub>0</sub> is undefined.)  Furthermore, \p warp_aggregate would be assigned \p 30 for threads in the first warp, \p 62 for threads
-     * in the second warp, etc.
-     *
-     * \tparam ScanOp     <b>[inferred]</b> Binary scan operator type having member <tt>T operator()(const T &a, const T &b)</tt>
-     */
+    //! @rst
+    //! Computes an exclusive prefix scan using the specified binary scan functor across the 
+    //! calling warp. Because no initial value is supplied, the ``output`` computed for 
+    //! *lane*\ :sub:`0` is undefined. Also provides every thread with the warp-wide 
+    //! ``warp_aggregate`` of all inputs.
+    //!
+    //! * @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans 
+    //! within a block of 128 threads (one per each of the 32-thread warps).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpScan for type int
+    //!        typedef cub::WarpScan<int> WarpScan;
+    //!
+    //!        // Allocate WarpScan shared memory for 4 warps
+    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+    //!
+    //!        // Obtain one input item per thread
+    //!        int thread_data = ...
+    //!
+    //!        // Compute exclusive warp-wide prefix max scans
+    //!        int warp_aggregate;
+    //!        int warp_id = threadIdx.x / 32;
+    //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data, 
+    //!                                                      thread_data, 
+    //!                                                      cub::Max(), 
+    //!                                                      warp_aggregate);
+    //!
+    //! Suppose the set of input ``thread_data`` across the block of threads is 
+    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first 
+    //! warp would be ``?, 0, 0, 2, ..., 28, 30``, the output for the second warp would be 
+    //! ``?, 32, 32, 34, ..., 60, 62``, etc. (The output ``thread_data`` in warp *lane*\ :sub:`0` 
+    //! is undefined). Furthermore, ``warp_aggregate`` would be assigned ``30`` for threads in the 
+    //! first warp, \p 62 for threads in the second warp, etc.
+    //! @endrst
+    //!
+    //! @tparam ScanOp     
+    //!   **[inferred]** Binary scan operator type having member 
+    //!   `T operator()(const T &a, const T &b)`
+    //!
+    //! @param[in] input
+    //!   Calling thread's input item
+    //!
+    //! @param[out] exclusive_output
+    //!   Calling thread's output item. May be aliased with `input`
+    //!
+    //! @param[in] scan_op
+    //!   Binary scan operator
+    //!
+    //! @param[out] warp_aggregate
+    //!   Warp-wide aggregate reduction of input items
     template <typename ScanOp>
-    __device__ __forceinline__ void ExclusiveScan(
-        T               input,              ///< [in] Calling thread's input item.
-        T               &exclusive_output,   ///< [out] Calling thread's output item.  May be aliased with \p input.
-        ScanOp          scan_op,            ///< [in] Binary scan operator
-        T               &warp_aggregate)    ///< [out] Warp-wide aggregate reduction of input items.
+    __device__ __forceinline__ void
+    ExclusiveScan(T input, T &exclusive_output, ScanOp scan_op, T &warp_aggregate)
     {
         InternalWarpScan internal(temp_storage);
 
@@ -682,53 +761,72 @@ public:
             Int2Type<IS_INTEGER>());
     }
 
-
-    /**
-     * \brief Computes an exclusive prefix scan using the specified binary scan functor across the calling warp.  Also provides every thread with the warp-wide \p warp_aggregate of all inputs.
-     *
-     * \par
-     * - @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans within a block of
-     * 128 threads (one per each of the 32-thread warps).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpScan for type int
-     *     typedef cub::WarpScan<int> WarpScan;
-     *
-     *     // Allocate WarpScan shared memory for 4 warps
-     *     __shared__ typename WarpScan::TempStorage temp_storage[4];
-     *
-     *     // Obtain one input item per thread
-     *     int thread_data = ...
-     *
-     *     // Compute exclusive warp-wide prefix max scans
-     *     int warp_aggregate;
-     *     int warp_id = threadIdx.x / 32;
-     *     WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data, thread_data, INT_MIN, cub::Max(), warp_aggregate);
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data across the block of threads is <tt>{0, -1, 2, -3, ..., 126, -127}</tt>.
-     * The corresponding output \p thread_data in the first warp would be
-     * <tt>INT_MIN, 0, 0, 2, ..., 28, 30</tt>, the output for the second warp would be <tt>30, 32, 32, 34, ..., 60, 62</tt>, etc.
-     * Furthermore, \p warp_aggregate would be assigned \p 30 for threads in the first warp, \p 62 for threads
-     * in the second warp, etc.
-     *
-     * \tparam ScanOp     <b>[inferred]</b> Binary scan operator type having member <tt>T operator()(const T &a, const T &b)</tt>
-     */
+    //! @rst
+    //! Computes an exclusive prefix scan using the specified binary scan functor across the 
+    //! calling warp. Also provides every thread with the warp-wide ``warp_aggregate`` of 
+    //! all inputs.
+    //!
+    //! * @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans 
+    //! within a block of 128 threads (one per each of the 32-thread warps).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpScan for type int
+    //!        typedef cub::WarpScan<int> WarpScan;
+    //!
+    //!        // Allocate WarpScan shared memory for 4 warps
+    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+    //!
+    //!        // Obtain one input item per thread
+    //!        int thread_data = ...
+    //!
+    //!        // Compute exclusive warp-wide prefix max scans
+    //!        int warp_aggregate;
+    //!        int warp_id = threadIdx.x / 32;
+    //!        WarpScan(temp_storage[warp_id]).ExclusiveScan(thread_data, 
+    //!                                                      thread_data, 
+    //!                                                      INT_MIN, 
+    //!                                                      cub::Max(), 
+    //!                                                      warp_aggregate);
+    //!
+    //! Suppose the set of input ``thread_data`` across the block of threads is 
+    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``thread_data`` in the first 
+    //! warp would be ``INT_MIN, 0, 0, 2, ..., 28, 30``, the output for the second warp would be
+    //! ``30, 32, 32, 34, ..., 60, 62``, etc. Furthermore, ``warp_aggregate`` would be assigned 
+    //! ``30`` for threads in the first warp, ``62`` for threads in the second warp, etc.
+    //! @endrst
+    //!
+    //! @tparam ScanOp     
+    //!   **[inferred]** Binary scan operator type having member 
+    //!   `T operator()(const T &a, const T &b)`
+    //!
+    //! @param[in] input
+    //!   Calling thread's input item
+    //!
+    //! @param[out] exclusive_output
+    //!   Calling thread's output item.  May be aliased with `input`
+    //!
+    //! @param[in] initial_value
+    //!   Initial value to seed the exclusive scan
+    //!
+    //! @param[in] scan_op
+    //!   Binary scan operator
+    //!
+    //! @param[out] warp_aggregate
+    //!   Warp-wide aggregate reduction of input items
+    //!
     template <typename ScanOp>
-    __device__ __forceinline__ void ExclusiveScan(
-        T               input,              ///< [in] Calling thread's input item.
-        T               &exclusive_output,  ///< [out] Calling thread's output item.  May be aliased with \p input.
-        T               initial_value,      ///< [in] Initial value to seed the exclusive scan
-        ScanOp          scan_op,            ///< [in] Binary scan operator
-        T               &warp_aggregate)    ///< [out] Warp-wide aggregate reduction of input items.
+    __device__ __forceinline__ void
+    ExclusiveScan(T input, T &exclusive_output, T initial_value, ScanOp scan_op, T &warp_aggregate)
     {
         InternalWarpScan internal(temp_storage);
 
@@ -746,58 +844,73 @@ public:
     }
 
 
-    //@}  end member group
-    /******************************************************************//**
-     * \name Combination (inclusive & exclusive) prefix scans
-     *********************************************************************/
-    //@{
+    //! @}  end member group
+    //! @name Combination (inclusive & exclusive) prefix scans
+    //! @{
 
 
-    /**
-     * \brief Computes both inclusive and exclusive prefix scans using the specified binary scan functor across the calling warp.  Because no initial value is supplied, the \p exclusive_output computed for <em>warp-lane</em><sub>0</sub> is undefined.
-     *
-     * \par
-     * - @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans within a block of
-     * 128 threads (one per each of the 32-thread warps).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpScan for type int
-     *     typedef cub::WarpScan<int> WarpScan;
-     *
-     *     // Allocate WarpScan shared memory for 4 warps
-     *     __shared__ typename WarpScan::TempStorage temp_storage[4];
-     *
-     *     // Obtain one input item per thread
-     *     int thread_data = ...
-     *
-     *     // Compute exclusive warp-wide prefix max scans
-     *     int inclusive_partial, exclusive_partial;
-     *     WarpScan(temp_storage[warp_id]).Scan(thread_data, inclusive_partial, exclusive_partial, cub::Max());
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data across the block of threads is <tt>{0, -1, 2, -3, ..., 126, -127}</tt>.
-     * The corresponding output \p inclusive_partial in the first warp would be
-     * <tt>0, 0, 2, 2, ..., 30, 30</tt>, the output for the second warp would be <tt>32, 32, 34, 34, ..., 62, 62</tt>, etc.
-     * The corresponding output \p exclusive_partial in the first warp would be
-     * <tt>?, 0, 0, 2, ..., 28, 30</tt>, the output for the second warp would be <tt>?, 32, 32, 34, ..., 60, 62</tt>, etc.
-     * (The output \p thread_data in warp lane<sub>0</sub> is undefined.)
-     *
-     * \tparam ScanOp     <b>[inferred]</b> Binary scan operator type having member <tt>T operator()(const T &a, const T &b)</tt>
-     */
+    //! @rst
+    //! Computes both inclusive and exclusive prefix scans using the specified binary scan functor
+    //! across the calling warp. Because no initial value is supplied, the ``exclusive_output``
+    //! computed for *lane*\ :sub:`0` is undefined.
+    //!
+    //! * @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates four concurrent warp-wide exclusive prefix max scans 
+    //! within a block of 128 threads (one per each of the 32-thread warps).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpScan for type int
+    //!        typedef cub::WarpScan<int> WarpScan;
+    //!
+    //!        // Allocate WarpScan shared memory for 4 warps
+    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+    //!
+    //!        // Obtain one input item per thread
+    //!        int thread_data = ...
+    //!
+    //!        // Compute exclusive warp-wide prefix max scans
+    //!        int inclusive_partial, exclusive_partial;
+    //!        WarpScan(temp_storage[warp_id]).Scan(thread_data, 
+    //!                                             inclusive_partial, 
+    //!                                             exclusive_partial, 
+    //!                                             cub::Max());
+    //!
+    //! Suppose the set of input ``thread_data`` across the block of threads is 
+    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``inclusive_partial`` in the 
+    //! first warp would be ``0, 0, 2, 2, ..., 30, 30``, the output for the second warp would be
+    //! ``32, 32, 34, 34, ..., 62, 62``, etc. The corresponding output ``exclusive_partial`` in the
+    //! first warp would be ``?, 0, 0, 2, ..., 28, 30``, the output for the second warp would be 
+    //! ``?, 32, 32, 34, ..., 60, 62``, etc. 
+    //! (The output ``thread_data`` in warp *lane*\ :sub:`0` is undefined.)
+    //! @endrst
+    //!
+    //! @tparam ScanOp     
+    //!   **[inferred]** Binary scan operator type having member 
+    //!   `T operator()(const T &a, const T &b)`
+    //!
+    //! @param[in] input
+    //!   Calling thread's input item
+    //!
+    //! @param[out] inclusive_output
+    //!   Calling thread's inclusive-scan output item
+    //!
+    //! @param[out] exclusive_output
+    //!   Calling thread's exclusive-scan output item
+    //!
+    //! @param[in] scan_op
+    //!   Binary scan operator
     template <typename ScanOp>
-    __device__ __forceinline__ void Scan(
-        T               input,              ///< [in] Calling thread's input item.
-        T               &inclusive_output,  ///< [out] Calling thread's inclusive-scan output item.
-        T               &exclusive_output,  ///< [out] Calling thread's exclusive-scan output item.
-        ScanOp          scan_op)            ///< [in] Binary scan operator
+    __device__ __forceinline__ void
+    Scan(T input, T &inclusive_output, T &exclusive_output, ScanOp scan_op)
     {
         InternalWarpScan internal(temp_storage);
 
@@ -812,52 +925,71 @@ public:
     }
 
 
-    /**
-     * \brief Computes both inclusive and exclusive prefix scans using the specified binary scan functor across the calling warp.
-     *
-     * \par
-     * - @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates four concurrent warp-wide prefix max scans within a block of
-     * 128 threads (one per each of the 32-thread warps).
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpScan for type int
-     *     typedef cub::WarpScan<int> WarpScan;
-     *
-     *     // Allocate WarpScan shared memory for 4 warps
-     *     __shared__ typename WarpScan::TempStorage temp_storage[4];
-     *
-     *     // Obtain one input item per thread
-     *     int thread_data = ...
-     *
-     *     // Compute inclusive warp-wide prefix max scans
-     *     int warp_id = threadIdx.x / 32;
-     *     int inclusive_partial, exclusive_partial;
-     *     WarpScan(temp_storage[warp_id]).Scan(thread_data, inclusive_partial, exclusive_partial, INT_MIN, cub::Max());
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data across the block of threads is <tt>{0, -1, 2, -3, ..., 126, -127}</tt>.
-     * The corresponding output \p inclusive_partial in the first warp would be
-     * <tt>0, 0, 2, 2, ..., 30, 30</tt>, the output for the second warp would be <tt>32, 32, 34, 34, ..., 62, 62</tt>, etc.
-     * The corresponding output \p exclusive_partial in the first warp would be
-     * <tt>INT_MIN, 0, 0, 2, ..., 28, 30</tt>, the output for the second warp would be <tt>30, 32, 32, 34, ..., 60, 62</tt>, etc.
-     *
-     * \tparam ScanOp     <b>[inferred]</b> Binary scan operator type having member <tt>T operator()(const T &a, const T &b)</tt>
-     */
+    //! @rst
+    //! Computes both inclusive and exclusive prefix scans using the specified binary scan functor
+    //! across the calling warp.
+    //!
+    //! * @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates four concurrent warp-wide prefix max scans within a 
+    //! block of 128 threads (one per each of the 32-thread warps).
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpScan for type int
+    //!        typedef cub::WarpScan<int> WarpScan;
+    //!
+    //!        // Allocate WarpScan shared memory for 4 warps
+    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+    //!
+    //!        // Obtain one input item per thread
+    //!        int thread_data = ...
+    //!
+    //!        // Compute inclusive warp-wide prefix max scans
+    //!        int warp_id = threadIdx.x / 32;
+    //!        int inclusive_partial, exclusive_partial;
+    //!        WarpScan(temp_storage[warp_id]).Scan(thread_data, 
+    //!                                             inclusive_partial, 
+    //!                                             exclusive_partial, 
+    //!                                             INT_MIN, 
+    //!                                             cub::Max());
+    //!
+    //! Suppose the set of input ``thread_data`` across the block of threads is 
+    //! ``{0, -1, 2, -3, ..., 126, -127}``. The corresponding output ``inclusive_partial`` in the 
+    //! first warp would be ``0, 0, 2, 2, ..., 30, 30``, the output for the second warp would be
+    //! ``32, 32, 34, 34, ..., 62, 62``, etc. The corresponding output ``exclusive_partial`` in the
+    //! first warp would be ``INT_MIN, 0, 0, 2, ..., 28, 30``, the output for the second warp would 
+    //! be ``30, 32, 32, 34, ..., 60, 62``, etc.
+    //! @endrst
+    //!
+    //! @tparam ScanOp     
+    //!   **[inferred]** Binary scan operator type having member 
+    //!   `T operator()(const T &a, const T &b)`
+    //!
+    //! @param[in] input 
+    //!   Calling thread's input item
+    //!
+    //! @param[out] inclusive_output 
+    //!   Calling thread's inclusive-scan output item
+    //!
+    //! @param[out] exclusive_output 
+    //!   Calling thread's exclusive-scan output item
+    //!
+    //! @param[in] initial_value
+    //!   Initial value to seed the exclusive scan
+    //!
+    //! @param[in] scan_op
+    //!   Binary scan operator
     template <typename ScanOp>
-    __device__ __forceinline__ void Scan(
-        T               input,              ///< [in] Calling thread's input item.
-        T               &inclusive_output,  ///< [out] Calling thread's inclusive-scan output item.
-        T               &exclusive_output,  ///< [out] Calling thread's exclusive-scan output item.
-        T               initial_value,      ///< [in] Initial value to seed the exclusive scan
-        ScanOp          scan_op)            ///< [in] Binary scan operator
+    __device__ __forceinline__ void
+    Scan(T input, T &inclusive_output, T &exclusive_output, T initial_value, ScanOp scan_op)
     {
         InternalWarpScan internal(temp_storage);
 
@@ -872,53 +1004,53 @@ public:
             Int2Type<IS_INTEGER>());
     }
 
+    //! @}  end member group
+    //! @name Data exchange
+    //! @{
 
-
-    //@}  end member group
-    /******************************************************************//**
-     * \name Data exchange
-     *********************************************************************/
-    //@{
-
-    /**
-     * \brief Broadcast the value \p input from <em>warp-lane</em><sub><tt>src_lane</tt></sub> to all lanes in the warp
-     *
-     * \par
-     * - @smemwarpreuse
-     *
-     * \par Snippet
-     * The code snippet below illustrates the warp-wide broadcasts of values from
-     * lanes<sub>0</sub> in each of four warps to all other threads in those warps.
-     * \par
-     * \code
-     * #include <cub/cub.cuh>
-     *
-     * __global__ void ExampleKernel(...)
-     * {
-     *     // Specialize WarpScan for type int
-     *     typedef cub::WarpScan<int> WarpScan;
-     *
-     *     // Allocate WarpScan shared memory for 4 warps
-     *     __shared__ typename WarpScan::TempStorage temp_storage[4];
-     *
-     *     // Obtain one input item per thread
-     *     int thread_data = ...
-     *
-     *     // Broadcast from lane0 in each warp to all other threads in the warp
-     *     int warp_id = threadIdx.x / 32;
-     *     thread_data = WarpScan(temp_storage[warp_id]).Broadcast(thread_data, 0);
-     *
-     * \endcode
-     * \par
-     * Suppose the set of input \p thread_data across the block of threads is <tt>{0, 1, 2, 3, ..., 127}</tt>.
-     * The corresponding output \p thread_data will be
-     * <tt>{0, 0, ..., 0}</tt> in warp<sub>0</sub>,
-     * <tt>{32, 32, ..., 32}</tt> in warp<sub>1</sub>,
-     * <tt>{64, 64, ..., 64}</tt> in warp<sub>2</sub>, etc.
-     */
-    __device__ __forceinline__ T Broadcast(
-        T               input,              ///< [in] The value to broadcast
-        unsigned int    src_lane)           ///< [in] Which warp lane is to do the broadcasting
+    //! @rst
+    //! Broadcast the value ``input`` from *lane*\ :sub:`src_lane` to all lanes in the warp
+    //!
+    //! * @smemwarpreuse
+    //!
+    //! Snippet
+    //! +++++++
+    //!
+    //! The code snippet below illustrates the warp-wide broadcasts of values from *lane*\ :sub:`0`
+    //! in each of four warps to all other threads in those warps.
+    //!
+    //! .. code-block:: c++
+    //!
+    //!    #include <cub/cub.cuh>
+    //!
+    //!    __global__ void ExampleKernel(...)
+    //!    {
+    //!        // Specialize WarpScan for type int
+    //!        typedef cub::WarpScan<int> WarpScan;
+    //!
+    //!        // Allocate WarpScan shared memory for 4 warps
+    //!        __shared__ typename WarpScan::TempStorage temp_storage[4];
+    //!
+    //!        // Obtain one input item per thread
+    //!        int thread_data = ...
+    //!
+    //!        // Broadcast from lane0 in each warp to all other threads in the warp
+    //!        int warp_id = threadIdx.x / 32;
+    //!        thread_data = WarpScan(temp_storage[warp_id]).Broadcast(thread_data, 0);
+    //!
+    //! Suppose the set of input ``thread_data`` across the block of threads is 
+    //! ``{0, 1, 2, 3, ..., 127}``. The corresponding output ``thread_data`` will be
+    //! ``{0, 0, ..., 0}`` in warp\ :sub:`0`,
+    //! ``{32, 32, ..., 32}`` in warp\ :sub:`1`,
+    //! ``{64, 64, ..., 64}`` in warp\ :sub:`2`, etc.
+    //! @endrst
+    //!
+    //! @param[in] input
+    //!   The value to broadcast
+    //!
+    //! @param[in] src_lane
+    //!   Which warp lane is to do the broadcasting
+    __device__ __forceinline__ T Broadcast(T input, unsigned int src_lane)
     {
         return InternalWarpScan(temp_storage).Broadcast(input, src_lane);
     }
@@ -926,7 +1058,5 @@ public:
     //@}  end member group
 
 };
-
-/** @} */       // end group WarpModule
 
 CUB_NAMESPACE_END

--- a/cub/warp/warp_store.cuh
+++ b/cub/warp/warp_store.cuh
@@ -25,10 +25,7 @@
  *
  ******************************************************************************/
 
-/**
- * @file
- * Operations for writing linear segments of data from the CUDA warp
- */
+//! @file Operations for writing linear segments of data from the CUDA warp
 
 #pragma once
 
@@ -45,161 +42,183 @@
 CUB_NAMESPACE_BEGIN
 
 
-/**
- * @brief cub::WarpStoreAlgorithm enumerates alternative algorithms for
- *        cub::WarpStore to write a blocked arrangement of items across a CUDA
- *        warp to a linear segment of memory.
- */
+//! @rst
+//! ``cub::WarpStoreAlgorithm`` enumerates alternative algorithms for :cpp:struct:`cub::WarpStore` 
+//! to write a blocked arrangement of items across a CUDA warp to a linear segment of memory.
+//! @endrst
 enum WarpStoreAlgorithm
 {
-  /**
-   * @par Overview
-   * A [<em>blocked arrangement</em>](index.html#sec5sec3) of data is written
-   * directly to memory.
-   *
-   * @par Performance Considerations
-   * The utilization of memory transactions (coalescing) decreases as the
-   * access stride between threads increases (i.e., the number items per thread).
-   */
+  //! @rst
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //!
+  //! A :ref:`blocked arrangement <flexible-data-arrangement>` of data is written directly 
+  //! to memory.
+  //!
+  //! Performance Considerations
+  //! ++++++++++++++++++++++++++
+  //!
+  //! The utilization of memory transactions (coalescing) decreases as the
+  //! access stride between threads increases (i.e., the number items per thread).
+  //! @endrst
   WARP_STORE_DIRECT,
 
-  /**
-   * @par Overview
-   * A [<em>striped arrangement</em>](index.html#sec5sec3) of data is written
-   * directly to memory.
-   *
-   * @par Performance Considerations
-   * The utilization of memory transactions (coalescing) remains high regardless
-   * of items written per thread.
-   */
+  //! @rst
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //!
+  //! A :ref:`striped arrangement <flexible-data-arrangement>` of data is written
+  //! directly to memory.
+  //!
+  //! Performance Considerations
+  //! ++++++++++++++++++++++++++
+  //!
+  //! The utilization of memory transactions (coalescing) remains high regardless
+  //! of items written per thread.
+  //! @endrst
   WARP_STORE_STRIPED,
 
-  /**
-   * @par Overview
-   *
-   * A [<em>blocked arrangement</em>](index.html#sec5sec3) of data is written
-   * directly to memory using CUDA's built-in vectorized stores as a coalescing
-   * optimization. For example, <tt>st.global.v4.s32</tt> instructions will be
-   * generated when @p T = @p int and @p ITEMS_PER_THREAD % 4 == 0.
-   *
-   * @par Performance Considerations
-   * - The utilization of memory transactions (coalescing) remains high until
-   *   the the access stride between threads (i.e., the number items per thread)
-   *   exceeds the maximum vector store width (typically 4 items or 64B,
-   *   whichever is lower).
-   * - The following conditions will prevent vectorization and writing will fall
-   *   back to cub::WARP_STORE_DIRECT:
-   *   - @p ITEMS_PER_THREAD is odd
-   *   - The @p OutputIteratorT is not a simple pointer type
-   *   - The block output offset is not quadword-aligned
-   *   - The data type @p T is not a built-in primitive or CUDA vector type
-   *     (e.g., @p short, @p int2, @p double, @p float2, etc.)
-   */
+  //! @rst
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //! 
+  //! A :ref:`blocked arrangement <flexible-data-arrangement>` of data is written
+  //! directly to memory using CUDA's built-in vectorized stores as a coalescing
+  //! optimization. For example, ``st.global.v4.s32`` instructions will be
+  //! generated when ``T = int`` and ``ITEMS_PER_THREAD % 4 == 0``.
+  //! 
+  //! Performance Considerations
+  //! ++++++++++++++++++++++++++
+  //! 
+  //! * The utilization of memory transactions (coalescing) remains high until
+  //!   the the access stride between threads (i.e., the number items per thread)
+  //!   exceeds the maximum vector store width (typically 4 items or 64B,
+  //!   whichever is lower).
+  //! * The following conditions will prevent vectorization and writing will fall
+  //!   back to ``cub::WARP_STORE_DIRECT``:
+  //!
+  //!   * ``ITEMS_PER_THREAD`` is odd
+  //!   * The ``OutputIteratorT`` is not a simple pointer type
+  //!   * The block output offset is not quadword-aligned
+  //!   * The data type ``T`` is not a built-in primitive or CUDA vector type
+  //!     (e.g., ``short``, ``int2``, ``double``, ``float2``, etc.)
+  //!
+  //! @endrst
   WARP_STORE_VECTORIZE,
 
-  /**
-   * @par Overview
-   * A [<em>blocked arrangement</em>](index.html#sec5sec3) is locally
-   * transposed and then efficiently written to memory as a
-   * [<em>striped arrangement</em>](index.html#sec5sec3).
-   *
-   * @par Performance Considerations
-   * - The utilization of memory transactions (coalescing) remains high
-   *   regardless of items written per thread.
-   * - The local reordering incurs slightly longer latencies and throughput than the
-   *   direct cub::WARP_STORE_DIRECT and cub::WARP_STORE_VECTORIZE alternatives.
-   */
+  //! @rst
+  //! Overview
+  //! ++++++++++++++++++++++++++
+  //!
+  //! A :ref:`blocked arrangement <flexible-data-arrangement>` is locally
+  //! transposed and then efficiently written to memory as a
+  //! :ref:`striped arrangement <flexible-data-arrangement>`.
+  //!  
+  //! Performance Considerations
+  //! ++++++++++++++++++++++++++
+  //!
+  //! * The utilization of memory transactions (coalescing) remains high
+  //!   regardless of items written per thread.
+  //! * The local reordering incurs slightly longer latencies and throughput than the
+  //!   direct ``cub::WARP_STORE_DIRECT`` and ``cub::WARP_STORE_VECTORIZE`` alternatives.
+  //!  
+  //! @endrst
   WARP_STORE_TRANSPOSE
 };
 
 
-/**
- * @brief The WarpStore class provides [<em>collective</em>](index.html#sec0)
- *        data movement methods for writing a [<em>blocked arrangement</em>](index.html#sec5sec3)
- *        of items partitioned across a CUDA warp to a linear segment of memory.
- * @ingroup WarpModule
- * @ingroup UtilIo
- *
- * @tparam T
- *   The type of data to be written.
- *
- * @tparam ITEMS_PER_THREAD
- *   The number of consecutive items partitioned onto each thread.
- *
- * @tparam ALGORITHM
- *   <b>[optional]</b> cub::WarpStoreAlgorithm tuning policy enumeration.
- *   default: cub::WARP_STORE_DIRECT.
- *
- * @tparam LOGICAL_WARP_THREADS
- *   <b>[optional]</b> The number of threads per "logical" warp (may be less
- *   than the number of hardware warp threads). Default is the warp size of the
- *   targeted CUDA compute-capability (e.g., 32 threads for SM86). Must be a
- *   power of two.
- *
- * @tparam LEGACY_PTX_ARCH
- *   Unused.
- *
- * @par Overview
- * - The WarpStore class provides a single data movement abstraction that can be
- *   specialized to implement different cub::WarpStoreAlgorithm strategies. This
- *   facilitates different performance policies for different architectures,
- *   data types, granularity sizes, etc.
- * - WarpStore can be optionally specialized by different data movement strategies:
- *   -# <b>cub::WARP_STORE_DIRECT</b>. A [<em>blocked arrangement</em>](index.html#sec5sec3)
- *      of data is written directly to memory. [More...](@ref cub::WarpStoreAlgorithm)
- *   -# <b>cub::WARP_STORE_STRIPED</b>. A [<em>striped arrangement</em>](index.html#sec5sec3)
- *      of data is written directly to memory. [More...](@ref cub::WarpStoreAlgorithm)
- *   -# <b>cub::WARP_STORE_VECTORIZE</b>. A [<em>blocked arrangement</em>](index.html#sec5sec3)
- *      of data is written directly to memory using CUDA's built-in vectorized
- *      stores as a coalescing optimization. [More...](@ref cub::WarpStoreAlgorithm)
- *   -# <b>cub::WARP_STORE_TRANSPOSE</b>. A [<em>blocked arrangement</em>](index.html#sec5sec3)
- *      is locally transposed into a [<em>striped arrangement</em>](index.html#sec5sec3)
- *      which is then written to memory. [More...](@ref cub::WarpStoreAlgorithm)
- * - \rowmajor
- *
- * @par A Simple Example
- * @par
- * The code snippet below illustrates the storing of a "blocked" arrangement
- * of 64 integers across 16 threads (where each thread owns 4 consecutive items)
- * into a linear segment of memory. The store is specialized for
- * @p WARP_STORE_TRANSPOSE, meaning items are locally reordered among threads so
- * that memory references will be efficiently coalesced using a warp-striped
- * access pattern.
- * @par
- * @code
- * #include <cub/cub.cuh>   // or equivalently <cub/warp/warp_store.cuh>
- *
- * __global__ void ExampleKernel(int *d_data, ...)
- * {
- *     constexpr int warp_threads = 16;
- *     constexpr int block_threads = 256;
- *     constexpr int items_per_thread = 4;
- *
- *     // Specialize WarpStore for a virtual warp of 16 threads owning 4 integer items each
- *     using WarpStoreT = WarpStore<int,
- *                                  items_per_thread,
- *                                  cub::WARP_STORE_TRANSPOSE,
- *                                  warp_threads>;
- *
- *     constexpr int warps_in_block = block_threads / warp_threads;
- *     constexpr int tile_size = items_per_thread * warp_threads;
- *     const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
- *
- *     // Allocate shared memory for WarpStore
- *     __shared__ typename WarpStoreT::TempStorage temp_storage[warps_in_block];
- *
- *     // Obtain a segment of consecutive items that are blocked across threads
- *     int thread_data[4];
- *     ...
- *
- *     // Store items to linear memory
- *     WarpStoreT(temp_storage[warp_id]).Store(d_data + warp_id * tile_size, thread_data);
- * @endcode
- * @par
- * Suppose the set of @p thread_data across the warp threads is
- * <tt>{ [0,1,2,3], [4,5,6,7], ..., [60,61,62,63] }</tt>.
- * The output @p d_data will be <tt>0, 1, 2, 3, 4, 5, ...</tt>.
- */
+//! @rst
+//! The WarpStore class provides :ref:`collective <collective-primitives>` 
+//! data movement methods for writing a :ref:`blocked arrangement <flexible-data-arrangement>`
+//! of items partitioned across a CUDA warp to a linear segment of memory.
+//! 
+//! Overview
+//! ++++++++++++++++
+//!
+//! * The WarpStore class provides a single data movement abstraction that can be
+//!   specialized to implement different cub::WarpStoreAlgorithm strategies. This
+//!   facilitates different performance policies for different architectures,
+//!   data types, granularity sizes, etc.
+//! * WarpStore can be optionally specialized by different data movement strategies:
+//!
+//!   #. :cpp:enumerator:`cub::WARP_STORE_DIRECT`: 
+//!      a :ref:`blocked arrangement <flexible-data-arrangement>` of data is written directly to 
+//!      memory. 
+//!   #. :cpp:enumerator:`cub::WARP_STORE_STRIPED`: 
+//!      a :ref:`striped arrangement <flexible-data-arrangement>` of data is written directly to 
+//!      memory. 
+//!   #. :cpp:enumerator:`cub::WARP_STORE_VECTORIZE`: 
+//!      a :ref:`blocked arrangement <flexible-data-arrangement>` of data is written directly to 
+//!      memory using CUDA's built-in vectorized stores as a coalescing optimization. 
+//!   #. :cpp:enumerator:`cub::WARP_STORE_TRANSPOSE`: 
+//!      a :ref:`blocked arrangement <flexible-data-arrangement>` is locally transposed into a 
+//!      :ref:`striped arrangement <flexible-data-arrangement>` which is then written to memory. 
+//!
+//! * @rowmajor
+//! 
+//! A Simple Example
+//! ++++++++++++++++
+//!
+//! The code snippet below illustrates the storing of a "blocked" arrangement
+//! of 64 integers across 16 threads (where each thread owns 4 consecutive items)
+//! into a linear segment of memory. The store is specialized for
+//! ``WARP_STORE_TRANSPOSE``, meaning items are locally reordered among threads so
+//! that memory references will be efficiently coalesced using a warp-striped
+//! access pattern.
+//!
+//! .. code-block:: c++
+//!
+//!    #include <cub/cub.cuh>   // or equivalently <cub/warp/warp_store.cuh>
+//! 
+//!    __global__ void ExampleKernel(int *d_data, ...)
+//!    {
+//!        constexpr int warp_threads = 16;
+//!        constexpr int block_threads = 256;
+//!        constexpr int items_per_thread = 4;
+//! 
+//!        // Specialize WarpStore for a virtual warp of 16 threads owning 4 integer items each
+//!        using WarpStoreT = WarpStore<int,
+//!                                     items_per_thread,
+//!                                     cub::WARP_STORE_TRANSPOSE,
+//!                                     warp_threads>;
+//! 
+//!        constexpr int warps_in_block = block_threads / warp_threads;
+//!        constexpr int tile_size = items_per_thread * warp_threads;
+//!        const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
+//! 
+//!        // Allocate shared memory for WarpStore
+//!        __shared__ typename WarpStoreT::TempStorage temp_storage[warps_in_block];
+//! 
+//!        // Obtain a segment of consecutive items that are blocked across threads
+//!        int thread_data[4];
+//!        ...
+//! 
+//!        // Store items to linear memory
+//!        WarpStoreT(temp_storage[warp_id]).Store(d_data + warp_id * tile_size, thread_data);
+//!
+//! Suppose the set of ``thread_data`` across the warp threads is
+//! ``{ [0,1,2,3], [4,5,6,7], ..., [60,61,62,63] }``.
+//! The output ``d_data`` will be ``0, 1, 2, 3, 4, 5, ...``.
+//! @endrst
+//! 
+//! @tparam T
+//!   The type of data to be written.
+//! 
+//! @tparam ITEMS_PER_THREAD
+//!   The number of consecutive items partitioned onto each thread.
+//! 
+//! @tparam ALGORITHM
+//!   <b>[optional]</b> cub::WarpStoreAlgorithm tuning policy enumeration.
+//!   default: cub::WARP_STORE_DIRECT.
+//! 
+//! @tparam LOGICAL_WARP_THREADS
+//!   <b>[optional]</b> The number of threads per "logical" warp (may be less
+//!   than the number of hardware warp threads). Default is the warp size of the
+//!   targeted CUDA compute-capability (e.g., 32 threads for SM86). Must be a
+//!   power of two.
+//! 
+//! @tparam LEGACY_PTX_ARCH
+//!   Unused.
 template <typename           T,
           int                ITEMS_PER_THREAD,
           WarpStoreAlgorithm ALGORITHM            = WARP_STORE_DIRECT,
@@ -221,7 +240,7 @@ private:
   template <int DUMMY>
   struct StoreInternal<WARP_STORE_DIRECT, DUMMY>
   {
-    typedef NullType TempStorage;
+    using TempStorage = NullType;
 
     int linear_tid;
 
@@ -250,7 +269,7 @@ private:
   template <int DUMMY>
   struct StoreInternal<WARP_STORE_STRIPED, DUMMY>
   {
-    typedef NullType TempStorage;
+    using TempStorage = NullType;
 
     int linear_tid;
 
@@ -282,7 +301,7 @@ private:
   template <int DUMMY>
   struct StoreInternal<WARP_STORE_VECTORIZE, DUMMY>
   {
-    typedef NullType TempStorage;
+    using TempStorage = NullType;
 
     int linear_tid;
 
@@ -379,86 +398,79 @@ public:
 
   struct TempStorage : Uninitialized<_TempStorage> {};
 
-  /*************************************************************************//**
-   * @name Collective constructors
-   ****************************************************************************/
-  //@{
+  //! @name Collective constructors
+  //! @{
 
-  /**
-   * @brief Collective constructor using a private static allocation of shared
-   *        memory as temporary storage.
-   */
+  //! @brief Collective constructor using a private static allocation of shared
+  //!        memory as temporary storage.
   __device__ __forceinline__ WarpStore()
       : temp_storage(PrivateStorage())
       , linear_tid(IS_ARCH_WARP ? LaneId() : (LaneId() % LOGICAL_WARP_THREADS))
   {}
 
-  /**
-   * @brief Collective constructor using the specified memory allocation as
-   *        temporary storage.
-   */
+  //! @brief Collective constructor using the specified memory allocation as
+  //!        temporary storage.
   __device__ __forceinline__ WarpStore(TempStorage &temp_storage)
       : temp_storage(temp_storage.Alias())
       , linear_tid(IS_ARCH_WARP ? LaneId() : (LaneId() % LOGICAL_WARP_THREADS))
   {}
 
-  //@}  end member group
-  /*************************************************************************//**
-   * @name Data movement
-   ****************************************************************************/
-  //@{
+  //! @}  end member group
+  //! @name Data movement
+  //! @{
 
-  /**
-   * @brief Store items into a linear segment of memory.
-   *
-   * @par
-   * @smemwarpreuse
-   *
-   * @par Snippet
-   * @par
-   * The code snippet below illustrates the storing of a "blocked" arrangement
-   * of 64 integers across 16 threads (where each thread owns 4 consecutive items)
-   * into a linear segment of memory. The store is specialized for
-   * @p WARP_STORE_TRANSPOSE, meaning items are locally reordered among threads so
-   * that memory references will be efficiently coalesced using a warp-striped
-   * access pattern.
-   * @code
-   * #include <cub/cub.cuh>   // or equivalently <cub/warp/warp_store.cuh>
-   *
-   * __global__ void ExampleKernel(int *d_data, ...)
-   * {
-   *     constexpr int warp_threads = 16;
-   *     constexpr int block_threads = 256;
-   *     constexpr int items_per_thread = 4;
-   *
-   *     // Specialize WarpStore for a virtual warp of 16 threads owning 4 integer items each
-   *     using WarpStoreT = WarpStore<int,
-   *                                  items_per_thread,
-   *                                  cub::WARP_STORE_TRANSPOSE,
-   *                                  warp_threads>;
-   *
-   *     constexpr int warps_in_block = block_threads / warp_threads;
-   *     constexpr int tile_size = items_per_thread * warp_threads;
-   *     const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
-   *
-   *     // Allocate shared memory for WarpStore
-   *     __shared__ typename WarpStoreT::TempStorage temp_storage[warps_in_block];
-   *
-   *     // Obtain a segment of consecutive items that are blocked across threads
-   *     int thread_data[4];
-   *     ...
-   *
-   *     // Store items to linear memory
-   *     WarpStoreT(temp_storage[warp_id]).Store(d_data + warp_id * tile_size, thread_data);
-   * @endcode
-   * @par
-   * Suppose the set of @p thread_data across the warp threads is
-   * <tt>{ [0,1,2,3], [4,5,6,7], ..., [60,61,62,63] }</tt>.
-   * The output @p d_data will be <tt>0, 1, 2, 3, 4, 5, ...</tt>.
-   *
-   * @param[out] block_itr The thread block's base output iterator for storing to
-   * @param[in] items Data to store
-   */
+  //! @rst
+  //! Store items into a linear segment of memory.
+  //! 
+  //! @smemwarpreuse
+  //! 
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates the storing of a "blocked" arrangement
+  //! of 64 integers across 16 threads (where each thread owns 4 consecutive items)
+  //! into a linear segment of memory. The store is specialized for
+  //! ``WARP_STORE_TRANSPOSE``, meaning items are locally reordered among threads so
+  //! that memory references will be efficiently coalesced using a warp-striped
+  //! access pattern.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>   // or equivalently <cub/warp/warp_store.cuh>
+  //!    
+  //!    __global__ void ExampleKernel(int *d_data, ...)
+  //!    {
+  //!        constexpr int warp_threads = 16;
+  //!        constexpr int block_threads = 256;
+  //!        constexpr int items_per_thread = 4;
+  //!    
+  //!        // Specialize WarpStore for a virtual warp of 16 threads owning 4 integer items each
+  //!        using WarpStoreT = WarpStore<int,
+  //!                                     items_per_thread,
+  //!                                     cub::WARP_STORE_TRANSPOSE,
+  //!                                     warp_threads>;
+  //!    
+  //!        constexpr int warps_in_block = block_threads / warp_threads;
+  //!        constexpr int tile_size = items_per_thread * warp_threads;
+  //!        const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
+  //!    
+  //!        // Allocate shared memory for WarpStore
+  //!        __shared__ typename WarpStoreT::TempStorage temp_storage[warps_in_block];
+  //!    
+  //!        // Obtain a segment of consecutive items that are blocked across threads
+  //!        int thread_data[4];
+  //!        ...
+  //!    
+  //!        // Store items to linear memory
+  //!        WarpStoreT(temp_storage[warp_id]).Store(d_data + warp_id * tile_size, thread_data);
+  //!
+  //! Suppose the set of ``thread_data`` across the warp threads is
+  //! ``{ [0,1,2,3], [4,5,6,7], ..., [60,61,62,63] }``.
+  //! The output ``d_data`` will be ``0, 1, 2, 3, 4, 5, ...``.
+  //! @endrst
+  //! 
+  //! @param[out] block_itr The thread block's base output iterator for storing to
+  //! @param[in] items Data to store
   template <typename OutputIteratorT>
   __device__ __forceinline__ void Store(OutputIteratorT block_itr,
                                         T (&items)[ITEMS_PER_THREAD])
@@ -466,61 +478,63 @@ public:
     InternalStore(temp_storage, linear_tid).Store(block_itr, items);
   }
 
-  /**
-   * @brief Store items into a linear segment of memory, guarded by range.
-   *
-   * @par
-   * @smemwarpreuse
-   *
-   * @par Snippet
-   * @par
-   * The code snippet below illustrates the storing of a "blocked" arrangement
-   * of 64 integers across 16 threads (where each thread owns 4 consecutive items)
-   * into a linear segment of memory. The store is specialized for
-   * @p WARP_STORE_TRANSPOSE, meaning items are locally reordered among threads so
-   * that memory references will be efficiently coalesced using a warp-striped
-   * access pattern.
-   * @code
-   * #include <cub/cub.cuh>   // or equivalently <cub/warp/warp_store.cuh>
-   *
-   * __global__ void ExampleKernel(int *d_data, int valid_items ...)
-   * {
-   *     constexpr int warp_threads = 16;
-   *     constexpr int block_threads = 256;
-   *     constexpr int items_per_thread = 4;
-   *
-   *     // Specialize WarpStore for a virtual warp of 16 threads owning 4 integer items each
-   *     using WarpStoreT = WarpStore<int,
-   *                                  items_per_thread,
-   *                                  cub::WARP_STORE_TRANSPOSE,
-   *                                  warp_threads>;
-   *
-   *     constexpr int warps_in_block = block_threads / warp_threads;
-   *     constexpr int tile_size = items_per_thread * warp_threads;
-   *     const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
-   *
-   *     // Allocate shared memory for WarpStore
-   *     __shared__ typename WarpStoreT::TempStorage temp_storage[warps_in_block];
-   *
-   *     // Obtain a segment of consecutive items that are blocked across threads
-   *     int thread_data[4];
-   *     ...
-   *
-   *     // Store items to linear memory
-   *     WarpStoreT(temp_storage[warp_id]).Store(
-   *       d_data + warp_id * tile_size, thread_data, valid_items);
-   * @endcode
-   * @par
-   * Suppose the set of @p thread_data across the warp threads is
-   * <tt>{ [0,1,2,3], [4,5,6,7], ..., [60,61,62,63] }</tt> and @p valid_items
-   * is @p 5.. The output @p d_data will be <tt>0, 1, 2, 3, 4, ?, ?, ...</tt>,
-   * with only the first two threads being unmasked to store portions of valid
-   * data.
-   *
-   * @param[out] block_itr The thread block's base output iterator for storing to
-   * @param[in] items Data to store
-   * @param[in] valid_items Number of valid items to write
-   */
+  //! @rst
+  //! Store items into a linear segment of memory, guarded by range.
+  //! 
+  //! @smemwarpreuse
+  //! 
+  //! Snippet
+  //! +++++++
+  //!
+  //! The code snippet below illustrates the storing of a "blocked" arrangement
+  //! of 64 integers across 16 threads (where each thread owns 4 consecutive items)
+  //! into a linear segment of memory. The store is specialized for
+  //! ``WARP_STORE_TRANSPOSE``, meaning items are locally reordered among threads so
+  //! that memory references will be efficiently coalesced using a warp-striped
+  //! access pattern.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>   // or equivalently <cub/warp/warp_store.cuh>
+  //! 
+  //!    __global__ void ExampleKernel(int *d_data, int valid_items ...)
+  //!    {
+  //!        constexpr int warp_threads = 16;
+  //!        constexpr int block_threads = 256;
+  //!        constexpr int items_per_thread = 4;
+  //! 
+  //!        // Specialize WarpStore for a virtual warp of 16 threads owning 4 integer items each
+  //!        using WarpStoreT = WarpStore<int,
+  //!                                     items_per_thread,
+  //!                                     cub::WARP_STORE_TRANSPOSE,
+  //!                                     warp_threads>;
+  //! 
+  //!        constexpr int warps_in_block = block_threads / warp_threads;
+  //!        constexpr int tile_size = items_per_thread * warp_threads;
+  //!        const int warp_id = static_cast<int>(threadIdx.x) / warp_threads;
+  //! 
+  //!        // Allocate shared memory for WarpStore
+  //!        __shared__ typename WarpStoreT::TempStorage temp_storage[warps_in_block];
+  //! 
+  //!        // Obtain a segment of consecutive items that are blocked across threads
+  //!        int thread_data[4];
+  //!        ...
+  //! 
+  //!        // Store items to linear memory
+  //!        WarpStoreT(temp_storage[warp_id]).Store(
+  //!          d_data + warp_id * tile_size, thread_data, valid_items);
+  //!
+  //! Suppose the set of ``thread_data`` across the warp threads is
+  //! ``{ [0,1,2,3], [4,5,6,7], ..., [60,61,62,63] }`` and ``valid_items``
+  //! is ``5``. The output ``d_data`` will be ``0, 1, 2, 3, 4, ?, ?, ...``,
+  //! with only the first two threads being unmasked to store portions of valid
+  //! data.
+  //! @endrst
+  //! 
+  //! @param[out] block_itr The thread block's base output iterator for storing to
+  //! @param[in] items Data to store
+  //! @param[in] valid_items Number of valid items to write
+  //! 
   template <typename OutputIteratorT>
   __device__ __forceinline__ void Store(OutputIteratorT block_itr,
                                         T (&items)[ITEMS_PER_THREAD],
@@ -529,7 +543,7 @@ public:
     InternalStore(temp_storage, linear_tid).Store(block_itr, items, valid_items);
   }
 
-  //@}  end member group
+  //! @}  end member group
 };
 
 

--- a/cub/warp/warp_store.cuh
+++ b/cub/warp/warp_store.cuh
@@ -412,7 +412,7 @@ public:
    * @brief Store items into a linear segment of memory.
    *
    * @par
-   * \smemreuse
+   * @smemwarpreuse
    *
    * @par Snippet
    * @par
@@ -470,7 +470,7 @@ public:
    * @brief Store items into a linear segment of memory, guarded by range.
    *
    * @par
-   * \smemreuse
+   * @smemwarpreuse
    *
    * @par Snippet
    * @par

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ CUB
    ${repo_docs_api_path}/CUB_api
    developer_overview
    test_overview
+   tuning
 
 .. the line below can be used to use the README.md file as the index page
 .. .. mdinclude:: ../README.md

--- a/docs/repo.toml
+++ b/docs/repo.toml
@@ -51,6 +51,7 @@ doxygen_input = [
 # more information on the format can be found at:
 #     https://www.doxygen.nl/manual/config.html#cfg_aliases
 doxygen_aliases = [
+  "smemwarpreuse=A subsequent `__syncwarp()` warp-wide barrier should be invoked after calling this method if the collective's temporary storage (e.g., @p temp_storage) is to be reused or repurposed.",
   "smemreuse=A subsequent `__syncthreads()` threadblock barrier should be invoked after calling this method if the collective's temporary storage (e.g., @p temp_storage) is to be reused or repurposed.",
   "smemreuse{1}=After any operation, a subsequent `__syncthreads()` barrier is required if the collective's \\1 is to be reused or repurposed",
   "smemstorage{1}=The operations exposed by \\1 require a temporary memory allocation of this nested type for thread communication. This opaque storage can be allocated directly using the `__shared__` keyword. Alternatively, it can be aliased to externally allocated memory (shared or global) or `union`'d with other storage allocation types to facilitate memory reuse.",


### PR DESCRIPTION
This PR addresses https://github.com/NVIDIA/cub/issues/677 and modernizes the docs to use rst. 