### PR TITLE
Fix multiset erase call

### DIFF
--- a/cub/util_allocator.cuh
+++ b/cub/util_allocator.cuh
@@ -484,9 +484,7 @@ struct CachingDeviceAllocator
                     if (debug) _CubLog("\tDevice %d freed %lld bytes.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
                         device, (long long) block_itr->bytes, (long long) cached_blocks.size(), (long long) cached_bytes[device].free, (long long) live_blocks.size(), (long long) cached_bytes[device].live);
 
-                    cached_blocks.erase(block_itr);
-
-                    block_itr++;
+                    block_itr = cached_blocks.erase(block_itr);
                 }
 
                 // Unlock


### PR DESCRIPTION
This is causing one of XGBoost's tests to segfault (https://github.com/dmlc/xgboost/blob/master/tests/cpp/common/test_device_helpers.cu#L170). According to this (https://en.cppreference.com/w/cpp/container/multiset/erase), the iterator is invalidated after the erase call, so incrementing it afterwards is undefined behavior. I guess the version of `libstdc++6` I have doesn't like it any more.

gdb backtrace  for the core dump:
```console
Core was generated by `./testxgboost'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f631eac6594 in std::_Rb_tree_increment(std::_Rb_tree_node_base const*) () from /lib/x86_64-linux-gnu/libstdc++.so.6
[Current thread is 1 (Thread 0x7f631ecc5000 (LWP 748486))]
(gdb) bt
#0  0x00007f631eac6594 in std::_Rb_tree_increment(std::_Rb_tree_node_base const*) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#1  0x000055c11c9912bc in std::_Rb_tree_const_iterator<cub::CachingDeviceAllocator::BlockDescriptor>::operator++ (this=0x7fff6c391710) at /usr/include/c++/12/bits/stl_tree.h:376
#2  0x000055c11c98f91d in cub::CachingDeviceAllocator::DeviceAllocate (this=0x55c139a001c0, device=0, d_ptr=0x7fff6c391858, bytes=45669154816, active_stream=0x0)
    at /usr/local/cuda/include/cub/util_allocator.cuh:488
#3  0x000055c11c98fca6 in cub::CachingDeviceAllocator::DeviceAllocate (this=0x55c139a001c0, d_ptr=0x7fff6c391858, bytes=45669154816, active_stream=0x0) at /usr/local/cuda/include/cub/util_allocator.cuh:543
#4  0x000055c11c995567 in dh::detail::XGBCachingDeviceAllocatorImpl<char>::allocate (this=0x7fff6c391a20, n=45669154816) at /home/rou/src/xgboost/src/collective/../common/device_helpers.cuh:490
#5  0x000055c11c994b70 in thrust::detail::allocator_traits<dh::detail::XGBCachingDeviceAllocatorImpl<char> >::allocate(dh::detail::XGBCachingDeviceAllocatorImpl<char>&, unsigned long)::workaround_warnings::allocate(dh::detail::XGBCachingDeviceAllocatorImpl<char>&, unsigned long) (a=..., n=45669154816) at /usr/local/cuda/include/thrust/detail/allocator/allocator_traits.inl:370
#6  0x000055c11c994b99 in thrust::detail::allocator_traits<dh::detail::XGBCachingDeviceAllocatorImpl<char> >::allocate (a=..., n=45669154816)
    at /usr/local/cuda/include/thrust/detail/allocator/allocator_traits.inl:374
#7  0x000055c11c994119 in thrust::detail::contiguous_storage<char, dh::detail::XGBCachingDeviceAllocatorImpl<char> >::allocate (this=0x7fff6c391a20, n=45669154816)
    at /usr/local/cuda/include/thrust/detail/contiguous_storage.inl:210
#8  0x000055c11c99e2b9 in thrust::detail::vector_base<char, dh::detail::XGBCachingDeviceAllocatorImpl<char> >::default_init (this=0x7fff6c391a20, n=45669154816)
    at /usr/local/cuda/include/thrust/detail/vector_base.inl:214
#9  0x000055c11c99d904 in thrust::detail::vector_base<char, dh::detail::XGBCachingDeviceAllocatorImpl<char> >::vector_base (this=0x7fff6c391a20, n=45669154816)
    at /usr/local/cuda/include/thrust/detail/vector_base.inl:62
#10 0x000055c11c99d207 in thrust::device_vector<char, dh::detail::XGBCachingDeviceAllocatorImpl<char> >::device_vector (this=0x7fff6c391a20, n=45669154816) at /usr/local/cuda/include/thrust/device_vector.h:86
#11 0x000055c11d534e53 in xgboost::Allocator_OOM_Test::TestBody (this=0x55c14b32ac20) at /home/rou/src/xgboost/tests/cpp/common/test_device_helpers.cu:170
#12 0x000055c11d8661cc in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void> (object=0x55c14b32ac20, method=&virtual testing::Test::TestBody(), 
    location=0x55c11e9863e3 "the test body") at /home/rou/src/xgboost/build/googletest-src/googletest/src/gtest.cc:2607
#13 0x000055c11d85f955 in testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void> (object=0x55c14b32ac20, method=&virtual testing::Test::TestBody(), location=0x55c11e9863e3 "the test body")
    at /home/rou/src/xgboost/build/googletest-src/googletest/src/gtest.cc:2643
#14 0x000055c11d835246 in testing::Test::Run (this=0x55c14b32ac20) at /home/rou/src/xgboost/build/googletest-src/googletest/src/gtest.cc:2682
#15 0x000055c11d835cfe in testing::TestInfo::Run (this=0x55c1374a7820) at /home/rou/src/xgboost/build/googletest-src/googletest/src/gtest.cc:2861
#16 0x000055c11d836628 in testing::TestSuite::Run (this=0x55c1374a7990) at /home/rou/src/xgboost/build/googletest-src/googletest/src/gtest.cc:3015
#17 0x000055c11d8466c2 in testing::internal::UnitTestImpl::RunAllTests (this=0x55c137455c50) at /home/rou/src/xgboost/build/googletest-src/googletest/src/gtest.cc:5855
#18 0x000055c11d867539 in testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (object=0x55c137455c50, 
    method=(bool (testing::internal::UnitTestImpl::*)(testing::internal::UnitTestImpl * const)) 0x55c11d8462b8 <testing::internal::UnitTestImpl::RunAllTests()>, 
    location=0x55c11e986e48 "auxiliary test code (environments or event listeners)") at /home/rou/src/xgboost/build/googletest-src/googletest/src/gtest.cc:2607
#19 0x000055c11d8608e1 in testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (object=0x55c137455c50, 
    method=(bool (testing::internal::UnitTestImpl::*)(testing::internal::UnitTestImpl * const)) 0x55c11d8462b8 <testing::internal::UnitTestImpl::RunAllTests()>, 
    location=0x55c11e986e48 "auxiliary test code (environments or event listeners)") at /home/rou/src/xgboost/build/googletest-src/googletest/src/gtest.cc:2643
#20 0x000055c11d844d49 in testing::UnitTest::Run (this=0x55c136b194a0 <testing::UnitTest::GetInstance()::instance>) at /home/rou/src/xgboost/build/googletest-src/googletest/src/gtest.cc:5438
#21 0x000055c11d46c217 in RUN_ALL_TESTS () at /home/rou/src/xgboost/build/googletest-src/googletest/include/gtest/gtest.h:2490
#22 0x000055c11d46c011 in main (argc=1, argv=0x7fff6c3920d8) at /home/rou/src/xgboost/tests/cpp/test_main.cc:18
```